### PR TITLE
Rewrite README around Metrik's product focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # Metrik
 
-本地优先的 AI Agent 用量统计桌面应用。读取本机 Agent 留下的日志，把**官方配额**、**本地解析的 Token**、**估算成本**三类事实分开呈现——估算不冒充账单，读不到就显示"不可用"，绝不用零值或演示数字顶替。
+把 Codex、Claude 等 AI Agent 的用量放到一个桌面小组件里。
 
-Windows 上是 320 × 320 的桌面小组件，可再折叠成一根横向或竖立的**配额胶囊条**；macOS 上是菜单栏面板。两者都能一键展开为完整统计视图。
+> **English:** Metrik is a local-first desktop usage tracker for Codex, Claude, and other AI coding agents. It brings official quota status, locally parsed token usage, estimated costs, trends, and session details into one view without mixing them together. Windows users can keep it as a desktop widget or compact quota strip, while macOS users can access it from the menu bar. In a Windows Task Manager snapshot taken while idle, Metrik used about 20.6 MB of memory; actual usage varies by system and log size. Usage data stays on your device by default, and optional multi-device sync uses a OneDrive, Nutstore, or Syncthing folder you choose without passing data through a Metrik server.
+
+Metrik 读取本机日志，同时展示三类数据：
+
+- **官方配额**：已用比例和重置时间
+- **本地 Token**：从会话日志解析出的处理量
+- **估算成本**：按公开 API 价格换算，仅供参考
+
+这三类数据分开计算。读取失败时会显示“不可用”或“部分覆盖”，不会用演示数字补位。
 
 [![Download](https://img.shields.io/github/v/release/keros68/metrik?label=下载&color=success)](https://github.com/keros68/metrik/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Tauri](https://img.shields.io/badge/Tauri-2-24C8DB.svg)](https://tauri.app/)
-[![Platform](https://img.shields.io/badge/Windows%20%7C%20macOS-0078D6.svg)](#验收边界)
+[![Platform](https://img.shields.io/badge/Windows%20%7C%20macOS-0078D6.svg)](#安装与限制)
 
-[下载最新版](https://github.com/keros68/metrik/releases/latest)：Windows `.exe` / macOS `.dmg`（通用包）。均未签名，首次运行需手动放行。
+[下载最新版](https://github.com/keros68/metrik/releases/latest)：Windows `.exe` / macOS `.dmg`（通用包）。安装包暂未签名，首次运行需要手动放行。
 
 <p align="center">
   <img src="design/shot-widget.png" width="320" alt="Metrik 桌面小组件">
@@ -20,14 +28,14 @@ Windows 上是 320 × 320 的桌面小组件，可再折叠成一根横向或竖
   &nbsp;&nbsp;&nbsp;
   <img src="design/shot-strip-horizontal.png" width="330" alt="配额胶囊条 · 横条">
 </p>
-<p align="center"><sub>小组件可折叠成配额胶囊条（Windows）：横条或竖立长条，只占一线屏幕。</sub></p>
+<p align="center"><sub>Windows 小组件可折叠成横向或竖向配额条。</sub></p>
 
 ![完整视图 · 概览](design/shot-overview.png)
 
-> 截图为浏览器演示数据，不是真实用量。
+> 截图使用浏览器演示数据，不代表真实用量。
 
 <details>
-<summary>更多截图（报告 / 用量 / 设置）</summary>
+<summary>查看报告、用量和设置页面</summary>
 
 ![报告](design/shot-reports.png)
 ![用量](design/shot-usage.png)
@@ -35,52 +43,68 @@ Windows 上是 320 × 320 的桌面小组件，可再折叠成一根横向或竖
 
 </details>
 
+## Metrik 的侧重点
+
+同类工具里，有的主要做 macOS 菜单栏配额，有的主要做终端 Token 报表。Metrik 不追求支持数量最多，当前更关注这几件事：
+
+- **Windows 和 macOS 都有桌面入口**：Windows 提供小组件与横竖配额条，macOS 提供菜单栏面板。
+- **空闲常驻占用较小**：一次 Windows 任务管理器截图中，Metrik 显示约 20.6 MB 内存和 0% CPU；实际占用会随日志规模、索引状态和系统环境变化。
+- **三类数据不混用**：官方配额、本地 Token、估算成本分别标注来源和状态。
+- **既看当前配额，也看历史用量**：同一应用里保留趋势、热力图、会话和 Token 构成。
+- **多设备不依赖 Metrik 服务器**：通过你自己的 OneDrive、坚果云或 Syncthing 文件夹合并统计事件。
+- **默认少碰凭据**：本地 Token 来自日志；Claude 配额默认使用 statusLine 钩子，OAuth 直连需要手动开启。
+
+## 主要功能
+
+- **桌面速览**：Windows 使用 320 × 320 小组件或配额条，macOS 使用菜单栏面板。
+- **完整统计**：查看趋势、26 周热力图、Agent 构成和 Token 构成。
+- **会话明细**：按天筛选会话，导出 CSV，复制会话 ID 用于继续会话。
+- **成本估算**：按 Token 类型和公开价目计算；没有价格的模型单独标记为“未计价”。
+- **多设备合并**：通过你指定的 OneDrive、坚果云或 Syncthing 文件夹合并近 30 天统计事件。
+- **桌面能力**：托盘常驻、可选开机启动、单实例运行，以及手动检查更新。
+
 ## 支持的 Agent
 
 | Agent | Token 来源 | 官方配额 |
 | --- | --- | --- |
-| ChatGPT / Codex | `~/.codex/sessions` 的会话日志 | ✅ 本机 `codex app-server` |
-| Claude | `~/.claude/projects` 的会话日志 | ✅ statusLine 钩子或 OAuth 直连（见下） |
-| ZCode / 智谱 GLM | `~/.zcode/cli/db/db.sqlite` 的 `model_usage` 表 | — |
+| ChatGPT / Codex | `~/.codex/sessions` | ✅ 本机 `codex app-server` |
+| Claude | `~/.claude/projects` | ✅ statusLine 钩子；可选 OAuth 直连 |
+| ZCode / 智谱 GLM | `~/.zcode/cli/db/db.sqlite` | — |
 | OpenCode | `~/.local/share/opencode/storage` | — |
-| Kimi | `~/.kimi-code` 与 `~/.kimi` 的 `wire.jsonl` | — |
+| Kimi | `~/.kimi-code` 与 `~/.kimi` | — |
 | Antigravity | 本机 language server 实时 RPC（IDE 需运行） | ✅ RPC 官方配额 |
 
-Gemini CLI 明确不在支持范围。Cursor 见[路线](#路线)。
+Gemini CLI 不在支持范围内。Cursor 仍在评估中。
 
-## 功能
+## 数据与隐私
 
-- **配额三行元语**：窗口名 → 进度条 → 已用百分比 + 重置倒计时，外加消耗节奏预测。数据陈旧或窗口已重置时显式标注。
-- **配额胶囊条**（Windows）：小组件一键折叠成横向或竖立的小条，每个 Agent 一格（图标 + 剩余百分比 + 品牌色进度条）；显示哪些 Agent 及顺序可在设置里自选，材质跟随小组件的玻璃开关。
-- **报告**：26 周热力图 / 周趋势折线 / Agent 构成环形。
-- **用量**：按天分组的会话明细，支持筛选、CSV 导出、复制会话 ID（方便 resume）。
-- **成本估算**：静态价目表按 Token 分量计价，没有价目的模型归入"未计价"。
-- **多设备同步**：指向一个共享文件夹（坚果云 / OneDrive / Syncthing 均可），各设备导出近 30 天的统计事件并自动合并。
-- **更新检查**：设置页手动触发，不后台轮询——这是本应用唯一会主动发出的网络请求。更新包经 minisign 校验，签名不符拒绝安装。
-- 托盘常驻、可选开机启动、单实例运行。
+首页的 Token 是处理量：`未缓存输入 + 缓存读取 + 缓存写入 + 输出`。推理 Token 已包含在输出中，不会重复叠加；这个数字也不是账单金额。
 
-## 数据口径
+Metrik 的本地数据库只保存统计字段和源文件定位，不保存 Prompt、回复正文、工具输出、凭据或原始文件内容。数据不会上传到 Metrik 的服务器；多设备功能只读写你指定的共享文件夹。
 
-首页的数字是**处理量**：`未缓存输入 + 缓存读取 + 缓存写入 + 输出`。推理 token 是输出的子项，不重复叠加。**它不是账单金额。**
+除用户主动开启的 Claude OAuth 查询外，应用只会在你手动检查更新时发起网络请求。更新包会经过 minisign 校验。
 
-三类事实永远分开：**官方配额**（Agent 官方推送的窗口百分比与重置时间）、**本地 Token**（从本机日志逐事件解析、去重后的处理量）、**估算成本**（按公开 API 价目折算，不是你的账单）。
+<details>
+<summary>Claude 官方配额的两种读取方式</summary>
 
-解析遇到坏行或读取异常，对应来源降级为"部分覆盖"，而不是继续伪装成精确结果。
+**statusLine 钩子（默认）**：读取 Claude Code 传给状态栏脚本的配额信息，不使用凭据。只有终端中的交互式 Claude Code 会话渲染状态栏时才会刷新。
 
-## 不做什么
+**OAuth 直连（可选，默认关闭）**：读取 Claude Code 已保存的登录凭据，查询账户配额，能够覆盖网页版消耗。
 
-- **不猜数字。** 读不到就显示"不可用"；模型没有价目就归入"未计价"；配额已重置而新数据未到，显示 `--` 而不是旧百分比。
-- **不存对话内容。** 数据库只保存时间、Agent、模型、会话标识和源文件定位。不存 Prompt、回复正文、工具输出、凭据或原始文件内容。
-- **不上传。** 多设备同步只经由你自己指定的文件夹，导出内容仅含统计字段。
-- **不默认碰凭据。** Claude 额度的默认来源是零凭据的 statusLine 钩子。
+Anthropic 当前的[消费者条款](https://www.anthropic.com/legal/consumer-terms)限制通过非 API 的自动化方式访问其服务，除非 Anthropic 明确允许。Metrik 的 OAuth 直连可能落入这一限制，请自行评估后再开启。
 
-## Claude 额度的两种来源
+</details>
 
-**statusLine 钩子**（默认）：Claude Code 本身会把官方额度推给状态栏脚本，钩子只提取额度数字落地成本地文件。零网络请求、零凭据。已有自定义 statusLine 时会自动串联，卸载时原样恢复。局限：只有在终端里渲染出状态栏的交互式会话才会刷新——你若主要在 IDE 或网页里用 Claude，额度会停更。
+## 安装与限制
 
-**OAuth 直连**（可选，默认关闭）：读取 Claude Code 已保存的登录凭据，直接查询官方额度接口，覆盖网页版消耗。
+- 已提供 Windows 10/11 x64 和 macOS Apple Silicon 安装包；Linux 暂无发布包。
+- v0.6.4 的 Windows 安装包约 3.3 MB，macOS 通用 DMG 约 8.4 MB。
+- 安装包尚未购买代码签名证书，首次运行会触发系统提示；Release 页面提供 SHA256。
+- Kimi 与 Antigravity 有测试夹具，但作者尚未在真机上验收。Antigravity 还要求 IDE 正在运行。
+- 大型日志首次索引会占用一段 CPU 和磁盘；索引在后台执行，未完成时会标记为不完整。
+- 从 v0.1.0 升级需要手动下载一次新版，之后才能使用应用内更新。
 
-> ⚠️ **条款风险**：Anthropic 2026 年 2 月更新的消费者条款禁止在第三方工具中使用 Claude 订阅的 OAuth 凭据。目前公开的封禁集中在借订阅做推理的工具，未见只读用量查询被封号的案例，但按条款字面本功能同样属于违规范围。**不愿承担风险请保持关闭。**
+更完整的验证范围见 [ACCEPTANCE.md](ACCEPTANCE.md)。
 
 ## 开发
 
@@ -88,32 +112,22 @@ Gemini CLI 明确不在支持范围。Cursor 见[路线](#路线)。
 
 ```bash
 npm install
-npm run desktop:dev    # 桌面开发模式（读取真实本机日志）
-npm run dev            # 仅浏览器预览（演示数据，显式标注）
+npm run desktop:dev    # 桌面开发模式，读取真实本机日志
+npm run dev            # 浏览器预览，使用演示数据
 npm run desktop:build  # 构建安装包
 
-npm run build                                                 # 验证
+npm run build
 cd src-tauri && cargo test && cargo clippy -- -D warnings && cargo fmt --check
-cargo test live_snapshot_smoke_test -- --ignored --nocapture  # 读真实本机日志的烟测
 ```
 
-## 验收边界
+架构与去重逻辑见 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)，视觉验收见 [design-qa.md](design-qa.md)。
 
-- **Windows 10/11 x64** 与 **macOS**（Apple Silicon 实机）均已验收。macOS 上是菜单栏应用：面板贴着菜单栏图标弹出、不抢当前窗口焦点、点击别处收起，完整视图是带原生红绿灯的独立窗口——这四项已在真机确认；macOS 的开机启动尚未逐项核过。Linux 共用代码但无产物。
-- **Kimi 与 Antigravity 尚未实机验收**：格式经官方协议与既有工具交叉核实、有测试夹具覆盖，但作者本机未安装。装了的用户请核对数字，发现偏差欢迎提 issue。Antigravity 需要 IDE 正在运行才能读到用量（它没有本地日志）。
-- 安装包**没有代码签名证书**，首次运行会被系统拦一次。Release 页面附有 SHA256 可核对文件完整性。（应用内更新用的 minisign 签名是另一回事，它只保证更新包没被掉包。）
-- Windows 上目标机未装 WebView2 时，默认安装器需要联网获取运行时。
-- **v0.1.0 无法自动更新**：更新器是 v0.2.0 才加的，装了 v0.1.0 需手动下载一次新版。
-- 持续增长的大型日志仍需整文件重扫，首次索引会占用一段 CPU 与磁盘。索引不阻塞界面，进度会显式显示，未覆盖完整历史时数字会标注为不完整。
+## Roadmap
 
-## 路线
-
-1. 真正的追加游标（避免大日志整文件重扫）
-2. Linux 构建
-3. 端到端加密的中继同步（当前为共享文件夹方案）
-4. **Cursor**：依赖云端 API + 本地凭据提取，需要先设计显式的凭据授权机制。
-
-架构与去重逻辑见 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)，视觉对照见 [design-qa.md](design-qa.md)，验收证据见 [ACCEPTANCE.md](ACCEPTANCE.md)。
+1. 使用追加游标读取持续增长的大型日志
+2. 提供 Linux 构建
+3. 增加端到端加密的中继同步
+4. 在明确授权机制后评估 Cursor 支持
 
 ## License
 


### PR DESCRIPTION
## What changed

- Rewrote the opening around Metrik's concrete product focus.
- Added a concise English overview.
- Explained desktop views, data separation, multi-device sync, privacy, and current platform limits.
- Added the measured Windows idle-memory wording without naming competing products.
- Updated package references to v0.6.4.

## Why

The previous README was long and repeated several ideas. The new version makes the product differences easier to scan while keeping data-source and validation limits explicit.

## Validation

- `git diff --check`
- Confirmed the branch changes only `README.md`
- Verified the v0.6.4 release assets and package sizes
