### PR TITLE
Read Claude OAuth credentials from the macOS keychain

### DIFF
--- a/src-tauri/src/claude_oauth.rs
+++ b/src-tauri/src/claude_oauth.rs
@@ -7,15 +7,30 @@ use std::time::Duration;
 /// Claude 官方额度的 opt-in 凭据来源。
 ///
 /// 隐私红线：默认关闭；用户在设置页显式开启后，才读取 Claude Code 自己
-/// 保存的 OAuth token（`~/.claude/.credentials.json`）。token 只在内存中
-/// 用于一次 GET 请求，不入库、不上传到 Metrik 之外的任何地方、不写日志。
-/// 端点是 Claude Code 客户端自用的非官方接口（`/api/oauth/usage`），额度
-/// 是账户级合并值（含网页版/桌面版消耗）；接口失效时如实报错，由上层
-/// 回落到 statusLine 钩子文件，绝不编造数字。
+/// 保存的 OAuth token。token 只在内存中用于一次 GET 请求，不入库、不上传
+/// 到 Metrik 之外的任何地方、不写日志。端点是 Claude Code 客户端自用的
+/// 非官方接口（`/api/oauth/usage`），额度是账户级合并值（含网页版/桌面版
+/// 消耗）；接口失效时如实报错，由上层回落到 statusLine 钩子文件，绝不编造
+/// 数字。
+///
+/// 凭据来源按序尝试（不同平台/安装方式落点不同）：
+/// 1. 环境变量 `CLAUDE_CODE_OAUTH_TOKEN`（用户显式指定的裸 token）；
+/// 2. 凭据文件 `$CLAUDE_CONFIG_DIR|~/.claude` 下的 `.credentials.json`
+///    （Linux、以及部分 Windows 安装）；
+/// 3. macOS 钥匙串条目 `Claude Code-credentials`（macOS 上 Claude Code 默认
+///    把 token 存进系统钥匙串而非明文文件）。读取经 `security` 命令，token
+///    同样只在内存里用一次，不落盘。
 const CREDENTIALS_FILE: &str = ".credentials.json";
 const USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
 const BETA_HEADER: &str = "oauth-2025-04-20";
 const REQUIRED_SCOPE: &str = "user:profile";
+/// 用户显式指定 token 的环境变量（与 Claude Code 官方同名）。
+const ENV_TOKEN: &str = "CLAUDE_CODE_OAUTH_TOKEN";
+/// Claude Code 在 macOS 钥匙串里存凭据用的 generic-password service 名。
+#[cfg(target_os = "macos")]
+const KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
+/// 覆盖 Claude 配置目录的环境变量（与 Claude Code 官方同名）。
+const ENV_CONFIG_DIR: &str = "CLAUDE_CONFIG_DIR";
 
 /// app_setting 里的开关键；"1" 表示用户已显式开启。
 pub const SETTING_KEY: &str = "claude_oauth_quota_enabled";
@@ -122,31 +137,57 @@ impl LimitEntry {
 
 pub struct ClaudeOauth {
     claude_dir: PathBuf,
+    /// 是否咨询进程外的系统来源（环境变量、macOS 钥匙串）。生产环境为 true；
+    /// 单测走 `with_dir`，仅读被测目录里的凭据文件，避免读到开发机真实凭据。
+    consult_system: bool,
 }
 
 impl ClaudeOauth {
     pub fn detected() -> Self {
         Self {
-            claude_dir: dirs::home_dir().unwrap_or_default().join(".claude"),
+            claude_dir: config_dir(),
+            consult_system: true,
         }
     }
 
     #[cfg(test)]
     pub fn with_dir(claude_dir: PathBuf) -> Self {
-        Self { claude_dir }
+        Self {
+            claude_dir,
+            consult_system: false,
+        }
     }
 
+    /// 按序尝试多个凭据来源，命中即返回；全部落空返回 None。
     fn read_credentials(&self) -> Option<OauthCredentials> {
-        let raw = std::fs::read_to_string(self.claude_dir.join(CREDENTIALS_FILE)).ok()?;
-        serde_json::from_str::<CredentialsFileShape>(raw.trim_start_matches('\u{feff}'))
-            .ok()?
-            .claude_ai_oauth
-            .filter(|oauth| {
-                oauth
-                    .access_token
-                    .as_deref()
-                    .is_some_and(|token| !token.trim().is_empty())
-            })
+        // 1. 用户显式指定的裸 token：直接采信，赋予必需 scope 以放行 scope 校验。
+        if self.consult_system {
+            if let Some(token) = env_token() {
+                return Some(OauthCredentials {
+                    access_token: Some(token),
+                    scopes: vec![REQUIRED_SCOPE.to_owned()],
+                });
+            }
+        }
+
+        // 2. 明文凭据文件。
+        if let Some(credentials) = std::fs::read_to_string(self.claude_dir.join(CREDENTIALS_FILE))
+            .ok()
+            .and_then(|raw| parse_credentials(&raw))
+        {
+            return Some(credentials);
+        }
+
+        // 3. macOS 钥匙串（Claude Code 在 mac 上的默认落点）。
+        #[cfg(target_os = "macos")]
+        if self.consult_system {
+            if let Some(credentials) = read_macos_keychain().and_then(|raw| parse_credentials(&raw))
+            {
+                return Some(credentials);
+            }
+        }
+
+        None
     }
 
     /// 只返回布尔状态，token 内容永不离开本函数所在进程的内存。
@@ -168,7 +209,7 @@ impl ClaudeOauth {
     /// 下游展示无需区分来源。
     pub fn fetch_quota_samples(&self, timeout: Duration) -> Result<Vec<QuotaSample>> {
         let Some(credentials) = self.read_credentials() else {
-            bail!("本机没有 Claude Code 登录凭据（~/.claude/.credentials.json）");
+            bail!("本机没有 Claude Code 登录凭据（环境变量、~/.claude/.credentials.json、macOS 钥匙串均未命中）");
         };
         if !credentials
             .scopes
@@ -213,6 +254,52 @@ impl ClaudeOauth {
         }
         Ok(samples)
     }
+}
+
+/// Claude 配置目录：优先 `$CLAUDE_CONFIG_DIR`，否则 `~/.claude`。
+fn config_dir() -> PathBuf {
+    std::env::var_os(ENV_CONFIG_DIR)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".claude"))
+}
+
+/// 环境变量里的裸 token（去空白后非空才算）。
+fn env_token() -> Option<String> {
+    std::env::var(ENV_TOKEN)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+/// 把凭据 JSON（文件或钥匙串同一形状）解析成带非空 accessToken 的凭据。
+fn parse_credentials(raw: &str) -> Option<OauthCredentials> {
+    serde_json::from_str::<CredentialsFileShape>(raw.trim_start_matches('\u{feff}'))
+        .ok()?
+        .claude_ai_oauth
+        .filter(|oauth| {
+            oauth
+                .access_token
+                .as_deref()
+                .is_some_and(|token| !token.trim().is_empty())
+        })
+}
+
+/// 从 macOS 钥匙串取 Claude Code 存的凭据 JSON。`security -w` 只输出密码本体
+/// （即那段 JSON）；条目不存在或被拒时命令非零退出，返回 None，绝不猜测。
+/// 首次读取可能弹出系统钥匙串授权框，这是 macOS 的预期行为。
+#[cfg(target_os = "macos")]
+fn read_macos_keychain() -> Option<String> {
+    let output = std::process::Command::new("security")
+        .args(["find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8(output.stdout).ok()?;
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
 }
 
 /// 把用量响应归一成额度样本：平铺窗口打底，limits[] 同键覆盖，
@@ -322,6 +409,39 @@ mod tests {
         .unwrap();
         assert!(oauth.status(true).scope_ok);
 
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parse_credentials_reads_keychain_or_file_shape() {
+        // 钥匙串 -w 输出与文件内容同形状，同一解析路径。
+        let blob = r#"{"claudeAiOauth":{"accessToken":"sk-abc","scopes":["user:inference","user:profile"]}}"#;
+        let parsed = parse_credentials(blob).expect("valid blob parses");
+        assert_eq!(parsed.access_token.as_deref(), Some("sk-abc"));
+        assert!(parsed.scopes.iter().any(|scope| scope == REQUIRED_SCOPE));
+
+        // 前导 BOM 容忍。
+        assert!(parse_credentials(&format!("\u{feff}{blob}")).is_some());
+
+        // 空 token / 非 JSON / 缺字段一律 None，绝不返回半个凭据。
+        assert!(parse_credentials(r#"{"claudeAiOauth":{"accessToken":"   "}}"#).is_none());
+        assert!(parse_credentials(r#"{"claudeAiOauth":{}}"#).is_none());
+        assert!(parse_credentials("not json").is_none());
+    }
+
+    #[test]
+    fn with_dir_does_not_consult_system_sources() {
+        // 单测构造器不看环境变量/钥匙串：空目录必然报告无凭据，
+        // 即便开发机（如 macOS）钥匙串里有真实 Claude 凭据也不受影响。
+        let dir = std::env::temp_dir().join(format!(
+            "metrik-claude-oauth-isolation-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let status = ClaudeOauth::with_dir(dir.clone()).status(true);
+        assert!(!status.credentials_present);
+        assert!(!status.scope_ok);
         fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
**Scope: `shared` + `macOS`**

## 问题
macOS 上 Claude Code 把 OAuth token 存进系统钥匙串（generic-password service `Claude Code-credentials`），**不是** `~/.claude/.credentials.json`。因此 OAuth 配额通道找不到凭据，面板一直是 `--`（而 token 用量正常）。这是 macOS 结构性缺口，0.7.0 也未覆盖。

## 改动
把凭据获取从「只读一个文件」改成**有序多来源链**（`claude_oauth.rs`）：

1. 环境变量 `CLAUDE_CODE_OAUTH_TOKEN`
2. 凭据文件（尊重 `CLAUDE_CONFIG_DIR`，回落 `~/.claude/.credentials.json`）
3. **macOS 钥匙串** `security find-generic-password -s "Claude Code-credentials" -w`（`cfg(target_os = "macos")`）

- token 仍只在内存用于一次 GET，不落盘、不入库、不写日志；钥匙串 blob 与文件同 JSON 形状，解析统一在 `parse_credentials`。
- 单测隔离：`with_dir` 设 `consult_system = false`，只读被测目录的文件，避免读到开发机真实钥匙串凭据。

## 验证
- 真机 macOS：钥匙串 blob 可解析、带 `user:profile`，OAuth 配额实时出数 ✓
- `cargo test`（claude 相关 19 项）绿、`cargo clippy --lib -- -D warnings` 干净、`cargo fmt --check` 通过

## 同步 / 待办（Windows shell，需在 Windows 机器上开发与验收）
Windows Claude Code 可能同样把凭据存进 **Windows 凭据管理器**而非文件；建议加一个对称的 `cfg(windows)` 来源。共享契约（`QuotaSample`、设置键、storage、sync）**未改动**，两 shell 保持同步。

## 注意
- 特性分支**不带版本号改动**（bump late，版本只在发版提交里改）。
- 运行时：需在设置里开启 OAuth 配额开关；Metrik 首次读钥匙串会弹一次系统授权框，点「始终允许」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)