### PR TITLE
Quota-first compact widget, per-form scales, Kimi K3 pricing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@ When implementing from a selected generated mock, treat that image as the source
 - Pinning (always-on-top + position lock) belongs only to the floating forms (compact widget and quota strip). The expanded view is a normal window: entering it always drops always-on-top and offers no pin button — a pinned 1120x760 window traps the user on top of every app.
 - On Windows the three forms are reachable from each other in one click (compact ↔ strip ↔ expanded), and each form returns to its own last position after a switch; positions are remembered per form and must never overwrite one another. Resizing the strip (orientation toggle, cell count change) preserves the screen edge it is flush to, and any position that falls fully outside every monitor must self-recover to center — a strip the user cannot reach is a trap, pinned strips have no drag region. Never persist an off-screen position either; the same applies on restore.
 - The strip's window size is derived from the rendered content (measure the main-axis length after layout and resize to fit), never from hand-maintained size constants. Constants may seed the first frame only — they drifted out of sync with the CSS once and clipped the vertical strip's buttons on other DPI/font/scale combinations.
+- The compact widget's primary content is per-agent official quota windows (5h/weekly remaining + reset countdown), not local token summaries; token analytics live in the expanded view. Missing or stale quota stays explicitly labeled.
+- The strip prefers the five-hour window per cell, falling back to the first available ranked window.
+- UI scale is continuous and per-form: compact uses `metrik:uiScale` [0.75–2.0]; the strip has its own `metrik:stripScale` [0.75–2.0]. Both are settings-page sliders that apply on next form entry. The expanded view has no scale setting — its window is freely resizable and webview zoom stays 1.
+- Manual refresh triggers `usage_snapshot` with `force: true`, bypassing quota TTL caches; failure still retains and stale-labels old rows — never clears them.
 
 ## Durable cross-platform development workflow
 

--- a/scripts/update-pricing.mjs
+++ b/scripts/update-pricing.mjs
@@ -5,9 +5,11 @@
 //
 // provider 选择：只取官方第一方 API（openai / anthropic / moonshot / zai / gemini）。
 // 适配器解析出的模型名只有在这些官方价目里有完全同名条目时才计价；
-// 订阅制 coding plan 的专属模型 ID（kimi-for-coding、k3、coding-plan 的 GLM 等）
+// 订阅制 coding plan 的专属模型 ID（kimi-for-coding、coding-plan 的 GLM 等）
 // 没有官方按 token 价目，宁可 unpriced 也不借 Bedrock/Azure/Cloudflare 等
 // 第三方转售价冒充官方价。
+// 注意：LiteLLM 未收录的新模型官方价手动补在 pricing.rs 的 MANUAL_PRICING
+// （如 kimi-k3），本脚本只生成 pricing_table.rs，不会覆盖它。
 //
 // 用法：npm run pricing:update   （改完提交生成的 .rs 文件）
 // 也可离线：node scripts/update-pricing.mjs <本地 json 路径>

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -119,6 +119,7 @@ pub fn build_snapshot(
     quota_cache: &Mutex<Option<(Instant, Vec<QuotaSample>)>>,
     claude_quota_cache: &Mutex<Option<(Instant, Vec<QuotaSample>)>>,
     http_quota_cache: &Mutex<HashMap<&'static str, (Instant, Vec<QuotaSample>)>>,
+    force: bool,
 ) -> Result<UsageSnapshot> {
     let mut connection = storage::open_database(database_path)?;
     let now = Utc::now().timestamp_millis();
@@ -127,7 +128,7 @@ pub fn build_snapshot(
 
     // app-server 是 Codex 额度的权威来源：拉到就整体替换，套餐变更后消失的
     // 窗口（如 prolite 没有 5 小时窗）不得留着旧日志快照冒充当前额度。
-    if let Ok(samples) = cached_live_quota(quota_cache) {
+    if let Ok(samples) = cached_live_quota(quota_cache, force) {
         if !samples.is_empty() {
             connection.execute("DELETE FROM quota_snapshot WHERE adapter_id = 'codex'", [])?;
         }
@@ -141,7 +142,7 @@ pub fn build_snapshot(
         storage::get_app_setting(&connection, claude_oauth::SETTING_KEY)?.as_deref() == Some("1");
     let mut claude_samples = Vec::new();
     if oauth_enabled {
-        if let Ok(samples) = cached_claude_oauth_quota(claude_quota_cache) {
+        if let Ok(samples) = cached_claude_oauth_quota(claude_quota_cache, force) {
             claude_samples = samples;
         }
     }
@@ -167,7 +168,7 @@ pub fn build_snapshot(
         ),
         ("kimi", coding_quota::fetch_kimi_quota),
     ] {
-        if let Ok(samples) = cached_coding_quota(http_quota_cache, adapter_id, fetch) {
+        if let Ok(samples) = cached_coding_quota(http_quota_cache, adapter_id, fetch, force) {
             if !samples.is_empty() {
                 connection.execute(
                     "DELETE FROM quota_snapshot WHERE adapter_id = ?1",
@@ -487,14 +488,19 @@ fn global_event_bounds(connection: &Connection) -> Result<(Option<i64>, Option<i
 
 fn cached_live_quota(
     cache: &Mutex<Option<(Instant, Vec<QuotaSample>)>>,
+    force: bool,
 ) -> Result<Vec<QuotaSample>> {
     let mut guard = cache
         .lock()
         .map_err(|_| anyhow::anyhow!("quota cache lock poisoned"))?;
-    if let Some((captured, value)) = guard.as_ref() {
-        let ttl = if value.is_empty() { 240 } else { 60 };
-        if captured.elapsed() < StdDuration::from_secs(ttl) {
-            return Ok(value.clone());
+    // force（手动刷新）跳过新鲜缓存的早退，立即尝试拉取；失败路径与常规一致：
+    // 依旧写入失败哨兵并保留库中旧行，绝不因强制刷新而删数据。
+    if !force {
+        if let Some((captured, value)) = guard.as_ref() {
+            let ttl = if value.is_empty() { 240 } else { 60 };
+            if captured.elapsed() < StdDuration::from_secs(ttl) {
+                return Ok(value.clone());
+            }
         }
     }
     match app_server::read_codex_quota(StdDuration::from_secs(4)) {
@@ -514,14 +520,17 @@ fn cached_live_quota(
 /// Claude OAuth 官方额度的缓存拉取：成功 120s、失败 300s（限流友好）。
 fn cached_claude_oauth_quota(
     cache: &Mutex<Option<(Instant, Vec<QuotaSample>)>>,
+    force: bool,
 ) -> Result<Vec<QuotaSample>> {
     let mut guard = cache
         .lock()
         .map_err(|_| anyhow::anyhow!("claude quota cache lock poisoned"))?;
-    if let Some((captured, value)) = guard.as_ref() {
-        let ttl = if value.is_empty() { 300 } else { 120 };
-        if captured.elapsed() < StdDuration::from_secs(ttl) {
-            return Ok(value.clone());
+    if !force {
+        if let Some((captured, value)) = guard.as_ref() {
+            let ttl = if value.is_empty() { 300 } else { 120 };
+            if captured.elapsed() < StdDuration::from_secs(ttl) {
+                return Ok(value.clone());
+            }
         }
     }
     match ClaudeOauth::detected().fetch_quota_samples(StdDuration::from_secs(6)) {
@@ -542,14 +551,17 @@ fn cached_coding_quota(
     cache: &Mutex<HashMap<&'static str, (Instant, Vec<QuotaSample>)>>,
     adapter_id: &'static str,
     fetch: fn(StdDuration) -> Result<Vec<QuotaSample>>,
+    force: bool,
 ) -> Result<Vec<QuotaSample>> {
     let mut guard = cache
         .lock()
         .map_err(|_| anyhow::anyhow!("coding quota cache lock poisoned"))?;
-    if let Some((captured, value)) = guard.get(adapter_id) {
-        let ttl = if value.is_empty() { 300 } else { 120 };
-        if captured.elapsed() < StdDuration::from_secs(ttl) {
-            return Ok(value.clone());
+    if !force {
+        if let Some((captured, value)) = guard.get(adapter_id) {
+            let ttl = if value.is_empty() { 300 } else { 120 };
+            if captured.elapsed() < StdDuration::from_secs(ttl) {
+                return Ok(value.clone());
+            }
         }
     }
     match fetch(StdDuration::from_secs(6)) {
@@ -1183,7 +1195,7 @@ fn source_views(report: ScanReport, sync_status: Option<SyncView>) -> Vec<Source
         SourceView {
             id: "zcode-local".into(),
             kind: "local".into(),
-            label: "ZCode / GLM 本地 Token".into(),
+            label: "GLM 本地 Token".into(),
             detail: format!(
                 "发现 {} 个用量库，本次更新 {} 个。{}只读取 model_usage 统计表的逐请求计数，主会话与子代理均覆盖；不读取消息内容表。",
                 discovered("zcode"),
@@ -2451,6 +2463,7 @@ mod tests {
             &quota_cache,
             &claude_quota_cache,
             &http_quota_cache,
+            false,
         )
         .unwrap();
         println!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -336,6 +336,7 @@ fn resolve_database_path(legacy_database: &Path, local_database: &Path) -> Resul
 #[tauri::command]
 async fn usage_snapshot(
     period: String,
+    force: Option<bool>,
     state: State<'_, AppState>,
 ) -> Result<UsageSnapshot, String> {
     let database_path = state.database_path.clone();
@@ -354,6 +355,7 @@ async fn usage_snapshot(
             &quota_cache,
             &claude_quota_cache,
             &http_quota_cache,
+            force.unwrap_or(false),
         )
         .map_err(|error| error.to_string())
     })
@@ -442,6 +444,7 @@ async fn rebuild_local_ledger(
             &quota_cache,
             &claude_quota_cache,
             &http_quota_cache,
+            false,
         )
         .map_err(|error| error.to_string())
     })

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -64,7 +64,7 @@ const STATUS_ITEMS: [StatusItemSpec; 6] = [
     },
     StatusItemSpec {
         id: "zcode",
-        name: "ZCode / GLM",
+        name: "GLM",
         icon: ZCODE_MARK,
     },
     StatusItemSpec {

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -23,11 +23,16 @@
 //! 计价（如 kimi-k2.5、glm-4.6、gemini-3-flash-preview）。
 //!
 //! 订阅制 coding plan 的专属模型 ID 一律 unpriced：Kimi Code 的 kimi-for-coding、
-//! k3，ZCode coding-plan 的 GLM-5.2 等。订阅额度按周期重置、不按 token 卖；
+//! ZCode coding-plan 的 GLM-5.2 等。订阅额度按周期重置、不按 token 卖；
 //! LiteLLM 里那些名字的 Bedrock/Azure/Cloudflare 条目是第三方转售价，拿来当
 //! 官方价就是猜价格。Kimi 官方文档只说 Extra Usage 按量计费且"接近开放平台
 //! 官方 API 价"，但未公布订阅模型 ID 的逐 token 价目——官方公布前不加。
 //! 同理，带 -preview 后缀的官方价不补给稳定版名字（gemini-3.1-pro 不计价）。
+//!
+//! 唯一的窄例外是「同一模型」别名：Kimi Code 订阅用量记的模型是 `kimi-code/k3`，
+//! 它就是 Kimi K3 这个模型本身——用 K3 的官方 API 价做估算，正是官方"接近开放
+//! 平台官方 API 价"的合理近似（成本页始终标注为估算，不与官方账单混淆）。
+//! 不借第三方转售价、不映射到别的模型，例外只此一类，见 SUBSCRIPTION_ALIASES。
 //!
 //! 缓存口径：OpenAI 的 prompt 缓存写入不计费（LiteLLM 里无该字段 → 记 0）；
 //! Anthropic 按 TTL 分级，LiteLLM 给的是最常见的 5 分钟档，1 小时档更贵——
@@ -49,17 +54,53 @@ pub struct Pricing {
     pub output: f64,
 }
 
+/// 手动补充的官方第一方价目（生成表之外）：模型太新、LiteLLM 尚未收录时
+/// 按官方定价页临时补齐，收录后即可删。查找时先于生成表命中。
+/// 来源：Moonshot 官方定价页（2026-07-18 核对，经多方转载交叉验证）：
+/// kimi-k3 输入 $3.00/M、缓存命中 $0.30/M、输出 $15.00/M（1M 上下文旗舰）。
+const MANUAL_PRICING: &[(&str, Pricing)] = &[(
+    "kimi-k3",
+    Pricing {
+        input: 3.0,
+        cache_read: 0.3,
+        cache_write: 0.0,
+        output: 15.0,
+    },
+)];
+
+/// 订阅制 coding plan 的模型 ID → 同一模型的官方第一方 API 价（估算口径）。
+/// 仅限"同一模型"：Kimi Code 订阅记的 `kimi-code/k3` 就是 kimi-k3 本身，
+/// 官方称 Extra Usage"接近开放平台官方 API 价"；成本页始终标注为估算。
+/// 没有官方价的订阅 ID（kimi-for-coding、GLM-5.2 等）继续 unpriced。
+const SUBSCRIPTION_ALIASES: &[(&str, &str)] = &[("kimi-code/k3", "kimi-k3")];
+
 /// 返回 `model` 的定价；表里没有则返回 `None`（调用方归入 unpriced，
-/// 不得臆造价格）。见模块文档：只精确匹配，日期快照后缀除外。
+/// 不得臆造价格）。见模块文档：只精确匹配，日期快照后缀与订阅别名除外。
 pub fn price_for(model: &str) -> Option<Pricing> {
-    exact(model).or_else(|| exact(strip_date_suffix(model)?))
+    exact(model)
+        .or_else(|| exact(strip_date_suffix(model)?))
+        .or_else(|| subscription_alias(model).and_then(exact))
 }
 
 fn exact(model: &str) -> Option<Pricing> {
-    PRICING_TABLE
-        .binary_search_by(|(name, _)| (*name).cmp(model))
-        .ok()
-        .map(|index| PRICING_TABLE[index].1)
+    MANUAL_PRICING
+        .iter()
+        .find(|(name, _)| *name == model)
+        .map(|(_, pricing)| *pricing)
+        .or_else(|| {
+            PRICING_TABLE
+                .binary_search_by(|(name, _)| (*name).cmp(model))
+                .ok()
+                .map(|index| PRICING_TABLE[index].1)
+        })
+}
+
+/// 订阅别名只按全名命中（`kimi-code/k3` → `kimi-k3`），不做任何前缀猜测。
+fn subscription_alias(model: &str) -> Option<&str> {
+    SUBSCRIPTION_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == model)
+        .map(|(_, target)| *target)
 }
 
 /// `claude-haiku-4-5-20251001` → `claude-haiku-4-5`。只认 8 位数字结尾，
@@ -114,13 +155,28 @@ mod tests {
     fn subscription_only_model_ids_stay_unpriced() {
         // 订阅 coding plan 的专属 ID 没有官方按 token 价目：不得借第三方
         // 转售价或同系模型的价格蒙混（Kimi Code 订阅、ZCode coding plan）。
-        assert!(price_for("kimi-code/k3").is_none());
         assert!(price_for("kimi-code/kimi-for-coding").is_none());
         assert!(price_for("kimi-for-coding").is_none());
         assert!(price_for("GLM-5.2").is_none());
         assert!(price_for("glm-5-turbo").is_none());
         // 有 -preview 后缀的官方价也不补给稳定版名字。
         assert!(price_for("gemini-3.1-pro").is_none());
+    }
+
+    #[test]
+    fn kimi_k3_priced_from_official_rates_including_subscription_alias() {
+        // 手动补充的官方价（LiteLLM 未收录时临时补齐）：K3 输入 $3、
+        // 缓存 $0.3、输出 $15（2026-07-18 官方定价页核对）。
+        let direct = price_for("kimi-k3").expect("kimi-k3 priced");
+        assert_eq!(direct.input, 3.0);
+        assert_eq!(direct.cache_read, 0.3);
+        assert_eq!(direct.output, 15.0);
+        // 窄例外：Kimi Code 订阅的 kimi-code/k3 就是 K3 本身，按同一官方价估算。
+        let aliased = price_for("kimi-code/k3").expect("alias priced");
+        assert_eq!(aliased.input, direct.input);
+        assert_eq!(aliased.output, direct.output);
+        // 其他订阅 ID 仍不得蒙混（见上一条测试）。
+        assert!(price_for("kimi-code/k4").is_none());
     }
 
     #[test]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRe
 import {
   ArrowDown,
   ArrowUp,
+  ArrowsClockwise,
   ArrowsDownUp,
   ArrowsInLineVertical,
   ArrowsInSimple,
@@ -44,6 +45,7 @@ import {
   setClaudeHook,
 } from "./usageClient";
 import {
+  UI_SCALE_RANGE,
   applyStartupUiScale,
   applyWindowMode,
   checkForUpdate,
@@ -56,6 +58,8 @@ import {
   onScaleFactorChanged,
   onTrayShowExpanded,
   openExpandedWindow,
+  readStripScale,
+  readUiScale,
   reassertCompactSize,
   resizeCompactWindow,
   resizeMacosPanel,
@@ -63,6 +67,7 @@ import {
   restoreWindowPosition,
   setAutostart,
   setNativeTheme,
+  setStripScale,
   updateMacStatusItems,
   setWindowGlass,
   setWindowPinned,
@@ -109,7 +114,7 @@ const AGENT_META = {
     iconClass: "agent-icon--claude",
   },
   zcode: {
-    label: "ZCode / GLM",
+    label: "GLM",
     accent: "#6a5ae0",
     iconSrc: zcodeAppIcon,
     iconClass: "agent-icon--zcode",
@@ -141,14 +146,14 @@ const AGENT_ORDER = Object.keys(AGENT_META);
 // 胶囊条首帧尺寸估计：横条一格约 68px 宽；竖条是横条立起来的窄长条，
 // 一格约 54px 高（图标/百分比/进度条纵向堆叠）。
 // 这些常量只用于进入 strip 的第一帧，之后的窗口尺寸由 StripBar 里的
-// 内容测量观察器按真实渲染结果收敛——不同字体/DPI/缩放档位、有无更新点
+// 内容测量观察器按真实渲染结果收敛——不同字体/DPI/缩放比例、有无更新点
 // 都不会再裁掉内容（曾因常量与 CSS 脱钩裁掉竖条最后一个按钮）。
 const STRIP_CELL_WIDTH = 68;
-const STRIP_CHROME_WIDTH = IS_MAC ? 76 : 102;
+const STRIP_CHROME_WIDTH = IS_MAC ? 76 : 158;
 const STRIP_BAR_HEIGHT = 40;
 const STRIP_VERTICAL_WIDTH = 52;
 const STRIP_VCELL_HEIGHT = 54;
-const STRIP_VCHROME_HEIGHT = IS_MAC ? 84 : 110;
+const STRIP_VCHROME_HEIGHT = IS_MAC ? 84 : 160;
 
 function stripWindowSize(orientation, count) {
   const cells = Math.max(1, count);
@@ -213,9 +218,9 @@ function scaledUnit(amount, divisor, unit) {
 }
 
 // 小组件窗口高度跟随 Agent 行数。内容自然高 = 各行 getBoundingClientRect
-// 实测之和（行高固定 52px，见 styles.css）；非列表部分（标题栏/周期/主区/
-// 页脚/间距）也是实测（shell.clientHeight - list.clientHeight）。不写布局
-// 常量——写死的常量差 4px 就会逼出一条本不该出现的滚动条。列表至少两行高。
+// 实测之和（行高固定 52px，见 styles.css 的 .widget-agent-list grid-auto-rows）；
+// 非列表部分（标题栏/双块/页脚/间距）也是实测（shell.clientHeight - list.clientHeight）。
+// 不写布局常量——写死的常量差 4px 就会逼出一条本不该出现的滚动条。列表至少两行高。
 const COMPACT_LIST_MIN_HEIGHT = 104;
 
 function compactTokens(value) {
@@ -275,17 +280,6 @@ function snapshotIsPartial(snapshot) {
   return snapshot.sources?.some((source) => source.quality === "partial") || false;
 }
 
-const UNAVAILABLE_QUOTA = {
-  available: false,
-  remainingPercent: 0,
-  resetsInMinutes: null,
-  ageMinutes: null,
-  stale: false,
-  resetExpired: false,
-  sourceLabel: "暂无可靠来源",
-  quality: "unavailable",
-};
-
 function agentQuotaFor(snapshot, agentId) {
   return (
     snapshot.agentQuotas?.find((entry) => entry.agent === agentId) || {
@@ -306,27 +300,60 @@ function shortWindowLabel(key) {
   return key.replace(/^seven_day_/, "").slice(0, 4);
 }
 
-// 小插件配额卡固定两行：优先取来源的前两个窗口，缺则补占位。
-function compactQuotaWindows(entry) {
-  const placeholders = [
-    { key: "five_hour", label: "Session", view: UNAVAILABLE_QUOTA },
-    { key: "seven_day", label: "每周", view: UNAVAILABLE_QUOTA },
-  ];
-  return [0, 1].map((index) => entry.windows?.[index] || placeholders[index]);
+// 小插件每行 Agent 最多展示两个配额窗口：按来源排序取前两个可用窗口
+// （已过期窗口也算有来源，单独走"已重置，等待刷新"样式）；一个都没有时
+// 由调用方渲染 "-- / 暂无可靠来源"，绝不编造数字。
+function compactDisplayWindows(entry) {
+  return (entry.windows || []).filter((window) => window.view.available).slice(0, 2);
 }
 
-// 胶囊条一格取"最紧张"窗口：可用窗口里已用百分比最高者。
+// Hero 块挑全组最紧的官方窗口：剩余最少的可用窗口（并列时取重置更近的）。
+// 只呈现官方数据的现状；全部不可用时返回 null，由列表里的 "--" 说明。
+function compactHeroQuota(snapshot, agents) {
+  let best = null;
+  for (const agentId of AGENT_ORDER.filter((id) => agents.includes(id))) {
+    const entry = agentQuotaFor(snapshot, agentId);
+    for (const window of entry.windows || []) {
+      const view = window.view;
+      if (!view.available || view.resetExpired || !Number.isFinite(view.remainingPercent)) continue;
+      const resets = Number.isFinite(view.resetsInMinutes) ? view.resetsInMinutes : Infinity;
+      if (
+        !best ||
+        view.remainingPercent < best.view.remainingPercent ||
+        (view.remainingPercent === best.view.remainingPercent && resets < best.resets)
+      ) {
+        best = { agentId, window, view, resets };
+      }
+    }
+  }
+  return best;
+}
+
+// 原生 title tooltip：逐窗口列出剩余与重置倒计时，并标注官方/快照/演示来源，
+// 让官方配额与本地解析用量始终可区分。
+function compactQuotaTooltip(agentId, windows) {
+  if (!windows.length) return `${AGENT_META[agentId].label}：暂无可靠来源`;
+  const lines = windows.map((window) => {
+    const view = window.view;
+    const label = window.label || shortWindowLabel(window.key);
+    if (view.resetExpired) return `${label}：已重置，等待刷新`;
+    const reset = Number.isFinite(view.resetsInMinutes)
+      ? ` · ${formatReset(view.resetsInMinutes)}后重置`
+      : "";
+    return `${label}：剩余 ${Math.round(view.remainingPercent)}%${reset} · ${quotaProvenance(view)}`;
+  });
+  return [AGENT_META[agentId].label, ...lines].join("\n");
+}
+
+// 胶囊条一格优先展示 5 小时窗口；该 Agent 没有 5h 窗口时，取后端排好序的
+// 第一个可用窗口（后端按 five_hour → seven_day → 模型/月度排序）。
 function stripCellData(entry) {
   const windows = (entry.windows || []).filter(
     (window) => window.view.available && !window.view.resetExpired,
   );
   if (!windows.length) return null;
-  const tightest = windows.reduce(
-    (worst, window) =>
-      quotaUsedPercent(window.view) > quotaUsedPercent(worst.view) ? window : worst,
-    windows[0],
-  );
-  return { tightest, windows };
+  const fiveHour = windows.find((window) => String(window.key || "").includes("five_hour"));
+  return { tightest: fiveHour || windows[0], windows };
 }
 
 // 原生 title tooltip：列出全部窗口的剩余与重置倒计时；快照数据标注更新时间。
@@ -844,7 +871,7 @@ function StripBar({
   const shellRef = useRef(null);
   // 窗口尺寸跟随真实内容（通用方案，替代手写常量）：每次渲染后与视口变化时
   // 复核目标尺寸，差 ≥1px 才调窗；量的是 CSS px，resizeStripWindow 内部统一
-  // 乘缩放档位与 DPI。任何字体/DPI/缩放/更新点组合都收敛，不再裁按钮。
+  // 乘缩放系数与 DPI。任何字体/DPI/缩放/更新点组合都收敛，不再裁按钮。
   useLayoutEffect(() => {
     if (IS_MAC || !isDesktop()) return undefined;
     const shell = shellRef.current;
@@ -983,7 +1010,7 @@ function StripBar({
             aria-pressed={pinned}
             title={pinned ? "取消固定，恢复拖动" : "固定在当前位置并置顶"}
           >
-            <PushPinSimple size={13} weight={pinned ? "fill" : "light"} aria-hidden="true" />
+            <PushPinSimple size={15} weight={pinned ? "fill" : "light"} aria-hidden="true" />
           </button>
         )}
         <button
@@ -993,7 +1020,7 @@ function StripBar({
           aria-label={vertical ? "切换为横条" : "切换为竖条"}
           title={vertical ? "切换为横条" : "切换为竖条"}
         >
-          <OrientationIcon size={13} weight="light" aria-hidden="true" />
+          <OrientationIcon size={15} weight="light" aria-hidden="true" />
         </button>
         <button
           type="button"
@@ -1002,7 +1029,7 @@ function StripBar({
           aria-label="展开为桌面小插件"
           title="展开为桌面小插件"
         >
-          <ArrowsOutSimple size={13} weight="light" aria-hidden="true" />
+          <ArrowsOutSimple size={15} weight="light" aria-hidden="true" />
         </button>
       </div>
     </main>
@@ -1011,29 +1038,20 @@ function StripBar({
 
 function CompactWidget({
   snapshot,
-  period,
-  selectedAgent,
-  visibleTokens,
   loading,
   pinned,
   transparent,
   glassMode = "css",
-  onPeriodChange,
-  onSelectAgent,
   onOpenSources,
   onTogglePinned,
   onToggleTransparent,
   onExpand,
-  quotaAgent,
-  onCycleQuotaAgent,
+  onRefresh,
   widgetAgents,
   glassAlpha = 0.82,
   availableUpdate,
   onOpenUpdate,
 }) {
-  const comparisonIsFlat = Math.abs(snapshot.comparisonPercent) < 0.5;
-  const comparisonIsLower = snapshot.comparisonPercent < -0.5;
-  const ComparisonArrow = comparisonIsLower ? ArrowDown : ArrowUp;
   const shellRef = useRef(null);
   // 一个观察器承担两条自愈：
   // 1) 宽度失配（zoom×物理尺寸失配，视口 < 320，右侧被裁）→ 整窗重应用（≤3 次）；
@@ -1101,16 +1119,10 @@ function CompactWidget({
       observer.disconnect();
     };
   });
-  // 标签必须描述快照本身的周期；切换周期的扫描期间不给旧数据贴新标签。
-  const comparisonLabel = snapshot.period === "today" ? "较近 7 日同时段" : "较前一周期";
-  const flatComparisonLabel = snapshot.period === "today" ? "与近 7 日同时段持平" : "与前一周期持平";
-  const switchingPeriod = !snapshot.pending && !snapshot.loadError && period !== snapshot.period;
-  const quotaEntry = agentQuotaFor(snapshot, quotaAgent);
-  const quotaWindows = compactQuotaWindows(quotaEntry);
-  const quotaView = quotaWindows.find((window) => window.view.available)?.view || UNAVAILABLE_QUOTA;
-  const quotaIsSnapshot = quotaView.stale || quotaView.quality === "official_snapshot";
-  const dataUnavailable = snapshot.pending || snapshot.loadError;
   const partial = snapshotIsPartial(snapshot);
+  // Hero 块：全组最紧缺的官方额度（大数字 + 粗条），恢复小卡片的视觉锚点；
+  // 列表作为第二块呈现各 Agent 明细。没有可用官方额度时整块不出现。
+  const hero = compactHeroQuota(snapshot, widgetAgents);
 
   return (
     <main
@@ -1157,118 +1169,107 @@ function CompactWidget({
         />
       </header>
 
-      <div className="widget-content">
-        <PeriodControl period={period} onChange={onPeriodChange} compact />
-
-        <section className="widget-primary" aria-label="用量摘要">
-          <div className="widget-metric">
-            <span>
-              {selectedAgent === "all" ? "总用量" : AGENT_META[selectedAgent].label}
-              {switchingPeriod ? `（${PERIODS.find((item) => item.id === snapshot.period)?.label}）` : ""}
-            </span>
-            <div aria-live="polite" aria-atomic="true">
-              <strong>{snapshot.pending || snapshot.loadError ? "--" : compactTokens(visibleTokens)}</strong>
-              <small>tokens</small>
-            </div>
-            <p className="widget-comparison">
-              {switchingPeriod ? (
-                <>正在统计{PERIODS.find((item) => item.id === period)?.label}数据…</>
-              ) : snapshot.pending ? (
-                <>正在建立本地索引</>
-              ) : snapshot.loadError ? (
-                <>本地数据读取失败</>
-              ) : selectedAgent !== "all" ? (
-                <>
-                  <FunnelSimple size={14} weight="light" aria-hidden="true" />
-                  已按 Agent 筛选
-                </>
-              ) : snapshot.comparisonAvailable ? (
-                <>
-                  {comparisonIsFlat ? (
-                    flatComparisonLabel
-                  ) : (
-                    <>
-                      <ComparisonArrow size={14} weight="bold" aria-hidden="true" />
-                      {comparisonLabel}{comparisonIsLower ? "低" : "高"} {Math.abs(snapshot.comparisonPercent).toFixed(0)}%
-                    </>
-                  )}
-                </>
-              ) : (
-                <>{period === "today" ? "同时段基线建立中" : "基线建立中"}</>
-              )}
-            </p>
-          </div>
-
-          <button
-            className={`widget-quota ${quotaIsSnapshot ? "widget-quota--stale" : ""}`}
-            style={{ "--quota-accent": AGENT_META[quotaAgent].accent }}
-            type="button"
-            onClick={onCycleQuotaAgent}
-            aria-label={`${AGENT_META[quotaAgent].label} 配额，点击切换 Agent`}
-            title="点击切换配额 Agent"
-          >
-            <span>{AGENT_META[quotaAgent].label} 已用</span>
-            {quotaWindows.map((window) => {
-              const severity = quotaSeverity(window.view);
-              const current = window.view.available && !window.view.resetExpired;
-              return (
-                <div
-                  className={`widget-quota-window ${severity ? `widget-quota-window--${severity}` : ""}`}
-                  key={window.key}
-                >
-                  <small>{shortWindowLabel(window.key)}</small>
-                  <div className="widget-quota-track" aria-hidden="true">
-                    <i style={{ transform: `scaleX(${current ? quotaUsedPercent(window.view) / 100 : 0})` }} />
-                  </div>
-                  <em>{current ? `${Math.round(quotaUsedPercent(window.view))}%` : "--"}</em>
+      <div className={`widget-content ${hero ? "widget-content--with-primary" : ""}`}>
+        {hero && (() => {
+          // 顶部双块：左侧焦点 Agent 的大剩余百分比，右侧该 Agent 的窗口明细卡。
+          // 焦点自动取全组剩余最少的窗口，不可点击、不轮播——数据是官方额度，
+          // 版式沿用原设计（原两处分别是 token 大数字与单家配额卡）。
+          const meta = AGENT_META[hero.agentId];
+          const view = hero.view;
+          const stale = view.stale || view.quality === "official_snapshot";
+          const remaining = Math.min(100, Math.max(0, view.remainingPercent));
+          const focusWindows = compactDisplayWindows(agentQuotaFor(snapshot, hero.agentId));
+          return (
+            <section className="widget-primary" aria-label="最紧缺的官方额度">
+              <div className="widget-metric">
+                <span>{meta.label} · {shortWindowLabel(hero.window.key)}</span>
+                <div aria-live="polite" aria-atomic="true">
+                  <strong>{stale ? "~" : ""}{Math.round(remaining)}%</strong>
+                  <small>剩余</small>
                 </div>
-              );
-            })}
-            <small>
-              {quotaView.quality === "demo"
-                ? quotaProvenance(quotaView)
-                : quotaView.resetExpired
-                  ? "窗口已重置，等待刷新"
-                  : quotaView.available
-                    ? `${formatReset(quotaView.resetsInMinutes)}后重置`
-                    : quotaAgent === "claude"
-                      ? "设置中开启配额钩子"
-                      : "官方配额不可用"}
-            </small>
-          </button>
-        </section>
-
-        <section className="widget-agent-list" aria-label="按 Agent 筛选">
+                <p className="widget-comparison">
+                  {Number.isFinite(view.resetsInMinutes)
+                    ? `${formatReset(view.resetsInMinutes)}后重置`
+                    : quotaProvenance(view)}
+                </p>
+              </div>
+              <div
+                className={`widget-quota ${stale ? "widget-quota--stale" : ""}`}
+                style={{ "--quota-accent": meta.accent }}
+                title={compactQuotaTooltip(hero.agentId, focusWindows)}
+              >
+                <span>{meta.label} 剩余</span>
+                {focusWindows.map((window) => {
+                  const windowView = window.view;
+                  const windowSeverity = quotaSeverity(windowView);
+                  const current = windowView.available && !windowView.resetExpired;
+                  const windowRemaining = Math.min(100, Math.max(0, windowView.remainingPercent));
+                  return (
+                    <div
+                      className={`widget-quota-window ${windowSeverity ? `widget-quota-window--${windowSeverity}` : ""}`}
+                      key={window.key}
+                    >
+                      <small>{shortWindowLabel(window.key)}</small>
+                      <div className="widget-quota-track" aria-hidden="true">
+                        {/* 窗口已过期的快照不再显示旧百分比，避免把陈旧值当现状。 */}
+                        <i style={{ transform: `scaleX(${current ? windowRemaining / 100 : 0})` }} />
+                      </div>
+                      <em>{current ? `${Math.round(windowRemaining)}%` : "--"}</em>
+                    </div>
+                  );
+                })}
+                <small>{quotaProvenance(view)}</small>
+              </div>
+            </section>
+          );
+        })()}
+        <section className="widget-agent-list" aria-label="各 Agent 官方剩余额度">
           {(() => {
             // 行集合只由用户的 Agent 选择决定（与胶囊条同一哲学：自选一律占格），
-            // 没用量/没数据的显示 0 而不是消失——否则周期一切换行数就变，
-            // 窗口高度跟着内容跳来跳去（用户称之为"乱飘"）。
-            const rows = AGENT_ORDER.filter(
-              (id) => widgetAgents.includes(id) || selectedAgent === id,
-            ).map((id) => {
-              const live = snapshot.agents.find((agent) => agent.id === id);
-              return live || { id, tokens: 0, share: 0 };
-            });
-            return rows.map((agent) => {
-              const meta = AGENT_META[agent.id];
+            // 没有可靠配额来源的 Agent 显示 "-- / 暂无可靠来源" 而不是消失——
+            // 否则来源一抖动行数就变，窗口高度跟着内容跳来跳去（用户称之为"乱飘"）。
+            return AGENT_ORDER.filter((id) => widgetAgents.includes(id)).map((agentId) => {
+              const meta = AGENT_META[agentId];
               if (!meta) return null;
-              const isSelected = selectedAgent === agent.id;
+              const entry = agentQuotaFor(snapshot, agentId);
+              const windows = compactDisplayWindows(entry);
+              // 行内头条窗口与胶囊条同规则：后端排序 five_hour 优先的第一个可用窗口；
+              // 完整窗口明细在该行的原生 tooltip 与焦点卡中。
+              const headline = windows[0] || null;
+              const headlineView = headline?.view || null;
+              const current = Boolean(headlineView && headlineView.available && !headlineView.resetExpired);
+              const stale = Boolean(
+                headlineView && (headlineView.stale || headlineView.quality === "official_snapshot"),
+              );
+              const severity = headlineView ? quotaSeverity(headlineView) : "";
+              const remaining = headlineView ? Math.min(100, Math.max(0, headlineView.remainingPercent)) : 0;
               return (
-                <button
-                  type="button"
-                  className={`widget-agent ${isSelected ? "widget-agent--selected" : ""}`}
-                  key={agent.id}
-                  aria-pressed={isSelected}
-                  onClick={() => onSelectAgent(isSelected ? "all" : agent.id)}
+                <div
+                  className={`widget-agent ${severity ? `widget-agent--${severity}` : ""} ${stale ? "widget-agent--stale" : ""}`}
+                  key={agentId}
+                  style={{ "--quota-accent": meta.accent }}
+                  title={compactQuotaTooltip(agentId, windows)}
                 >
                   <i className="widget-agent-accent" style={{ backgroundColor: meta.accent }} aria-hidden="true" />
-                  <AgentMark agentId={agent.id} />
+                  <AgentMark agentId={agentId} />
                   <span>
                     <strong>{meta.label}</strong>
-                    <small>{snapshot.pending || snapshot.loadError ? "--" : compactTokens(agent.tokens)} tokens</small>
+                    {/* 窗口标签与名称同一行：5h/7d 剩余；无来源或已重置时明示状态。 */}
+                    <small>
+                      {current
+                        ? `· ${shortWindowLabel(headline.key)}`
+                        : headlineView
+                          ? "· 已重置，等待刷新"
+                          : snapshot.pending
+                            ? "· 正在读取…"
+                            : snapshot.loadError
+                              ? "· 读取失败"
+                              : "· 暂无可靠来源"}
+                    </small>
                   </span>
-                  <em>{dataUnavailable ? "--" : `${agent.share.toFixed(1)}%`}</em>
-                </button>
+                  {/* 展示剩余额度（用户关心的是还能用多少），陈旧快照带 ~ 前缀。 */}
+                  <em>{current ? `${stale ? "~" : ""}${Math.round(remaining)}%` : "--"}</em>
+                </div>
               );
             });
           })()}
@@ -1279,6 +1280,16 @@ function CompactWidget({
             <ShieldCheck size={15} weight="fill" aria-hidden="true" />
             <span>{snapshot.pending ? "正在读取" : snapshot.loadError ? "数据暂不可用" : partial ? "部分覆盖" : snapshot.isDemo ? "演示数据" : "数据可追溯"}</span>
             <small>{snapshot.pending ? "请稍候" : loading ? "更新中" : snapshot.loadError ? "未替换" : partial ? "查看说明" : formatClock(snapshot.generatedAt)}</small>
+          </button>
+          <button
+            type="button"
+            className="widget-refresh"
+            onClick={onRefresh}
+            disabled={loading}
+            aria-label="强制刷新官方额度与本地统计"
+            title="强制刷新官方额度与本地统计"
+          >
+            <ArrowsClockwise size={13} weight="light" aria-hidden="true" />
           </button>
           <button type="button" className="widget-expand" onClick={() => onExpand("expanded")}>
             <span>完整视图</span>
@@ -1850,33 +1861,51 @@ function GlassAlphaCard({ glassAlpha, onGlassAlpha }) {
   );
 }
 
-const UI_SCALE_OPTIONS = [
-  { value: 1, label: "100%" },
-  { value: 1.25, label: "125%" },
-  { value: 1.5, label: "150%" },
-];
-
 function UiScaleCard({ uiScale, onUiScale }) {
+  const percent = Math.round(uiScale * 100);
   return (
     <div className="settings-card">
       <h2>小组件缩放</h2>
       <p className="settings-muted">
         {IS_MAC
-          ? "整体放大菜单栏面板（窗口和内容等比缩放，不会变形）。完整视图不受此设置影响。"
-          : "整体放大桌面小插件与胶囊条（窗口和内容等比缩放，不会变形）。完整视图不受此设置影响。"}
+          ? "整体放大菜单栏面板（窗口和内容等比缩放，不会变形），下次打开面板时生效。"
+          : "整体放大桌面小插件（窗口和内容等比缩放，不会变形），下次进入时生效。胶囊条在下方单独调。"}
       </p>
-      <div className="theme-toggle" role="group" aria-label="小组件缩放档位">
-        {UI_SCALE_OPTIONS.map((option) => (
-          <button
-            key={option.value}
-            type="button"
-            className={uiScale === option.value ? "is-selected" : ""}
-            aria-pressed={uiScale === option.value}
-            onClick={() => onUiScale(option.value)}
-          >
-            {option.label}
-          </button>
-        ))}
+      <div className="glass-slider-row">
+        <input
+          type="range"
+          min={UI_SCALE_RANGE.min * 100}
+          max={UI_SCALE_RANGE.max * 100}
+          step="5"
+          value={percent}
+          aria-label="小组件缩放百分比"
+          onChange={(event) => onUiScale(Number(event.target.value) / 100)}
+        />
+        <em>{percent}%</em>
+      </div>
+    </div>
+  );
+}
+
+function StripScaleCard({ stripScale, onStripScale }) {
+  const percent = Math.round(stripScale * 100);
+  return (
+    <div className="settings-card">
+      <h2>胶囊条缩放</h2>
+      <p className="settings-muted">
+        整体放大胶囊条（条和内容等比缩放，不会变形），与小组件互不影响，下次进入胶囊条时生效。
+      </p>
+      <div className="glass-slider-row">
+        <input
+          type="range"
+          min={UI_SCALE_RANGE.min * 100}
+          max={UI_SCALE_RANGE.max * 100}
+          step="5"
+          value={percent}
+          aria-label="胶囊条缩放百分比"
+          onChange={(event) => onStripScale(Number(event.target.value) / 100)}
+        />
+        <em>{percent}%</em>
       </div>
     </div>
   );
@@ -1963,7 +1992,7 @@ function StripAgentsCard({ stripAgents, onToggleStripAgent, onMoveStripAgent }) 
   );
 }
 
-function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, glassAlpha, onGlassAlpha, uiScale, onUiScale, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
+function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, glassAlpha, onGlassAlpha, uiScale, onUiScale, stripScale, onStripScale, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
   const [settings, setSettings] = useState(null);
   const [directoryInput, setDirectoryInput] = useState("");
   const [busy, setBusy] = useState(false);
@@ -2122,6 +2151,8 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
       <GlassAlphaCard glassAlpha={glassAlpha} onGlassAlpha={onGlassAlpha} />
 
       <UiScaleCard uiScale={uiScale} onUiScale={onUiScale} />
+
+      {!IS_MAC && <StripScaleCard stripScale={stripScale} onStripScale={onStripScale} />}
 
       <ClaudeHookCard onSnapshotRefresh={onSnapshotRefresh} />
       </div>
@@ -2799,9 +2830,6 @@ export function App() {
   const [transparent, setTransparent] = useState(
     () => IS_MAC || (localStorage.getItem("metrik:transparent") ?? "true") === "true",
   );
-  const [quotaAgent, setQuotaAgent] = useState(
-    () => localStorage.getItem("metrik:quotaAgent") || "codex",
-  );
   // 胶囊条方向：横条 / 竖条，用户手动选，记住选择。
   const [stripOrientation, setStripOrientation] = useState(() =>
     localStorage.getItem("metrik:stripOrientation") === "vertical" ? "vertical" : "horizontal",
@@ -2873,17 +2901,13 @@ export function App() {
     setGlassAlpha(next);
     localStorage.setItem("metrik:glassAlpha", String(next));
   }, []);
-  // 卡片/胶囊的整体缩放档位：窗口尺寸与 WebView 原生 zoom 同乘一个系数，
-  // 等比放大不会变形；expanded 不参与。生效在 windowClient 的形态切换里，
-  // 设置页改档后下次回到卡片/胶囊时应用。
-  const [uiScale, setUiScale] = useState(() => {
-    const stored = Number(localStorage.getItem("metrik:uiScale"));
-    return UI_SCALE_OPTIONS.some((option) => option.value === stored) ? stored : 1;
-  });
+  // 卡片/胶囊的整体缩放系数（连续值）：窗口尺寸与 WebView 原生 zoom 同乘一个系数，
+  // 等比放大不会变形；expanded 有独立系数。生效在 windowClient 的形态切换里，
+  // 设置页调整后下次回到卡片/胶囊时应用。
+  const [uiScale, setUiScale] = useState(() => readUiScale());
   const handleUiScale = useCallback((next) => {
-    setUiScale(next);
-    localStorage.setItem("metrik:uiScale", String(next));
-    setWindowUiScale(next);
+    // setWindowUiScale 负责钳位与持久化，返回实际生效值回填 UI。
+    setUiScale(setWindowUiScale(next));
   }, []);
   // 自动检查更新：默认开、设置里可关。只检查和提醒（小组件上的小圆点），
   // 下载安装始终由用户在设置页点击触发。
@@ -2940,7 +2964,7 @@ export function App() {
   const rebuildInFlight = useRef(false);
   currentPeriod.current = period;
 
-  const loadSnapshot = useCallback(async (nextPeriod) => {
+  const loadSnapshot = useCallback(async (nextPeriod, options) => {
     if (loadInFlight.current) {
       queuedLoadPeriod.current = activeLoadPeriod.current === nextPeriod ? null : nextPeriod;
       return;
@@ -2948,13 +2972,16 @@ export function App() {
 
     loadInFlight.current = true;
     let periodToLoad = nextPeriod;
+    // force（手动强制刷新）只作用于本次请求；排队的周期切换仍按常规加载。
+    let forceLoad = options?.force === true;
     try {
       while (periodToLoad) {
         activeLoadPeriod.current = periodToLoad;
         queuedLoadPeriod.current = null;
         const requestId = ++requestSequence.current;
         setLoading(true);
-        const next = await getUsageSnapshot(periodToLoad);
+        const next = await getUsageSnapshot(periodToLoad, forceLoad ? { force: true } : undefined);
+        forceLoad = false;
         if (requestId === requestSequence.current && !queuedLoadPeriod.current) {
           setSnapshot(next);
         }
@@ -3095,16 +3122,6 @@ export function App() {
     return snapshot.agents.find((agent) => agent.id === selectedAgent)?.tokens || 0;
   }, [selectedAgent, snapshot]);
 
-  // Codex 与 Claude 始终可切换：即使某个官方配额来源尚未启用，也要让用户
-  // 看到明确的不可用/设置提示；其它 Agent 仍只在有可靠配额数据时加入循环。
-  const quotaAgents = useMemo(() => {
-    const withData = (snapshot.agentQuotas || [])
-      .filter(quotaHasData)
-      .map((entry) => entry.agent)
-      .filter((agent) => AGENT_META[agent]);
-    return [...new Set(["codex", "claude", ...withData])];
-  }, [snapshot]);
-  const activeQuotaAgent = quotaAgents.includes(quotaAgent) ? quotaAgent : quotaAgents[0];
   // 自动模式：胶囊条显示全部有官方配额数据的 agent（快照顺序）。
   const autoStripAgents = useMemo(
     () =>
@@ -3130,6 +3147,12 @@ export function App() {
     return null;
   });
   const stripAgents = stripAgentsSetting ?? autoStripAgents;
+
+  // 胶囊条的独立缩放系数（与小组件互不影响）：设置页滑杆调整，下次进入时生效。
+  const [stripScale, setStripScaleState] = useState(() => readStripScale());
+  const handleStripScale = useCallback((next) => {
+    setStripScaleState(setStripScale(next));
+  }, []);
 
   // macOS 菜单栏与紧凑小组件共用 widgetAgents：用户勾选哪些 Agent，状态栏就
   // 显示哪些品牌图标与官方额度。无可靠额度时传 null，原生状态项明确显示 "--"。
@@ -3201,12 +3224,6 @@ export function App() {
       await setWindowPinned(pinnedRef.current);
     });
   }, [viewMode, stripAgents.length, stripOrientation]);
-  const handleCycleQuotaAgent = useCallback(() => {
-    const index = quotaAgents.indexOf(activeQuotaAgent);
-    const next = quotaAgents[(index + 1) % quotaAgents.length];
-    setQuotaAgent(next);
-    localStorage.setItem("metrik:quotaAgent", next);
-  }, [activeQuotaAgent, quotaAgents]);
   const appBusy = loading || rebuildState.status === "busy";
   const comparisonIsFlat = Math.abs(snapshot.comparisonPercent) < 0.5;
   const comparisonIsLower = snapshot.comparisonPercent < -0.5;
@@ -3354,6 +3371,13 @@ export function App() {
     }
   }, [loadSnapshot]);
 
+  // 小插件/完整视图的手动刷新：强制后端重取官方额度与本地统计（绕过缓存）。
+  // 注意：这是 Hook，必须放在 strip/compact 的条件 return 之前，
+  // 否则切形态时 hooks 数量变化会直接把 React 树崩成白屏。
+  const handleForceRefresh = useCallback(() => {
+    loadSnapshot(currentPeriod.current, { force: true });
+  }, [loadSnapshot]);
+
   if (viewMode === "strip" && !IS_MAC) {
     return (
       <StripBar
@@ -3379,21 +3403,15 @@ export function App() {
       <>
         <CompactWidget
           snapshot={snapshot}
-          period={period}
-          selectedAgent={selectedAgent}
-          visibleTokens={visibleTokens}
           loading={appBusy}
           pinned={pinned}
           transparent={transparent}
           glassMode={glassMode}
-          onPeriodChange={setPeriod}
-          onSelectAgent={setSelectedAgent}
           onOpenSources={() => setDrawerOpen(true)}
           onTogglePinned={handleTogglePinned}
           onToggleTransparent={handleToggleTransparent}
           onExpand={handleWindowMode}
-          quotaAgent={activeQuotaAgent}
-          onCycleQuotaAgent={handleCycleQuotaAgent}
+          onRefresh={handleForceRefresh}
           widgetAgents={widgetAgents}
           glassAlpha={glassAlpha}
           availableUpdate={availableUpdate}
@@ -3426,6 +3444,17 @@ export function App() {
             />
           </>
         )}
+        {/* 手动强制刷新：强制后端重取官方额度与本地统计（绕过缓存），加载期间禁用并旋转。 */}
+        <button
+          type="button"
+          className={`expanded-refresh ${IS_MAC ? "expanded-refresh--mac" : ""}`}
+          onClick={handleForceRefresh}
+          disabled={appBusy}
+          aria-label="强制刷新官方额度与本地统计"
+          title="强制刷新官方额度与本地统计"
+        >
+          <ArrowsClockwise size={15} weight="light" aria-hidden="true" />
+        </button>
         <Sidebar activeNav={activeNav} onNavChange={handleNavChange} snapshot={snapshot} loading={appBusy} />
 
         {indexingPending > 0 ? (
@@ -3518,6 +3547,8 @@ export function App() {
             onGlassAlpha={handleGlassAlpha}
             uiScale={uiScale}
             onUiScale={handleUiScale}
+            stripScale={stripScale}
+            onStripScale={handleStripScale}
             theme={theme}
             onThemeChange={handleThemeChange}
             autoUpdateCheck={autoUpdateCheck}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,7 +5,7 @@
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   /* 小组件布局按像素精调，禁止系统文本缩放单独放大文字挤坏布局；
-     用户想放大走设置里的整体缩放档位。 */
+     用户想放大走设置里的整体缩放滑杆。 */
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   --canvas: #f7f6f2;
@@ -181,13 +181,6 @@ button:focus-visible {
   box-shadow: 0 1px rgba(255, 255, 255, 0.08);
 }
 
-.widget-shell--transparent .widget-metric {
-  padding-inline: 7px 5px;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 14px;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.09);
-}
-
 /* ============ 玻璃拟态回落层 ============
    原生 Acrylic/HostBackdrop 不可用时（含浏览器预览与 release 失效场景），
    同一套深色 HUD 加深到近实心（0.94），外观不塌。
@@ -252,7 +245,7 @@ button:focus-visible {
   flex: 1;
   /* 列表行吃掉窗口的额外高度：行数少时 104px 起步与原 320 设计一致，
      行数多时窗口加高、列表随之舒展。 */
-  grid-template-rows: 34px 86px minmax(104px, 1fr) 30px;
+  grid-template-rows: minmax(104px, 1fr) 30px;
   gap: 4px;
   padding: 2px 10px 6px;
   transition-property: opacity;
@@ -262,32 +255,14 @@ button:focus-visible {
 
 .widget-shell.is-loading .widget-content { opacity: 0.88; }
 
-.widget-shell .period-control--compact {
-  position: relative;
-  top: auto;
-  left: auto;
-  transform: none;
-  width: 100%;
-  max-width: none;
-  height: 34px;
-  margin: 0;
-  padding: 2px;
-  background: rgba(31, 33, 36, 0.045);
-  border-radius: 11px;
-  box-shadow: none;
+/* 有顶部双块时网格多一行：双块自适应高，列表继续吃剩余空间。 */
+.widget-content--with-primary {
+  grid-template-rows: auto minmax(104px, 1fr) 30px;
+  gap: 6px;
 }
 
-.widget-shell .period-control--compact button.is-selected {
-  box-shadow: 0 1px 3px rgba(28, 30, 33, 0.1), 0 0 0 1px rgba(31, 33, 36, 0.04);
-}
-
-.widget-shell .period-control--compact button {
-  min-height: 30px;
-  padding: 0 7px;
-  border-radius: 9px;
-  font-size: 12px;
-}
-
+/* 顶部双块：左侧焦点 Agent 的大剩余百分比，右侧该 Agent 的窗口明细卡。
+   数据是官方额度；版式沿用原设计（原为 token 大数字 + 单家配额卡），静态展示不可点击。 */
 .widget-primary {
   display: grid;
   min-width: 0;
@@ -380,24 +355,11 @@ button:focus-visible {
   color: #25262a;
   text-align: left;
   background: rgba(251, 251, 250, 0.88);
-  border: 0;
   border-radius: 15px;
-  cursor: pointer;
   box-shadow:
     0 0 0 1px rgba(31, 33, 36, 0.07),
     0 8px 22px rgba(31, 33, 36, 0.045),
     inset 0 1px rgba(255, 255, 255, 0.92);
-  transition-property: background-color, transform, box-shadow;
-  transition-duration: 260ms;
-  transition-timing-function: var(--motion);
-}
-
-.widget-quota:hover {
-  background: rgba(255, 255, 255, 0.95);
-  box-shadow:
-    0 0 0 1px rgba(31, 33, 36, 0.08),
-    0 11px 26px rgba(31, 33, 36, 0.06),
-    inset 0 1px rgba(255, 255, 255, 0.98);
 }
 
 /* 陈旧快照：用透明度编码新鲜度，颜色语义（品牌色/警示色）保持不变。 */
@@ -408,11 +370,6 @@ button:focus-visible {
 .widget-quota-window--warn em { color: #8f681f; }
 .widget-quota-window--critical .widget-quota-track i { background: var(--critical); }
 .widget-quota-window--critical em { color: #a1402e; }
-
-.widget-quota:active,
-.widget-agent:active,
-.widget-source:active,
-.widget-expand:active { transform: scale(0.96); }
 
 .widget-quota-window {
   display: grid;
@@ -438,6 +395,90 @@ button:focus-visible {
   text-align: right;
 }
 
+.widget-quota > small {
+  margin-top: 3px;
+  overflow: hidden;
+  color: #66686c;
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* 每个 Agent 一行：品牌色条 + 图标 + 名称/窗口标签 + 头条窗口剩余百分比（静态行）。 */
+.widget-agent {
+  position: relative;
+  display: grid;
+  width: 100%;
+  min-height: 0;
+  grid-template-columns: 4px 43px minmax(0, 1fr) auto;
+  align-items: center;
+  padding: 4px 11px 4px 0;
+  color: #25262a;
+  text-align: left;
+  background: transparent;
+  box-shadow: 0 1px rgba(31, 33, 36, 0.075);
+}
+
+.widget-agent:last-child { box-shadow: none; }
+
+.widget-agent-accent {
+  width: 3px;
+  height: 34px;
+  border-radius: 0 3px 3px 0;
+  opacity: 0.48;
+  transform: scaleY(0.4);
+}
+
+.widget-agent .agent-icon {
+  width: 36px;
+  height: 36px;
+  margin-left: 7px;
+  border-radius: 10px;
+}
+
+.widget-agent > span:not(.agent-icon) {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 5px;
+  padding-left: 7px;
+}
+
+.widget-agent > span > strong {
+  overflow: hidden;
+  font-size: 13.5px;
+  font-weight: 560;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.widget-agent > span > small {
+  overflow: hidden;
+  color: #65676b;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.widget-agent em {
+  color: #2b2d31;
+  font-size: 12.5px;
+  font-style: normal;
+  font-weight: 570;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+
+.widget-agent--stale em { opacity: 0.62; }
+.widget-agent--warn em { color: #8f681f; }
+.widget-agent--critical em { color: #a1402e; }
+
+.widget-source:active,
+.widget-expand:active,
+.widget-refresh:active { transform: scale(0.96); }
+
 .widget-quota-track {
   height: 5px;
   overflow: hidden;
@@ -457,21 +498,11 @@ button:focus-visible {
   transition-timing-function: var(--motion);
 }
 
-.widget-quota > small {
-  margin-top: 3px;
-  overflow: hidden;
-  color: #66686c;
-  font-size: 9px;
-  font-variant-numeric: tabular-nums;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .widget-agent-list {
   display: grid;
   min-height: 0;
-  /* 每行固定 52px（图标 + 文字的自然高度）：scrollHeight 恒等于内容自然高，
-     供窗口高度跟随内容测量；装不下时内部滚动，不再把 N 行压进固定高度叠字。 */
+  /* 每行固定 52px（图标 + 文字的自然高度）：内容自然高 = 行数 × 52，
+     供窗口高度跟随内容测量；装不下时内部滚动。 */
   overflow-y: auto;
   grid-auto-rows: 52px;
   background: rgba(251, 251, 250, 0.78);
@@ -510,102 +541,10 @@ button:focus-visible {
   background: rgba(255, 255, 255, 0.26);
 }
 
-/* 用户可勾选 1–4 个 Agent；3 行起收紧密度，4 行去掉次要信息。 */
-.widget-agent-list:has(> :nth-child(3)) .agent-icon {
-  width: 26px;
-  height: 26px;
-  border-radius: 8px;
-}
-
-.widget-agent-list:has(> :nth-child(3)) .widget-agent { grid-template-columns: 4px 33px minmax(0, 1fr) auto; }
-.widget-agent-list:has(> :nth-child(3)) .widget-agent > span { gap: 1px; }
-.widget-agent-list:has(> :nth-child(3)) .widget-agent > span > strong { font-size: 11px; }
-.widget-agent-list:has(> :nth-child(3)) .widget-agent > span > small { font-size: 9px; }
-.widget-agent-list:has(> :nth-child(3)) .widget-agent-accent { height: 24px; }
-
-.widget-agent-list:has(> :nth-child(4)) .widget-agent > span > small { display: none; }
-
-.widget-agent-list:has(> :nth-child(4)) .agent-icon {
-  width: 22px;
-  height: 22px;
-  border-radius: 7px;
-}
-
-.widget-agent {
-  position: relative;
-  display: grid;
-  width: 100%;
-  min-height: 0;
-  grid-template-columns: 4px 43px minmax(0, 1fr) auto;
-  align-items: center;
-  padding: 4px 11px 4px 0;
-  color: #25262a;
-  text-align: left;
-  background: transparent;
-  border: 0;
-  cursor: pointer;
-  box-shadow: 0 1px rgba(31, 33, 36, 0.075);
-  transition-property: background-color, transform;
-  transition-duration: 260ms;
-  transition-timing-function: var(--motion);
-}
-
-.widget-agent:last-child { box-shadow: none; }
-
-.widget-agent:hover,
-.widget-agent--selected { background: rgba(36, 107, 219, 0.035); }
-
-.widget-agent-accent {
-  width: 3px;
-  height: 34px;
-  border-radius: 0 3px 3px 0;
-  opacity: 0.48;
-  transform: scaleY(0.4);
-  transition-property: opacity, transform;
-  transition-duration: 260ms;
-  transition-timing-function: var(--motion);
-}
-
-.widget-agent:hover .widget-agent-accent,
-.widget-agent--selected .widget-agent-accent {
-  opacity: 1;
-  transform: scaleY(1);
-}
-
-.widget-agent .agent-icon {
-  width: 36px;
-  height: 36px;
-  margin-left: 7px;
-  border-radius: 10px;
-}
-
-.widget-agent > span:not(.agent-icon) {
-  display: grid;
-  min-width: 0;
-  gap: 3px;
-  padding-left: 7px;
-}
-
-.widget-agent > span > strong {
-  overflow: hidden;
-  font-size: 12px;
-  font-weight: 560;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.widget-agent > span > small {
-  color: #65676b;
-  font-size: 10px;
-  font-variant-numeric: tabular-nums;
-}
-
-.widget-agent em {
-  color: #717378;
-  font-size: 10px;
-  font-style: normal;
-  font-variant-numeric: tabular-nums;
-}
+/* 行图标统一全尺寸（36px 填满 52px 行高），不做按行数收缩——收缩后行内
+   上下空白过大，且单行文本时代更明显。 */
+.widget-agent .agent-icon--zcode { width: 44px; height: 44px; margin: -4px 0 -4px 3px; }
+.widget-agent .agent-icon--kimi { width: 40px; height: 40px; margin: -2px 0 -2px 5px; }
 
 .widget-footer {
   display: flex;
@@ -666,6 +605,33 @@ button:focus-visible {
 .widget-expand:hover { background: #111214; }
 .widget-expand span { font-size: 10px; font-weight: 520; }
 
+/* 手动强制刷新：加载期间禁用并让图标旋转，复用 loading 状态。 */
+.widget-refresh {
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  color: #66686c;
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  transition-property: color, background-color, transform;
+  transition-duration: 250ms;
+  transition-timing-function: var(--motion);
+}
+
+.widget-refresh:hover { color: #34363a; background: rgba(31, 33, 36, 0.06); }
+.widget-refresh:disabled { cursor: default; }
+.widget-refresh:disabled:hover { color: #66686c; background: transparent; }
+.widget-refresh:disabled svg { animation: widget-refresh-spin 0.9s linear infinite; }
+
+@keyframes widget-refresh-spin {
+  to { transform: rotate(360deg); }
+}
+
 /* ---- 深色 HUD 玻璃的文字与控件层（不随系统主题变化） ---- */
 .widget-shell--transparent .widget-brand { color: rgba(255, 255, 255, 0.94); }
 
@@ -678,21 +644,6 @@ button:focus-visible {
 
 .widget-shell--transparent .window-action--active { color: #9ec1f5; }
 
-.widget-shell--transparent .period-control--compact {
-  background: rgba(255, 255, 255, 0.09);
-  box-shadow: none;
-}
-
-.widget-shell--transparent .period-control--compact button { color: rgba(255, 255, 255, 0.6); }
-
-.widget-shell--transparent .period-control--compact button.is-selected {
-  color: rgba(18, 20, 24, 0.94);
-  background: rgba(255, 255, 255, 0.92);
-}
-
-.widget-shell--transparent .widget-metric strong { color: rgba(255, 255, 255, 0.96); }
-
-.widget-shell--transparent .widget-quota,
 .widget-shell--transparent .widget-agent-list {
   background: rgba(255, 255, 255, 0.06);
   box-shadow:
@@ -700,35 +651,36 @@ button:focus-visible {
     inset 0 1px rgba(255, 255, 255, 0.08);
 }
 
-.widget-shell--transparent .widget-quota { color: rgba(255, 255, 255, 0.94); }
+.widget-shell--transparent .widget-metric strong { color: rgba(255, 255, 255, 0.96); }
 
-.widget-shell--transparent .widget-quota:hover {
-  background: rgba(255, 255, 255, 0.1);
+.widget-shell--transparent .widget-quota {
+  color: rgba(255, 255, 255, 0.94);
+  background: rgba(255, 255, 255, 0.06);
   box-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.13),
-    inset 0 1px rgba(255, 255, 255, 0.1);
+    0 0 0 1px rgba(255, 255, 255, 0.09),
+    inset 0 1px rgba(255, 255, 255, 0.08);
 }
+
+.widget-shell--transparent .widget-agent { color: rgba(255, 255, 255, 0.92); box-shadow: 0 1px rgba(255, 255, 255, 0.08); }
+.widget-shell--transparent .widget-agent:last-child { box-shadow: none; }
 
 .widget-shell--transparent .widget-quota-track {
   background: color-mix(in srgb, var(--quota-accent, #7fabef) 24%, rgba(255, 255, 255, 0.06));
 }
-.widget-shell--transparent .widget-quota-window small { color: rgba(255, 255, 255, 0.55); }
-.widget-shell--transparent .widget-quota-window em { color: rgba(255, 255, 255, 0.94); }
 .widget-shell--transparent .widget-quota-track i {
   background: var(--quota-accent, #7fabef);
   filter: brightness(1.22) saturate(0.92);
 }
+.widget-shell--transparent .widget-quota-window small { color: rgba(255, 255, 255, 0.55); }
+.widget-shell--transparent .widget-quota-window em { color: rgba(255, 255, 255, 0.94); }
 .widget-shell--transparent .widget-quota--stale .widget-quota-track i { opacity: 0.55; }
 .widget-shell--transparent .widget-quota-window--warn .widget-quota-track i { background: #e8b04a; filter: none; }
 .widget-shell--transparent .widget-quota-window--warn em { color: #e8b04a; }
 .widget-shell--transparent .widget-quota-window--critical .widget-quota-track i { background: #ec7a63; filter: none; }
 .widget-shell--transparent .widget-quota-window--critical em { color: #ec7a63; }
-
-.widget-shell--transparent .widget-agent { color: rgba(255, 255, 255, 0.92); box-shadow: 0 1px rgba(255, 255, 255, 0.08); }
-.widget-shell--transparent .widget-agent:last-child { box-shadow: none; }
-
-.widget-shell--transparent .widget-agent:hover,
-.widget-shell--transparent .widget-agent--selected { background: rgba(255, 255, 255, 0.07); }
+.widget-shell--transparent .widget-agent--warn em { color: #e8b04a; }
+.widget-shell--transparent .widget-agent--critical em { color: #ec7a63; }
+.widget-shell--transparent .widget-agent em { color: rgba(255, 255, 255, 0.94); }
 
 .widget-shell--transparent .widget-metric > span,
 .widget-shell--transparent .widget-quota > span,
@@ -736,14 +688,16 @@ button:focus-visible {
 .widget-shell--transparent .widget-comparison,
 .widget-shell--transparent .widget-quota > small,
 .widget-shell--transparent .widget-agent > span > small,
-.widget-shell--transparent .widget-agent em,
 .widget-shell--transparent .widget-source,
 .widget-shell--transparent .widget-source small {
   color: rgba(255, 255, 255, 0.58);
 }
 
-.widget-shell--transparent .widget-comparison svg { color: #7fabef; }
 .widget-shell--transparent .widget-source:hover { color: rgba(255, 255, 255, 0.9); }
+
+.widget-shell--transparent .widget-refresh { color: rgba(255, 255, 255, 0.58); }
+.widget-shell--transparent .widget-refresh:hover { color: rgba(255, 255, 255, 0.9); background: rgba(255, 255, 255, 0.1); }
+.widget-shell--transparent .widget-refresh:disabled:hover { color: rgba(255, 255, 255, 0.58); background: transparent; }
 
 .widget-shell--transparent .widget-expand {
   color: rgba(255, 255, 255, 0.95);
@@ -769,7 +723,7 @@ html:has(.strip-shell) #root {
   align-items: center;
   width: 100vw;
   height: 100dvh;
-  padding: 0 6px 0 8px;
+  padding: 0 5px 0 6px;
   gap: 4px;
   overflow: hidden;
   color: var(--ink);
@@ -784,7 +738,7 @@ html:has(.strip-shell) #root {
 .strip-shell--vertical {
   flex-direction: column;
   align-items: stretch;
-  padding: 8px 5px 6px;
+  padding: 6px 3px 4px;
   gap: 4px;
 }
 
@@ -828,7 +782,7 @@ html:has(.strip-shell) #root {
   flex: none;
   flex-direction: column;
   gap: 4px;
-  padding: 6px 4px;
+  padding: 5px 2px;
 }
 
 .strip-shell--vertical .strip-cell-icon {
@@ -946,13 +900,13 @@ html:has(.strip-shell) #root {
   padding-top: 4px;
 }
 
-/* 状态点/更新点与按钮共用 22px 槽位：所有控件恒同心，
+/* 状态点/更新点与按钮共用 26px 槽位：所有控件恒同心，
    不再靠"各自恰好居中"的巧合（内容超窗挤压时曾错位）。 */
 .strip-control-slot {
   display: grid;
   flex: none;
-  width: 22px;
-  height: 22px;
+  width: 26px;
+  height: 26px;
   place-items: center;
 }
 
@@ -964,12 +918,12 @@ html:has(.strip-shell) #root {
   display: grid;
   flex: none;
   place-items: center;
-  width: 22px;
-  height: 22px;
+  width: 26px;
+  height: 26px;
   color: #4f5257;
   background: rgba(31, 33, 36, 0.06);
   border: none;
-  border-radius: 7px;
+  border-radius: 8px;
   cursor: pointer;
   transition-property: color, background-color;
   transition-duration: 240ms;
@@ -1027,22 +981,6 @@ html:has(.strip-shell) #root {
     background: rgba(31, 33, 36, 0.08);
   }
 
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .period-control--compact {
-    background: rgba(31, 33, 36, 0.07);
-  }
-
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .period-control--compact button {
-    color: rgba(31, 33, 36, 0.58);
-  }
-
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .period-control--compact button.is-selected {
-    color: rgba(24, 26, 30, 0.94);
-    background: rgba(255, 255, 255, 0.78);
-    box-shadow: 0 1px 3px rgba(31, 33, 36, 0.12);
-  }
-
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-metric,
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota,
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent-list {
     background: rgba(255, 255, 255, 0.34);
     box-shadow:
@@ -1050,14 +988,19 @@ html:has(.strip-shell) #root {
       inset 0 1px rgba(255, 255, 255, 0.52);
   }
 
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota:hover,
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent:hover,
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent--selected {
-    background: rgba(255, 255, 255, 0.5);
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota {
+    background: rgba(255, 255, 255, 0.34);
+    box-shadow:
+      0 0 0 1px rgba(31, 33, 36, 0.08),
+      inset 0 1px rgba(255, 255, 255, 0.52);
   }
 
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent {
     box-shadow: 0 1px rgba(31, 33, 36, 0.07);
+  }
+
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-window em {
+    color: rgba(24, 26, 30, 0.92);
   }
 
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-metric > span,
@@ -1067,14 +1010,9 @@ html:has(.strip-shell) #root {
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota > small,
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-window small,
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent > span > small,
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent em,
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-source,
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-source small {
     color: rgba(31, 33, 36, 0.58);
-  }
-
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-window em {
-    color: rgba(24, 26, 30, 0.92);
   }
 
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-track {
@@ -1083,6 +1021,20 @@ html:has(.strip-shell) #root {
 
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-source:hover {
     color: rgba(24, 26, 30, 0.9);
+  }
+
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-refresh {
+    color: rgba(31, 33, 36, 0.58);
+  }
+
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-refresh:hover {
+    color: rgba(24, 26, 30, 0.9);
+    background: rgba(31, 33, 36, 0.08);
+  }
+
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-refresh:disabled:hover {
+    color: rgba(31, 33, 36, 0.58);
+    background: transparent;
   }
 
   .strip-shell--mac:not(.strip-shell--glass-css) {
@@ -1365,6 +1317,40 @@ html:has(.strip-shell) #root {
   background: rgba(255, 255, 255, 0.92);
   box-shadow: 0 1px 2px rgba(28, 30, 33, 0.08), 0 5px 18px rgba(28, 30, 33, 0.06);
 }
+
+/* 完整视图的手动强制刷新：右上角悬浮，Windows 上贴着自绘按钮条左侧；
+   加载期间禁用并让图标旋转。 */
+.expanded-refresh {
+  position: absolute;
+  z-index: 9;
+  top: 10px;
+  right: 190px;
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  padding: 0;
+  color: #77797d;
+  background: rgba(247, 246, 242, 0.72);
+  border: 0;
+  border-radius: 10px;
+  box-shadow:
+    0 0 0 1px rgba(31, 33, 36, 0.07),
+    0 4px 14px rgba(31, 33, 36, 0.05);
+  cursor: pointer;
+  transition-property: color, background-color, transform;
+  transition-duration: 240ms;
+  transition-timing-function: var(--motion);
+}
+
+/* macOS 没有自绘按钮条，直接贴右上角。 */
+.expanded-refresh--mac { right: 12px; }
+
+.expanded-refresh:hover { color: #242529; background: rgba(247, 246, 242, 0.95); }
+.expanded-refresh:active { transform: scale(0.96); }
+.expanded-refresh:disabled { cursor: default; opacity: 0.65; }
+.expanded-refresh:disabled:hover { color: #77797d; }
+.expanded-refresh:disabled svg { animation: widget-refresh-spin 0.9s linear infinite; }
 
 .app-shell--expanded {
   height: 100dvh;
@@ -2226,10 +2212,9 @@ html:has(.strip-shell) #root {
 .settings-section {
   grid-column: 2 / 4;
   height: 100dvh;
+  /* 与其他三个页面同一流体 padding 模式、铺满宽度：宽屏时卡片网格
+     由 auto-fit 自然展开成 3-4 列，不再限宽居中。 */
   padding: 88px min(9vw, 110px) 56px;
-  /* 内容限宽 1000px 由左右 padding 撑出来并居中：表头、横幅、卡片网格
-     共享同一内容列，左边缘永远对齐，不依赖子元素自己的 margin。 */
-  padding-inline: max(min(9vw, 110px), calc((100% - 1000px) / 2));
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: rgba(31, 33, 36, 0.22) transparent;
@@ -2262,8 +2247,7 @@ html:has(.strip-shell) #root {
   border-radius: 12px;
 }
 
-/* 双列等高：同一行的卡片拉到等高，所有边缘对齐；窄窗口自动回退单列。
-   整个设置区限宽居中（见下），宽屏最多两列，不追求铺满。 */
+/* 双列起、宽屏更多列：同一行的卡片拉到等高，所有边缘对齐；窄窗口自动回退单列。 */
 .settings-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
@@ -2987,11 +2971,12 @@ html:has(.strip-shell) #root {
       rgba(24, 27, 33, 0.98);
   }
 
-  .widget-shell--transparent .period-control--compact { background: rgba(255, 255, 255, 0.14); }
+  .widget-shell--transparent .widget-agent-list {
+    background: rgba(255, 255, 255, 0.1);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+  }
 
-  .widget-shell--transparent .widget-quota,
-  .widget-shell--transparent .widget-agent-list,
-  .widget-shell--transparent .widget-metric {
+  .widget-shell--transparent .widget-quota {
     background: rgba(255, 255, 255, 0.1);
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
   }
@@ -3000,9 +2985,8 @@ html:has(.strip-shell) #root {
 @media (forced-colors: active) {
   .widget-shell,
   .widget-shell--transparent,
-  .widget-shell .period-control--compact,
-  .widget-shell .widget-quota,
-  .widget-shell .widget-agent-list {
+  .widget-shell .widget-agent-list,
+  .widget-shell .widget-quota {
     color: CanvasText;
     background: Canvas;
     box-shadow: none;
@@ -3417,7 +3401,19 @@ html:has(.strip-shell) #root {
 :root[data-theme="dark"] .empty-section p { color: var(--d-muted); }
 :root[data-theme="dark"] .empty-section button { color: #fff; background: #3a63c9; }
 
-/* --- 展开窗口自绘按钮条（仅 Windows；macOS 完整视图用原生标题栏） --- */
+/* --- 展开窗口自绘按钮条与刷新按钮（仅 Windows；macOS 完整视图用原生标题栏） --- */
+:root[data-theme="dark"] .expanded-refresh {
+  color: var(--d-muted);
+  background: rgba(30, 32, 36, 0.72);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.07),
+    0 4px 14px rgba(0, 0, 0, 0.35);
+}
+:root[data-theme="dark"] .expanded-refresh:hover {
+  color: var(--d-strong);
+  background: rgba(30, 32, 36, 0.9);
+}
+:root[data-theme="dark"] .expanded-refresh:disabled:hover { color: var(--d-muted); }
 :root[data-theme="dark"] .window-actions--expanded {
   background: rgba(30, 32, 36, 0.72);
   box-shadow:

--- a/src/usageClient.js
+++ b/src/usageClient.js
@@ -57,7 +57,7 @@ function demoSeries(period) {
   });
 }
 
-function demoQuotaView(remainingPercent, resetsInMinutes) {
+function demoQuotaView(remainingPercent, resetsInMinutes, overrides = {}) {
   return {
     available: true,
     remainingPercent,
@@ -67,6 +67,7 @@ function demoQuotaView(remainingPercent, resetsInMinutes) {
     resetExpired: false,
     sourceLabel: "演示配额",
     quality: "demo",
+    ...overrides,
   };
 }
 
@@ -107,18 +108,34 @@ function demoSnapshot(period = "today") {
       {
         agent: "codex",
         windows: [
-          { key: "primary", label: "Session", view: demoQuotaView(72, 198) },
-          { key: "secondary", label: "每周", view: demoQuotaView(86, 8_940) },
+          { key: "five_hour", label: "Session", view: demoQuotaView(72, 198) },
+          { key: "seven_day", label: "每周", view: demoQuotaView(86, 8_940) },
         ],
       },
       {
         agent: "claude",
         windows: [
           { key: "five_hour", label: "Session", view: demoQuotaView(94, 102) },
-          { key: "seven_day", label: "每周 · 全模型", view: demoQuotaView(67, 6_180) },
-          { key: "seven_day_fable", label: "每周 · Fable", view: demoQuotaView(52, 6_180) },
+          // 故意做一扇陈旧窗口，让浏览器预览能走到 stale 标注路径。
+          { key: "seven_day", label: "每周 · 全模型", view: demoQuotaView(67, 6_180, { ageMinutes: 23, stale: true }) },
         ],
       },
+      {
+        agent: "zcode",
+        windows: [
+          { key: "five_hour", label: "Session", view: demoQuotaView(58, 241) },
+          { key: "seven_day", label: "每周", view: demoQuotaView(81, 5_760) },
+        ],
+      },
+      {
+        agent: "kimi",
+        windows: [
+          { key: "five_hour", label: "Session", view: demoQuotaView(90, 130) },
+          { key: "seven_day", label: "每周", view: demoQuotaView(76, 4_320) },
+        ],
+      },
+      // OpenCode 现实中没有官方配额来源：窗口列表保持为空。
+      { agent: "opencode", windows: [] },
     ],
     agents: [
       demoAgentSummary("codex", codexTokens, totalTokens),
@@ -158,7 +175,7 @@ function demoSnapshot(period = "today") {
       { id: "codex-quota", kind: "official", label: "ChatGPT / Codex 官方配额", detail: "通过本机 ChatGPT / Codex 服务读取滚动窗口；不接触登录凭据。", quality: "official", qualityLabel: "官方" },
       { id: "codex-local", kind: "local", label: "ChatGPT / Codex 本地 Token", detail: "由 Codex Agent 会话日志中的累计快照计算正增量，并排除重复记录。", quality: "exact", qualityLabel: "精确解析" },
       { id: "claude-local", kind: "local", label: "Claude Code 本地 Token", detail: "读取消息 usage 字段并以消息标识去重；配额无可靠来源时不推算。", quality: "exact", qualityLabel: "精确解析" },
-      { id: "zcode-local", kind: "local", label: "ZCode / GLM 本地 Token", detail: "读取 model_usage 统计表的逐请求计数；不读取消息内容。", quality: "exact", qualityLabel: "精确解析" },
+      { id: "zcode-local", kind: "local", label: "GLM 本地 Token", detail: "读取 model_usage 统计表的逐请求计数；不读取消息内容。", quality: "exact", qualityLabel: "精确解析" },
       { id: "opencode-local", kind: "local", label: "OpenCode 本地 Token", detail: "读取消息 usage 字段并以消息标识去重；未安装 OpenCode 时保持为 0。", quality: "exact", qualityLabel: "精确解析" },
       { id: "kimi-local", kind: "local", label: "Kimi 本地 Token", detail: "只计单轮增量记录（会话累计记录会重复计数）；未安装 Kimi 时保持为 0。", quality: "exact", qualityLabel: "精确解析" },
       { id: "antigravity-live", kind: "local", label: "Antigravity 用量", detail: "来自本机 language server 实时 RPC；IDE 未运行时为 0，不估算。尚未实机验收。", quality: "exact", qualityLabel: "精确解析" },
@@ -233,14 +250,14 @@ function unavailableSnapshot(period = "today") {
   };
 }
 
-async function loadUsageSnapshot(period = "today") {
+async function loadUsageSnapshot(period = "today", options = {}) {
   if (!isTauriRuntime()) {
     await new Promise((resolve) => setTimeout(resolve, 180));
     return demoSnapshot(period);
   }
 
   try {
-    return await invoke("usage_snapshot", { period });
+    return await invoke("usage_snapshot", { period, force: !!options.force });
   } catch (error) {
     console.warn("Unable to load live usage.", error);
     return unavailableSnapshot(period);

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -8,15 +8,26 @@ const WINDOW_SIZES = {
   strip: { width: 240, height: 40, minWidth: 48, minHeight: 40 },
 };
 
-// 卡片/胶囊的整体缩放档位（1 / 1.25 / 1.5）。窗口尺寸与页面 zoom 同乘一个系数，
-// 比例不变所以不会变形；expanded 不参与（窗口本身可自由缩放）。
+// 卡片/胶囊的整体缩放系数（连续值）。窗口尺寸与页面 zoom 同乘一个系数，
+// 比例不变所以不会变形；完整视图窗口本身可自由拖拽，不参与缩放（zoom 恒为 1）。
 const UI_SCALE_KEY = "metrik:uiScale";
-const UI_SCALE_STEPS = [1, 1.25, 1.5];
+const UI_SCALE_RANGE = { min: 0.75, max: 2 };
+
+function normalizeScale(value, range) {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return 1;
+  return Math.min(range.max, Math.max(range.min, parsed));
+}
+
+/// 连续缩放系数：parseFloat 后钳进范围，NaN/非数回退 1。
+/// 旧档位值（1 / 1.25 / 1.5）都在范围内，存量存储自然兼容。
+function normalizeUiScale(value) {
+  return normalizeScale(value, UI_SCALE_RANGE);
+}
 
 function readStoredUiScale() {
   try {
-    const stored = Number(localStorage.getItem(UI_SCALE_KEY));
-    return UI_SCALE_STEPS.includes(stored) ? stored : 1;
+    return normalizeUiScale(localStorage.getItem(UI_SCALE_KEY));
   } catch {
     return 1;
   }
@@ -24,8 +35,47 @@ function readStoredUiScale() {
 
 let uiScale = readStoredUiScale();
 
+/// 设置卡片/胶囊缩放系数（任意浮点，钳到 0.75–2.0）并持久化；
+/// 下次进入卡片/胶囊时应用，返回实际生效值（调用方用它回填 UI 状态）。
 function setWindowUiScale(scale) {
-  uiScale = UI_SCALE_STEPS.includes(scale) ? scale : 1;
+  uiScale = normalizeUiScale(scale);
+  try {
+    localStorage.setItem(UI_SCALE_KEY, String(uiScale));
+  } catch {}
+  return uiScale;
+}
+
+/// 窗口层当前实际使用的卡片/胶囊缩放系数（模块加载时已从存储归一化）。
+function readUiScale() {
+  return uiScale;
+}
+
+// 胶囊条的独立缩放系数：与小组件互不干扰（用户反馈共用一个比例不合适）。
+const STRIP_SCALE_KEY = "metrik:stripScale";
+
+function readStoredStripScale() {
+  try {
+    return normalizeUiScale(localStorage.getItem(STRIP_SCALE_KEY));
+  } catch {
+    return 1;
+  }
+}
+
+let stripScale = readStoredStripScale();
+
+/// 设置胶囊条缩放系数（钳到 0.75–2.0）并持久化；返回实际生效值。
+/// 生效在形态切换里（进入胶囊条时应用），这里只管存储。
+function setStripScale(scale) {
+  stripScale = normalizeUiScale(scale);
+  try {
+    localStorage.setItem(STRIP_SCALE_KEY, String(stripScale));
+  } catch {}
+  return stripScale;
+}
+
+/// 窗口层当前实际使用的胶囊条缩放系数。
+function readStripScale() {
+  return stripScale;
 }
 
 // 各形态最近一次由内容测量收敛出的窗口尺寸（CSS px，跨会话持久化）。
@@ -83,13 +133,14 @@ function rememberCompactHeight(height) {
   } catch {}
 }
 
-/// compact/strip 的窗口尺寸：乘缩放档位后取整到物理像素再下发，
+/// compact/strip 的窗口尺寸：乘各自缩放系数后取整到物理像素再下发，
 /// 避免分数 DPI（125%/150%）下逻辑尺寸取整产生的半像素裁切。
-async function scaledPhysicalSize(api, appWindow, width, height) {
+/// 小组件用 uiScale（默认参数），胶囊条传自己的 stripScale。
+async function scaledPhysicalSize(api, appWindow, width, height, scale = uiScale) {
   const factor = await appWindow.scaleFactor().catch(() => 1);
   return new api.PhysicalSize(
-    Math.round(width * uiScale * factor),
-    Math.round(height * uiScale * factor),
+    Math.round(width * scale * factor),
+    Math.round(height * scale * factor),
   );
 }
 
@@ -104,7 +155,7 @@ async function applyWebviewZoom(factor) {
     .catch(() => {});
 }
 
-/// 启动时就地应用缩放档位（不走 applyWindowMode 的 hide/show，避免闪烁）。
+/// 启动时就地应用缩放系数（不走 applyWindowMode 的 hide/show，避免闪烁）。
 /// strip 的启动尺寸由 strip 专属 effect 走 applyWindowMode，这里只管 compact。
 async function applyStartupUiScale(mode) {
   if (isMacPlatform()) return;
@@ -390,7 +441,8 @@ async function applyWindowMode(mode, options = {}) {
     // 无边框窗口的任务栏按钮由 WS_EX_APPWINDOW 决定，setSkipTaskbar 补不上它，
     // 所以走后端改窗口样式；样式必须在隐藏状态下改，重新显示后 shell 才重读。
     await appWindow.hide().catch(() => {});
-    // 缩放档位只作用卡片/胶囊，完整视图恢复 1:1；藏起来再改，避免闪缩放跳变。
+    // 卡片/胶囊的缩放系数不进完整视图；完整视图窗口本身可自由拖拽，
+    // 不需要内容缩放（zoom 恒为 1）。藏起来再改，避免闪缩放跳变。
     await applyWebviewZoom(1);
     await appWindow.setSkipTaskbar(false).catch(() => {});
     await invoke("set_taskbar_button", { visible: true }).catch(() => {});
@@ -415,8 +467,8 @@ async function applyWindowMode(mode, options = {}) {
     await appWindow.unmaximize();
   }
   await appWindow.hide().catch(() => {});
-  // 卡片/胶囊按用户的缩放档位显示；藏起来再改，避免闪缩放跳变。
-  await applyWebviewZoom(uiScale);
+  // 卡片与胶囊各有独立缩放系数，互不干扰；藏起来再改，避免闪缩放跳变。
+  await applyWebviewZoom(mode === "strip" ? stripScale : uiScale);
   await appWindow.setSkipTaskbar(true).catch(() => {});
   await invoke("set_taskbar_button", { visible: false }).catch(() => {});
   await appWindow.setMinSize(null);
@@ -425,7 +477,7 @@ async function applyWindowMode(mode, options = {}) {
   if (mode === "strip") {
     const width = Math.max(size.minWidth, Math.round(options.width || size.width));
     const height = Math.max(size.minHeight, Math.round(options.height || size.height));
-    await appWindow.setSize(await scaledPhysicalSize(api, appWindow, width, height));
+    await appWindow.setSize(await scaledPhysicalSize(api, appWindow, width, height, stripScale));
     await appWindow.setResizable(false);
     // 有记忆位置回记忆位置；首次进入保持当前位置（出现在卡片原地）。
     const storedStrip = readStoredPosition("strip");
@@ -456,7 +508,7 @@ async function applyWindowMode(mode, options = {}) {
     lastPositions.compact || (stored ? new api.PhysicalPosition(stored.x, stored.y) : null);
   if (target) {
     await appWindow.setPosition(target).catch(() => appWindow.center());
-    // 缩放档位调大后，记忆位置 + 新尺寸可能伸出屏幕，钳回工作区。
+    // 缩放系数调大后，记忆位置 + 新尺寸可能伸出屏幕，钳回工作区。
     await clampIntoWorkArea(api, appWindow);
   } else {
     await appWindow.center();
@@ -494,7 +546,7 @@ async function resizeStripWindow({ width, height }) {
     anchor.right = Math.abs(pos.x + outer.width - workRight) <= 8;
     anchor.bottom = Math.abs(pos.y + outer.height - workBottom) <= 8;
   }
-  const physical = await scaledPhysicalSize(api, appWindow, targetWidth, targetHeight);
+  const physical = await scaledPhysicalSize(api, appWindow, targetWidth, targetHeight, stripScale);
   await appWindow.setSize(physical).catch(() => {});
   // 测量收敛出的尺寸记作下次变形的首帧（否则首帧永远是常量估计）。
   rememberStripSize(targetWidth, targetHeight);
@@ -542,7 +594,7 @@ async function resizeCompactWindow({ height }) {
   if (!clamped) await appWindow.center().catch(() => {});
 }
 
-/// DPI 变化（拖到另一台显示器、系统改缩放）后按当前缩放档位重算 compact
+/// DPI 变化（拖到另一台显示器、系统改缩放）后按当前缩放系数重算 compact
 /// 物理尺寸：zoom 不变、不 hide/show，只把视口校正回 320 CSS px。
 /// 否则 zoom 与物理尺寸失配时视口缩成 ~256px，320 的最小内容宽度被裁。
 async function reassertCompactSize() {
@@ -849,6 +901,7 @@ async function closeWindow() {
 }
 
 export {
+  UI_SCALE_RANGE,
   WINDOW_SIZES,
   applyStartupUiScale,
   applyWindowMode,
@@ -859,9 +912,12 @@ export {
   isDesktop,
   isMacPlatform,
   minimizeWindow,
+  normalizeUiScale,
   onScaleFactorChanged,
   onTrayShowExpanded,
   openExpandedWindow,
+  readStripScale,
+  readUiScale,
   reassertCompactSize,
   resizeCompactWindow,
   resizeMacosPanel,
@@ -870,6 +926,7 @@ export {
   setAutostart,
   setNativeTheme,
   updateMacStatusItems,
+  setStripScale,
   setWindowGlass,
   setWindowPinned,
   setWindowUiScale,


### PR DESCRIPTION
**Scope: `shared` + `Windows shell`**

## 改了什么（3 个 commit)

**小卡片（两 shell 共用 UI)**
- 内容从本地 token 汇总改为**各家官方额度**:5h/周剩余百分比 + 重置倒计时；版式保持原双块设计（焦点 Agent 大剩余 % + 该家窗口明细卡）+ 单行 Agent 列表。token 统计留在完整视图
- 缺失/陈旧/过期的额度照旧显式标注（`--`、`~`、已重置等待刷新），不编造；无周期 tab、无轮播点击
- 行图标统一 36px 全尺寸 + ZCode/Kimi 图标透明边距补偿；名称/百分比字号放大

**胶囊条（Windows shell)**
- 每格**优先 5 小时窗口**，没有才回落到后端排序的第一个可用窗口（同一逻辑也喂给 macOS 菜单栏状态项，语义一致）
- **独立缩放系数** `metrik:stripScale`，与小组件 `metrik:uiScale` 解耦（均为 0.75–2.0 连续值，设置页滑杆，下次进入生效）；完整视图缩放设置移除（窗口可拖拽，zoom 恒 1)
- 收紧壳/格内边距，控件 22px → 26px

**共享后端**
- `usage_snapshot` 新增 `force` 参数：小卡片/完整视图的手动刷新按钮经它**绕过额度 TTL 缓存**真抓；失败仍保留旧行并标 stale，绝不清空
- **Kimi K3 按官方价计价**($3/$0.30/$15 每 M,2026-07-18 官方定价页核对）:LiteLLM 未收录，放 `MANUAL_PRICING` 手动补充；订阅用量 `kimi-code/k3` 经窄别名按同一官方价**估算**(Kimi 官方称 Extra Usage 接近 API 价），其余订阅 ID 继续 unpriced
- ZCode / GLM 展示名统一为 **GLM**（前端 + 来源标签 + macOS 状态项；agent id 不变）

**其他**
- 设置页去掉 1000px 限宽，与其他页面统一铺满（宽屏 3–4 列，窄屏单列）

## Windows 侧验证

- `cargo test` 116/116、`npm run build`、`npm test` 3/3 ✅
- 自研 CDP 真机断言（`output/playwright/zoom_leak_test.py`,11 项）：两套缩放系数完全隔离，拖小组件滑杆/胶囊条滑杆互不影响，完整视图 zoom 恒 1 ✅
- 形态切换回归 6 项（compact ↔ strip ↔ expanded 无 hooks 崩溃）✅；竖条/浅色/深色/设置页截图核对 ✅

## macOS 侧影响与待办（需在 Mac 上验收）

- 小卡片是同一份 `CompactWidget`,**菜单栏面板需在 macOS 上做视觉验收**（双块 + 单行列表 + 新字号；mac 浅色 vibrancy 覆盖已同步补齐）
- 菜单栏状态项百分比现在与胶囊条同源（5h 优先回落），与既定语法一致；GLM 状态项名称已改
- 快照/设置/存储契约**零变化**；expandedScale 移除后 mac 独立窗口的既有启动缺口随之消失
- AGENTS.md 决策记录已同步更新

## 发版协议

特性分支**不带版本号改动**(bump late)；合并走保护路径，双平台矩阵绿后再发版。