### PR TITLE
Release 0.8.0: quota-first widget, per-form scales, Kimi K3 pricing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.7.0"
+version = "0.8.0"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
**Scope: release（版本提交只含 5 个版本文件）**

合并后即按发版协议从合并提交打 v0.8.0 标签并立即推送，tag 触发 release 工作流构建双平台资产与更新包（latest.json）。

- Windows 侧：#11 全部内容已在真机/CDP 断言下验收（116 项 cargo 测试、11 项缩放断言、6 项形态切换）
- macOS 侧：面板视觉验收待 Mac 实机进行（Release 说明需标明，沿用 0.7.0 的声明口径）
- v0.8.0 标签不存在于当前历史（未烧号）