### PR TITLE
Align ranking bars across rows; label synced tokens as synced

### DIFF
--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -969,15 +969,16 @@ fn period_bucket_count(period: &str, current_hour: u32) -> usize {
 
 fn load_events(connection: &Connection, start_ms: i64, end_ms: i64) -> Result<Vec<StoredEvent>> {
     // 远端同步事件只带处理量总数，不带模型或分量拆解（见架构约束：同步导出
-    // 只含派生统计字段）；用 NULL/0 补齐列，让这些事件归入 "unknown" 模型、
-    // 分量记 0，而不是被丢弃。
+    // 只含派生统计字段）；模型列给哨兵值 "synced-remote"、分量记 0，让这些
+    // 事件在模型聚合里单列成"其他设备同步（无模型名）"，与本地确实缺模型名
+    // 的 "unknown" 区分开，而不是混在一起被误读成一个叫"未标注"的模型。
     let mut statement = connection.prepare(
         "SELECT adapter_id, occurred_at_ms, processed_tokens, model,
                 input_uncached_tokens, cache_read_tokens, cache_write_tokens, output_tokens
          FROM usage_event
          WHERE occurred_at_ms >= ?1 AND occurred_at_ms < ?2
          UNION ALL
-         SELECT adapter_id, occurred_at_ms, processed_tokens, NULL AS model,
+         SELECT adapter_id, occurred_at_ms, processed_tokens, 'synced-remote' AS model,
                 0, 0, 0, 0
          FROM remote_usage_event
          WHERE occurred_at_ms >= ?1 AND occurred_at_ms < ?2

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -300,6 +300,15 @@ function shortWindowLabel(key) {
   return key.replace(/^seven_day_/, "").slice(0, 4);
 }
 
+// 模型名展示：本地确实缺模型名的记 "unknown"（未标注模型）；
+// "synced-remote" 是同步事件（导出本就不含模型名，见 sync 架构约束），
+// 不是某个叫这个名字的模型，必须说人话。
+function modelDisplayName(model) {
+  if (model === "synced-remote") return "其他设备同步（无模型名）";
+  if (model === "unknown") return "未标注模型";
+  return model;
+}
+
 // 小插件每行 Agent 最多展示两个配额窗口：按来源排序取前两个可用窗口
 // （已过期窗口也算有来源，单独走"已重置，等待刷新"样式）；一个都没有时
 // 由调用方渲染 "-- / 暂无可靠来源"，绝不编造数字。
@@ -636,7 +645,7 @@ function BreakdownSection({ snapshot, selectedAgent }) {
                   aria-hidden="true"
                   title={AGENT_META[entry.agent]?.label || entry.agent}
                 />
-                <span className="model-name">{entry.model === "unknown" ? "未标注模型" : entry.model}</span>
+                <span className="model-name">{modelDisplayName(entry.model)}</span>
                 <span className="model-track" aria-hidden="true">
                   <i style={{ transform: `scaleX(${entry.tokens / modelMax})`, backgroundColor: AGENT_META[entry.agent]?.accent || "#74767a" }} />
                 </span>
@@ -2773,7 +2782,7 @@ function ReportsSection({ report }) {
               return (
                 <li key={`${entry.agent}-${entry.model}`}>
                   <i className="model-dot" style={{ backgroundColor: AGENT_META[entry.agent]?.accent || "#74767a" }} aria-hidden="true" />
-                  <span className="model-name">{entry.model === "unknown" ? "未标注模型" : entry.model}</span>
+                  <span className="model-name">{modelDisplayName(entry.model)}</span>
                   <span className="model-track" aria-hidden="true">
                     <i style={{ transform: `scaleX(${entry.tokens / max})`, backgroundColor: AGENT_META[entry.agent]?.accent || "#74767a" }} />
                   </span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1606,17 +1606,22 @@ html:has(.strip-shell) #root {
 
 .comp-legend em,
 .model-list em {
+  overflow: hidden;
   color: #74767a;
   font-size: 11px;
   font-style: normal;
   font-variant-numeric: tabular-nums;
   text-align: right;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .model-list li {
   display: grid;
-  grid-template-columns: 8px minmax(0, 1fr) 64px auto;
+  /* 数值列定宽：各行 1fr 名称列因此同宽，进度条轨道在所有行严格对齐。
+     （曾经 auto 宽随数值文本变化——"441B · 31 天" 与 "311M · 3 天" 列宽
+     不同，小数值行的轨道整体左移，肉眼可见没对齐。） */
+  grid-template-columns: 8px minmax(0, 1fr) 64px 92px;
   align-items: center;
   gap: 9px;
   font-size: 12px;


### PR DESCRIPTION
**Scope: `shared`**

- 排行条目（报告页 Agent/模型排行 + 概览模型分布）的数值列原来是 auto 宽，每行独立网格使 1fr 名称列宽随数值文本变化，64px 进度条轨道起点逐行漂移（用户截图红框处）。数值列定宽 92px 后全行轨道严格对齐（复现脚本测量：修复前 356.9/360.7 两个起点，修复后统一 295.0）
- 远端同步事件按设计不含模型名（导出只含事件标识/Agent/时间/token 数），原来落入 "unknown" 桶渲染成 "未标注模型"，用户看不懂。load_events 的 UNION 改打 'synced-remote' 哨兵，前端渲染为"其他设备同步（无模型名）"；本地真缺模型名的记录仍显示"未标注模型"，语义分开

验证：cargo test 118/118 ✅、npm build ✅、条形几何复现脚本对比 ✅