### PR TITLE
Release 0.9.0: bump version in all 5 manifest files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.8.0"
+version = "0.9.0"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Scope: **release** (shared, no platform code changes).

Bumps the version from `0.8.0` → `0.9.0` in all five manifest files so they stay in agreement, as required by AGENTS.md's release protocol:

- `package.json`
- `package-lock.json` (top-level and `packages[""]`)
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock`

The actual 0.9.0 content (WorkBuddy and Qoder agents, GLM-5.2/GLM-5-Turbo pricing, taskbar-registered expanded window, widget token headline restored, OpenCode/Antigravity real-machine fixes) landed in main via #14. This PR only carries the version bump.

The tag `v0.9.0` already points at this commit and the Release workflow is building the Windows and macOS assets against it. This PR brings the `main` branch ref to the same commit so the release lands on main per the protocol ("push it the moment the release commit lands on main"). `main` is branch-protected and declined the direct push, so this PR is the legitimate path in.