### PR TITLE
Fix WorkBuddy token accounting; add a title-bar theme toggle; split settings into tabs

### DIFF
--- a/docs/MACOS-HANDOFF.md
+++ b/docs/MACOS-HANDOFF.md
@@ -67,6 +67,29 @@ aws-lc-rs，`cargo check` 会立刻报出来。
 明文落在那个 `.info` 里，我们自动读、仅在内存中用于一次请求，不入库、不写日志、
 错误信息里不带 token。
 
+#### WorkBuddy 的 token 用量：只有 CLI 有，桌面版没有
+
+adapter 扫的是 **CLI** 的转录 `~/.codebuddy/projects`、`~/.workbuddy/projects`
+下的 JSONL。**桌面版（Electron）不写这些 JSONL**，Windows 真机确认：装了桌面版
+并跑过会话后，两个目录都不存在，用量只落在 `~/.workbuddy/workbuddy.db` 的
+`session_usage` 表里，形如
+
+```
+session_id | used=82275 | size=168000 | credit_json={"<req-id>":3.47, ...}
+```
+
+`size` 恰好是上下文窗口大小，所以 `used` **很可能是当前上下文占用量而非累计
+处理量**——若当累计量记进账本，会漏掉输出 token 与跨轮缓存读，且上下文压缩后
+还会倒退。这就是这张表至今没有接入的原因（见 `workbuddy.rs` 的 `coverage_gaps`，
+它会如实上报"旧版数据库暂不支持读取"）。判定实验：在同一会话里持续追加对话，
+看 `used` 是否突破 `size`——突破则为累计量可接，回落则为上下文占用不可接。
+
+`credit_json` 是本地记录的待结算 Credits（实测与官方配额接口有延迟，接口那边
+可能还显示已用 0），属于计费口径不是 token 口径，不要混进 token 统计。
+
+结论：**mac 上若只装桌面版，WorkBuddy 显示 0 token 是正确行为**，不是 bug；
+配额卡仍应正常显示。要有 token 统计需装 CodeBuddy Code CLI。
+
 ### 2. Antigravity 进程发现
 
 Antigravity 在 Windows 上一共踩了三个坑，其中**两个是 shared、mac 直接受益**，

--- a/docs/MACOS-HANDOFF.md
+++ b/docs/MACOS-HANDOFF.md
@@ -67,28 +67,44 @@ aws-lc-rs，`cargo check` 会立刻报出来。
 明文落在那个 `.info` 里，我们自动读、仅在内存中用于一次请求，不入库、不写日志、
 错误信息里不带 token。
 
-#### WorkBuddy 的 token 用量：只有 CLI 有，桌面版没有
+#### WorkBuddy 的转录目录被桌面版改到了 `~/.workbuddy`
 
-adapter 扫的是 **CLI** 的转录 `~/.codebuddy/projects`、`~/.workbuddy/projects`
-下的 JSONL。**桌面版（Electron）不写这些 JSONL**，Windows 真机确认：装了桌面版
-并跑过会话后，两个目录都不存在，用量只落在 `~/.workbuddy/workbuddy.db` 的
-`session_usage` 表里，形如
+桌面版（Electron）内置 CLI，启动时把 CLI 的 home 重定向：
 
-```
-session_id | used=82275 | size=168000 | credit_json={"<req-id>":3.47, ...}
+```js
+process.env.CODEBUDDY_CONFIG_DIR = getWorkbuddyConfigDir();  // → ~/.workbuddy
+// CLI 侧：读 CODEBUDDY_CONFIG_DIR，为空才回退 ~/.codebuddy
 ```
 
-`size` 恰好是上下文窗口大小，所以 `used` **很可能是当前上下文占用量而非累计
-处理量**——若当累计量记进账本，会漏掉输出 token 与跨轮缓存读，且上下文压缩后
-还会倒退。这就是这张表至今没有接入的原因（见 `workbuddy.rs` 的 `coverage_gaps`，
-它会如实上报"旧版数据库暂不支持读取"）。判定实验：在同一会话里持续追加对话，
-看 `used` 是否突破 `size`——突破则为累计量可接，回落则为上下文占用不可接。
+所以转录落在 **`~/.workbuddy/projects/<项目>/<sessionId>.jsonl`**，官方 CLI 文档
+（`cli/dist/web-ui/docs/cn/cli/daemon.md`）也确认 transcript 是"始终"写的。
+adapter 两个根都扫，mac 上应当同样成立——**除非 mac 版把 configDir 指到了
+`~/Library/...`**，这是 mac 上唯一需要复核的点：跑一次会话后确认
+`~/.workbuddy/projects/` 下出现 JSONL 即可。
 
-`credit_json` 是本地记录的待结算 Credits（实测与官方配额接口有延迟，接口那边
-可能还显示已用 0），属于计费口径不是 token 口径，不要混进 token 统计。
+`workbuddy.db` 的 `session_usage` 表**不是用量来源**，别去接：其 `size` 是模型
+上下文窗口、`used` 是当前上下文占用（桌面版源码里该组件叫 `ContextUsageDisplay`，
+设计文档 `acp-session-usage-context-ring.md`）。`credit_json` 是本地待结算
+Credits，与官方配额接口有延迟，属计费口径不是 token 口径。两者都不能混进统计。
 
-结论：**mac 上若只装桌面版，WorkBuddy 显示 0 token 是正确行为**，不是 bug；
-配额卡仍应正常显示。要有 token 统计需装 CodeBuddy Code CLI。
+#### token 口径：`input_tokens` 含缓存（与 Anthropic 相反）
+
+真机转录实测（16/16 行成立）：
+
+```
+total_tokens == input_tokens + output_tokens
+cache_read_input_tokens ⊂ input_tokens
+```
+
+即**所有** input 别名（蛇形 `input_tokens`、驼峰 `inputTokens`、`prompt_tokens`）
+都是含缓存的 prompt 总量，未缓存部分 = input − cache_read。这与 Anthropic 同名
+字段的语义相反，早先按 Anthropic 风格处理会把缓存读重复计一遍。
+
+另一条：`function_call` 行带 usage 但 **status 恒为 null**（16 条带 usage 的行里
+13 条是 function_call），只认 `status == "completed"` 会漏掉 81% 的用量。status
+只对 `message` 有约束（生成中先落一行、完成后重写）。
+
+两条都有真机形状的测试锁住，改动前先看测试。
 
 ### 2. Antigravity 进程发现
 

--- a/src-tauri/src/adapters/workbuddy.rs
+++ b/src-tauri/src/adapters/workbuddy.rs
@@ -118,18 +118,25 @@ impl BuddyUsage {
             self.prompt_cache_hit_tokens,
             self.cached_tokens,
         ]);
-        // 未缓存输入按别名语义分别处理（真实夹具核实 64700+76032=140732，
-        // 驼峰 inputTokens 确为含缓存总量）：
-        // - cachedMissTokens：本就是未缓存量，直接用；
-        // - 蛇形 input_tokens：Anthropic 风格，不含缓存，原样用；
-        // - 驼峰 inputTokens / OpenAI 风格 prompt_tokens：含缓存总量，扣缓存读。
+        // 未缓存输入：
+        // - `cachedMissTokens` 本就是未缓存量，存在时直接用；
+        // - 其余别名（蛇形 input_tokens、驼峰 inputTokens、prompt_tokens）**都是
+        //   含缓存的 prompt 总量**，要扣掉 cache_read 才是未缓存部分。
+        //
+        // 蛇形这条与 Anthropic 的同名字段语义相反，是真机实测定的：CodeBuddy CLI
+        // 转录里 `total_tokens == input_tokens + output_tokens` 恒成立（16/16 行），
+        // 而 cache_read_input_tokens 不进这个等式——它是 input_tokens 的子集。
+        // 早先按 Anthropic 风格当作"不含缓存"会把缓存读重复计一遍。
         let input_uncached = if let Some(miss) = self.cached_miss_tokens.or(self.cache_miss_tokens)
         {
             miss.max(0)
-        } else if let Some(exclusive) = self.input_tokens {
-            exclusive.max(0)
         } else {
-            (first_positive(&[self.input_tokens_camel, self.prompt_tokens]) - cache_read).max(0)
+            (first_positive(&[
+                self.input_tokens,
+                self.input_tokens_camel,
+                self.prompt_tokens,
+            ]) - cache_read)
+                .max(0)
         };
         let output = first_positive(&[
             self.output_tokens,
@@ -231,13 +238,21 @@ impl AgentAdapter for WorkbuddyAdapter {
                 }
                 continue;
             };
-            // 只计已完成的 assistant 回复与工具调用；进行中的行会在完成后重写。
+            // assistant 回复与工具调用都带 usage，都要计。
+            //
+            // status 只对 `message` 有约束：它在生成中会先落一行、完成后重写，
+            // 未完成的不计。`function_call` 的 status 恒为 null（真机实测：16 条
+            // 带 usage 的行里 13 条是 function_call、status 全空），对它要求
+            // "completed" 会漏掉 81% 的用量。
             let countable = match record.record_type.as_deref() {
-                Some("message") => record.role.as_deref() == Some("assistant"),
+                Some("message") => {
+                    record.role.as_deref() == Some("assistant")
+                        && record.status.as_deref() == Some("completed")
+                }
                 Some("function_call") => true,
                 _ => false,
             };
-            if !countable || record.status.as_deref() != Some("completed") {
+            if !countable {
                 continue;
             }
             let Some(timestamp) = record.timestamp.filter(|value| *value > 0) else {
@@ -372,11 +387,38 @@ mod tests {
         let event = &parsed.source.events[0];
         assert_eq!(event.event_key, "message:msg-1");
         assert_eq!(event.model.as_deref(), Some("glm-5.2"));
-        // 蛇形 input_tokens 是 Anthropic 风格：不含缓存，原样计入。
-        assert_eq!(event.tokens.input_uncached, 24486);
+        // 蛇形 input_tokens 同样含缓存：未缓存部分 = input - cache_read。
+        assert_eq!(event.tokens.input_uncached, 24486 - 14720);
         assert_eq!(event.tokens.cache_read, 14720);
         assert_eq!(event.tokens.output, 3);
-        assert_eq!(event.tokens.processed(), 24486 + 14720 + 3);
+        // processed 与来源的 total_tokens 口径一致（input 已含 cache_read）。
+        assert_eq!(event.tokens.processed(), 24486 + 3);
+    }
+
+    /// 真机转录行（本机 WorkBuddy 桌面版实测，2026-07-21）：
+    /// `total_tokens == input_tokens + output_tokens` 恒成立，cache_read 是
+    /// input_tokens 的子集；function_call 带 usage 但 status 为空。
+    #[test]
+    fn real_desktop_transcript_rows_are_counted_with_total_matching() {
+        let lines = vec![
+            r#"{"id":"a-1","timestamp":1784603600000,"type":"message","role":"assistant","status":"completed","sessionId":"d180683e","providerData":{"messageId":"65a92f2e6275"},"message":{"usage":{"input_tokens":32514,"output_tokens":855,"total_tokens":33369,"cache_read_input_tokens":19008}}}"#.to_string(),
+            // function_call 的 status 是 null——必须照计，否则漏掉大部分用量。
+            r#"{"id":"f-1","timestamp":1784603601000,"type":"function_call","sessionId":"d180683e","providerData":{"messageId":"4a0fe9346f49"},"message":{"usage":{"input_tokens":33785,"output_tokens":372,"total_tokens":34157,"cache_read_input_tokens":32512}}}"#.to_string(),
+        ];
+        let parsed = parse_lines("real-desktop", &lines);
+        assert_eq!(parsed.source.events.len(), 2, "function_call 也要计入");
+        for (event, (input, output, cache)) in parsed
+            .source
+            .events
+            .iter()
+            .zip([(32514, 855, 19008), (33785, 372, 32512)])
+        {
+            assert_eq!(event.tokens.cache_read, cache);
+            assert_eq!(event.tokens.input_uncached, input - cache);
+            assert_eq!(event.tokens.output, output);
+            // 与来源自报的 total_tokens 对齐，不重复计缓存读。
+            assert_eq!(event.tokens.processed(), input + output);
+        }
     }
 
     /// 驼峰 inputTokens 含缓存但缺 cachedMissTokens 时：扣缓存读，不重复计入。

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,8 @@ import {
   ChartLineUp,
   Check,
   CircleHalfTilt,
+  Moon,
+  Sun,
   Copy,
   CornersOut,
   ClockCounterClockwise,
@@ -801,7 +803,76 @@ function runWindowAction(action) {
   });
 }
 
-function WindowActions({ mode, pinned, transparent = false, macMinimal = false, onToggleMode, onTogglePinned, onToggleTransparent }) {
+/// 标题栏的主题快捷键：单击在亮/暗之间切换，右键（或长按）弹出含「自动」的
+/// 三选菜单——单击不进「自动」是刻意的：一次点击只该有一个确定结果，
+/// 而「自动」的结果取决于系统当前是什么。
+function ThemeQuickToggle({ theme, darkTheme, onThemeChange }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const wrapRef = useRef(null);
+
+  useEffect(() => {
+    if (!menuOpen) return undefined;
+    const dismiss = (event) => {
+      if (!wrapRef.current?.contains(event.target)) setMenuOpen(false);
+    };
+    const onEscape = (event) => {
+      if (event.key === "Escape") setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", dismiss);
+    document.addEventListener("keydown", onEscape);
+    return () => {
+      document.removeEventListener("mousedown", dismiss);
+      document.removeEventListener("keydown", onEscape);
+    };
+  }, [menuOpen]);
+
+  const label = theme === "auto" ? "自动（跟随系统）" : theme === "dark" ? "暗色" : "亮色";
+  return (
+    <div className="theme-quick" ref={wrapRef}>
+      <button
+        type="button"
+        className={`window-action ${menuOpen ? "window-action--active" : ""}`}
+        onClick={() => onThemeChange(darkTheme ? "light" : "dark")}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          setMenuOpen((open) => !open);
+        }}
+        aria-label={`切换明暗，当前${label}`}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        title={`当前：${label}\n单击切换明暗 · 右键选择模式`}
+      >
+        {darkTheme ? (
+          <Moon size={16} weight="light" aria-hidden="true" />
+        ) : (
+          <Sun size={16} weight="light" aria-hidden="true" />
+        )}
+      </button>
+      {menuOpen && (
+        <div className="theme-quick-menu" role="menu">
+          {THEME_OPTIONS.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              role="menuitemradio"
+              aria-checked={theme === option.id}
+              className={theme === option.id ? "is-selected" : ""}
+              onClick={() => {
+                onThemeChange(option.id);
+                setMenuOpen(false);
+              }}
+            >
+              {option.label}
+              {theme === option.id && <Check size={13} weight="bold" aria-hidden="true" />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WindowActions({ mode, pinned, transparent = false, macMinimal = false, theme, darkTheme, onThemeChange, onToggleMode, onTogglePinned, onToggleTransparent }) {
   return (
     <div className={`window-actions window-actions--${mode}`} aria-label="窗口操作">
       {mode === "expanded" && (
@@ -824,6 +895,7 @@ function WindowActions({ mode, pinned, transparent = false, macMinimal = false, 
           >
             <ArrowsInLineVertical size={16} weight="light" aria-hidden="true" />
           </button>
+          <ThemeQuickToggle theme={theme} darkTheme={darkTheme} onThemeChange={onThemeChange} />
         </>
       )}
       {mode === "compact" && !macMinimal && (
@@ -3704,6 +3776,9 @@ export function App() {
             <WindowActions
               mode="expanded"
               pinned={pinned}
+              theme={theme}
+              darkTheme={darkTheme}
+              onThemeChange={handleThemeChange}
               onToggleMode={handleWindowMode}
               onTogglePinned={handleTogglePinned}
             />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2286,6 +2286,29 @@ function QoderQuotaCard({ onSnapshotRefresh }) {
   );
 }
 
+// 设置分三类子页：每页 2 张卡，高度相近。Agent 列表会随支持的 Agent 变多而
+// 变高，与短卡混排时会把整排撑出大片空白——分页正是为了让它只影响自己那一页。
+const SETTINGS_TABS = [
+  {
+    id: "display",
+    label: "显示",
+    title: "显示与外观",
+    blurb: "选择小组件与胶囊条展示哪些 Agent、以什么顺序，以及完整视图的明暗与各形态的缩放。",
+  },
+  {
+    id: "sources",
+    label: "数据来源",
+    title: "官方额度来源",
+    blurb: "配置各 Agent 的官方配额读取方式。官方额度、本地解析用量与估算成本是三类不同事实，界面上始终分开呈现。",
+  },
+  {
+    id: "sync",
+    label: "同步与更新",
+    title: "多设备同步与更新",
+    blurb: "多台电脑指向同一个共享文件夹即可互相合并统计；导出只含事件标识、Agent、时间与 token 数，不含对话内容或凭据。",
+  },
+];
+
 function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, glassAlpha, onGlassAlpha, uiScale, onUiScale, stripScale, onStripScale, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
   const [settings, setSettings] = useState(null);
   const [directoryInput, setDirectoryInput] = useState("");
@@ -2327,134 +2350,155 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
     }
   };
 
+  const [tab, setTab] = useState("display");
+  const activeTab = SETTINGS_TABS.find((item) => item.id === tab) || SETTINGS_TABS[0];
+
   return (
     <main className="settings-section" aria-labelledby="settings-title">
       <header className="settings-header">
         <span className="section-kicker">设置</span>
-        <h1 id="settings-title">多设备同步</h1>
-        <p>
-          多台电脑指向同一个共享文件夹（坚果云、OneDrive、Syncthing 均可）即可互相合并统计。
-          导出只含事件标识、Agent、时间与 token 数，不含对话内容或凭据。
-        </p>
+        <h1 id="settings-title">{activeTab.title}</h1>
+        <p>{activeTab.blurb}</p>
       </header>
 
-      {settings?.demo && (
+      <div className="settings-tabs" role="tablist" aria-label="设置分类">
+        {SETTINGS_TABS.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={item.id === activeTab.id}
+            className={item.id === activeTab.id ? "is-selected" : ""}
+            onClick={() => setTab(item.id)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      {settings?.demo && activeTab.id === "sync" && (
         <p className="settings-demo-note">浏览器演示模式：同步配置仅在桌面应用中可用。</p>
       )}
 
       <div className="settings-grid">
-      <div className="settings-card">
-        <label htmlFor="sync-directory">同步文件夹（绝对路径）</label>
-        <div className="settings-directory-row">
-          <input
-            id="sync-directory"
-            type="text"
-            value={directoryInput}
-            placeholder="例如 D:\Nutstore\metrik-sync"
-            spellCheck={false}
-            disabled={busy || settings?.demo}
-            onChange={(event) => setDirectoryInput(event.target.value)}
-          />
-          <button
-            type="button"
-            className="ledger-button ledger-button--primary"
-            disabled={busy || settings?.demo || !directoryInput.trim()}
-            onClick={() => applySync(directoryInput.trim())}
-          >
-            {settings?.enabled ? "更新目录" : "开启同步"}
-          </button>
-          {settings?.enabled && (
-            <button
-              type="button"
-              className="ledger-button ledger-button--secondary"
-              disabled={busy || settings?.demo}
-              onClick={() => applySync(null)}
-            >
-              关闭同步
-            </button>
-          )}
-        </div>
-
-        {feedback && (
-          <p
-            className={`settings-feedback settings-feedback--${feedback.tone}`}
-            role={feedback.tone === "error" ? "alert" : "status"}
-          >
-            {feedback.message}
-          </p>
+        {activeTab.id === "display" && (
+          <>
+            <AgentsDisplayCard
+              widgetAgents={widgetAgents}
+              onToggleWidgetAgent={onToggleWidgetAgent}
+              onMoveWidgetAgent={onMoveWidgetAgent}
+              stripAgents={stripAgents}
+              onToggleStripAgent={onToggleStripAgent}
+              onMoveStripAgent={onMoveStripAgent}
+            />
+            <AppearanceCard
+              theme={theme}
+              onThemeChange={onThemeChange}
+              glassAlpha={glassAlpha}
+              onGlassAlpha={onGlassAlpha}
+              uiScale={uiScale}
+              onUiScale={onUiScale}
+              stripScale={stripScale}
+              onStripScale={onStripScale}
+            />
+          </>
         )}
 
-        {settings && !settings.demo && (
-          <dl className="settings-status">
-            <div>
-              <dt>本机设备</dt>
-              <dd>{settings.deviceLabel} · {settings.deviceId}</dd>
-            </div>
-            <div>
-              <dt>上次同步</dt>
-              <dd>{settings.enabled ? formatSyncTime(settings.lastExportMs) : "同步未开启"}</dd>
-            </div>
-            {settings.lastError && (
-              <div>
-                <dt>同步告警</dt>
-                <dd className="settings-error-text">{settings.lastError}</dd>
+        {activeTab.id === "sources" && (
+          <>
+            <ClaudeHookCard onSnapshotRefresh={onSnapshotRefresh} />
+            <QoderQuotaCard onSnapshotRefresh={onSnapshotRefresh} />
+          </>
+        )}
+
+        {activeTab.id === "sync" && (
+          <>
+            <div className="settings-card">
+              <label htmlFor="sync-directory">同步文件夹（绝对路径）</label>
+              <div className="settings-directory-row">
+                <input
+                  id="sync-directory"
+                  type="text"
+                  value={directoryInput}
+                  placeholder="例如 D:\Nutstore\metrik-sync"
+                  spellCheck={false}
+                  disabled={busy || settings?.demo}
+                  onChange={(event) => setDirectoryInput(event.target.value)}
+                />
+                <button
+                  type="button"
+                  className="ledger-button ledger-button--primary"
+                  disabled={busy || settings?.demo || !directoryInput.trim()}
+                  onClick={() => applySync(directoryInput.trim())}
+                >
+                  {settings?.enabled ? "更新目录" : "开启同步"}
+                </button>
+                {settings?.enabled && (
+                  <button
+                    type="button"
+                    className="ledger-button ledger-button--secondary"
+                    disabled={busy || settings?.demo}
+                    onClick={() => applySync(null)}
+                  >
+                    关闭同步
+                  </button>
+                )}
               </div>
-            )}
-          </dl>
+
+              {feedback && (
+                <p
+                  className={`settings-feedback settings-feedback--${feedback.tone}`}
+                  role={feedback.tone === "error" ? "alert" : "status"}
+                >
+                  {feedback.message}
+                </p>
+              )}
+
+              {settings && !settings.demo && (
+                <dl className="settings-status">
+                  <div>
+                    <dt>本机设备</dt>
+                    <dd>{settings.deviceLabel} · {settings.deviceId}</dd>
+                  </div>
+                  <div>
+                    <dt>上次同步</dt>
+                    <dd>{settings.enabled ? formatSyncTime(settings.lastExportMs) : "同步未开启"}</dd>
+                  </div>
+                  {settings.lastError && (
+                    <div>
+                      <dt>同步告警</dt>
+                      <dd className="settings-error-text">{settings.lastError}</dd>
+                    </div>
+                  )}
+                </dl>
+              )}
+
+              {settings?.enabled && (
+                <div className="settings-subsection">
+                  <h3>已发现的设备</h3>
+                  {settings.devices.length === 0 ? (
+                    <p className="settings-muted">尚未发现其他设备的导出文件。另一台电脑指向同一文件夹后会出现在这里。</p>
+                  ) : (
+                    <ul className="settings-device-list">
+                      {settings.devices.map((device) => (
+                        <li key={device.id}>
+                          <strong>{device.label}</strong>
+                          <span>{device.id}</span>
+                          <small>{device.events} 条事件 · 导出于 {formatSyncTime(device.exportedAtMs)}</small>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </div>
+            <StartupCard
+              autoUpdateCheck={autoUpdateCheck}
+              onAutoUpdateCheck={onAutoUpdateCheck}
+              availableUpdate={availableUpdate}
+            />
+          </>
         )}
-
-        {settings?.enabled && (
-          <div className="settings-subsection">
-            <h3>已发现的设备</h3>
-            {settings.devices.length === 0 ? (
-              <p className="settings-muted">尚未发现其他设备的导出文件。另一台电脑指向同一文件夹后会出现在这里。</p>
-            ) : (
-              <ul className="settings-device-list">
-                {settings.devices.map((device) => (
-                  <li key={device.id}>
-                    <strong>{device.label}</strong>
-                    <span>{device.id}</span>
-                    <small>{device.events} 条事件 · 导出于 {formatSyncTime(device.exportedAtMs)}</small>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        )}
-      </div>
-
-      <AgentsDisplayCard
-        widgetAgents={widgetAgents}
-        onToggleWidgetAgent={onToggleWidgetAgent}
-        onMoveWidgetAgent={onMoveWidgetAgent}
-        stripAgents={stripAgents}
-        onToggleStripAgent={onToggleStripAgent}
-        onMoveStripAgent={onMoveStripAgent}
-      />
-
-      <ClaudeHookCard onSnapshotRefresh={onSnapshotRefresh} />
-      </div>
-
-      {/* 第二排：外观/启动等短卡自成一排，不与上面的大卡混排拉高。 */}
-      <div className="settings-grid">
-      <AppearanceCard
-        theme={theme}
-        onThemeChange={onThemeChange}
-        glassAlpha={glassAlpha}
-        onGlassAlpha={onGlassAlpha}
-        uiScale={uiScale}
-        onUiScale={onUiScale}
-        stripScale={stripScale}
-        onStripScale={onStripScale}
-      />
-
-      <StartupCard
-        autoUpdateCheck={autoUpdateCheck}
-        onAutoUpdateCheck={onAutoUpdateCheck}
-        availableUpdate={availableUpdate}
-      />
-
-      <QoderQuotaCard onSnapshotRefresh={onSnapshotRefresh} />
       </div>
     </main>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -83,6 +83,45 @@ button:focus-visible {
     inset 0 1px rgba(255, 255, 255, 0.88);
 }
 
+/* 主题快捷键：按钮本身混在按钮组里，弹出菜单挂在它下方。 */
+.theme-quick {
+  position: relative;
+  display: flex;
+}
+
+.theme-quick-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 6px);
+  right: 0;
+  display: grid;
+  min-width: 128px;
+  padding: 4px;
+  background: rgba(252, 252, 251, 0.98);
+  border-radius: 12px;
+  box-shadow:
+    0 0 0 1px rgba(31, 33, 36, 0.08),
+    0 12px 30px rgba(31, 33, 36, 0.14);
+}
+
+.theme-quick-menu button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 10px;
+  color: #2b2d31;
+  font-size: 13px;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.theme-quick-menu button:hover { background: rgba(31, 33, 36, 0.06); }
+.theme-quick-menu button.is-selected { color: var(--blue); font-weight: 560; }
+
 .window-action {
   display: grid;
   width: 40px;
@@ -1406,9 +1445,9 @@ html:has(.strip-shell) #root {
   /* 与窗口按钮组垂直居中对齐：按钮组 top 8 + 总高 44（40 按钮 + 2×2 padding），
      中线 30；本按钮高 32 → top = 30 - 16 = 14。 */
   top: 14px;
-  /* 贴在窗口按钮组左侧：按钮组 right 10 + padding 4 + 5 个 40px 按钮 = 右缘 214，
+  /* 贴在窗口按钮组左侧：按钮组 right 10 + padding 4 + 6 个 40px 按钮 = 右缘 254，
      再留 16px 间距。按钮增减时这里要跟着改。 */
-  right: 230px;
+  right: 270px;
   display: grid;
   width: 32px;
   height: 32px;
@@ -3550,6 +3589,16 @@ html:has(.strip-shell) #root {
   background: rgba(30, 32, 36, 0.9);
 }
 :root[data-theme="dark"] .expanded-refresh:disabled:hover { color: var(--d-muted); }
+:root[data-theme="dark"] .theme-quick-menu {
+  background: rgba(32, 34, 39, 0.98);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.09),
+    0 12px 30px rgba(0, 0, 0, 0.5);
+}
+:root[data-theme="dark"] .theme-quick-menu button { color: var(--d-ink-2); }
+:root[data-theme="dark"] .theme-quick-menu button:hover { background: rgba(255, 255, 255, 0.08); }
+:root[data-theme="dark"] .theme-quick-menu button.is-selected { color: var(--d-accent, #7fabef); }
+
 :root[data-theme="dark"] .window-actions--expanded {
   background: rgba(30, 32, 36, 0.72);
   box-shadow:

--- a/src/styles.css
+++ b/src/styles.css
@@ -2379,21 +2379,59 @@ html:has(.strip-shell) #root {
 }
 
 /* 双列起、宽屏更多列：同一行的卡片拉到等高，所有边缘对齐；窄窗口自动回退单列。 */
-.settings-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-  gap: 20px;
-  margin-top: 26px;
+/* 设置分类子页签：与周期分段控件同族的胶囊样式。 */
+.settings-tabs {
+  display: inline-flex;
+  gap: 2px;
+  margin-top: 22px;
+  padding: 3px;
+  background: rgba(31, 33, 36, 0.05);
+  border-radius: 12px;
 }
 
-/* 两排栅格：大卡一排（同步/Agent/配额，同排拉伸到统一高度）、短卡一排。 */
-.settings-grid + .settings-grid { margin-top: 20px; }
+.settings-tabs button {
+  padding: 7px 16px;
+  color: #55575b;
+  font-size: 13.5px;
+  background: transparent;
+  border: 0;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: color 180ms var(--motion), background-color 180ms var(--motion);
+}
 
-/* Agent 双栏：小组件与胶囊条各一列，窄卡时自动叠为单列。 */
+.settings-tabs button:hover { color: #25262a; }
+
+.settings-tabs button.is-selected {
+  color: #17181a;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(28, 30, 33, 0.1), 0 0 0 1px rgba(31, 33, 36, 0.04);
+}
+
+.settings-grid {
+  display: grid;
+  /* 每页两张卡：门槛放宽到 460px，宽屏下并排、窄屏自动堆叠。 */
+  grid-template-columns: repeat(auto-fit, minmax(460px, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+
+/* Agent 双栏：小组件与胶囊条各一列，窄卡时自动叠为单列。
+   门槛压到 168px——两列并排才能把 16 行压成 8 行高，这是这张卡不再
+   把整排撑高的关键。 */
 .settings-agent-columns {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 4px 20px;
+  grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
+  gap: 4px 18px;
+}
+
+/* 行内元素在窄列里不许撑破列宽，否则 auto-fit 退回单列。 */
+.settings-agent-toggle li { min-width: 0; }
+.settings-agent-toggle label { min-width: 0; }
+.settings-agent-toggle label > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-agent-column > h3 {
@@ -3458,6 +3496,15 @@ html:has(.strip-shell) #root {
   color: #e0c67c;
   background: rgba(220, 166, 72, 0.13);
 }
+:root[data-theme="dark"] .settings-tabs { background: rgba(255, 255, 255, 0.06); }
+:root[data-theme="dark"] .settings-tabs button { color: var(--d-muted); }
+:root[data-theme="dark"] .settings-tabs button:hover { color: var(--d-ink-2); }
+:root[data-theme="dark"] .settings-tabs button.is-selected {
+  color: var(--d-strong);
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
 :root[data-theme="dark"] .settings-card {
   background: var(--d-card);
   box-shadow: var(--d-card-shadow);


### PR DESCRIPTION
四个提交，均在 Windows 实机验证。

## WorkBuddy 用量修复（真机数据推翻了原假设）

adapter 原本按 tokscale 的夹具写了两条假设，本机跑出真实会话后**两条都被推翻**，而转录自带 `total_tokens` 正好能当裁判：

| 原假设 | 真相（16/16 行成立） | 后果 |
|---|---|---|
| 蛇形 `input_tokens` 不含缓存，需另加 `cache_read` | `total = input + output`，**cache_read ⊂ input** | 缓存读重复计入，1.07M 会报成 2.04M |
| `function_call` 也要 `status == "completed"` | 它的 status **恒为 null**（16 条里 13 条是 function_call） | 漏掉 81% 的用量 |

修完拿真文件端到端跑：**1,070,541 processed，与转录自报 total 逐字节相等**。

顺带查清了之前"找不到转录"的原因：桌面版不是独立实现，它**内置 CLI 并通过 `CODEBUDDY_CONFIG_DIR` 把 home 重定向到 `~/.workbuddy`**，转录落在 `~/.workbuddy/projects/`——adapter 本来就扫这个根，之前查不到纯粹是还没跑过会话。

另外定性了 `workbuddy.db` 的 `session_usage`：读桌面版源码确认 `size` 是模型上下文窗口、`used` 是当前占用（组件名 `ContextUsageDisplay`，设计文档 `context-ring`），**不是累计用量，不能接**；`credit_json` 是待结算计费额度，也不属 token 口径。

## 完整视图标题栏加主题切换

暗色模式本来就有，但要点四五下进设置。现在标题栏有太阳/月亮按钮：**单击**亮⇄暗，**右键**弹出自动/亮/暗三选。单击刻意不轮进"自动"——一次点击该有一个确定结果，而"自动"的结果取决于系统当下是什么。

## 设置页拆成三个子页签

Agent 卡片竖堆 16 行，高度是旁边卡片的两倍，把整排撑出大片空白，且 Agent 越多越糟。现在分为 **显示 / 数据来源 / 同步与更新**，每页两张卡、高度相近，高卡片只影响自己那页。

同时修好了 Agent 卡内部双栏失效（`minmax(190px)` 加行内固有宽度放不下两列，`auto-fit` 退回单列）——降到 168px + 标签省略后真正并排，卡片高度减半。

## 验证
`cargo test` 136 通过、`clippy -D warnings` 干净、`cargo fmt` 通过、`npm run build` 通过。三个页签在实际窗口宽度下逐页截图确认；主题按钮单击与右键均在真实 app 验证通过。

macOS 侧的注意事项已同步进 `docs/MACOS-HANDOFF.md`（WorkBuddy 转录目录、token 口径陷阱、`session_usage` 为何不能接）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
