### PR TITLE
Release 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.9.0"
+version = "0.10.0"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
只改五个版本文件，0.9.0 → 0.10.0。tag `v0.10.0` 已在同一会话推送。

## 本次内容（均已合入 main 并在 Windows 实机验证）

**WorkBuddy 用量修复**（#19）——两个方向相反的错误同时存在，靠真实会话转录自带的 `total_tokens` 当裁判发现：
- 所有 input 别名都**含缓存**，原按 Anthropic 风格另加 `cache_read`，导致缓存读重复计入
- `function_call` 行带 usage 但 status 恒为 null，原要求 `completed` 漏掉 81% 的用量

修完解析真实文件得 1,070,541 processed，与转录自报总量逐字节相等。

**标题栏主题切换**（#19）——完整视图右上角加太阳/月亮按钮，单击亮⇄暗、右键选自动/亮/暗。暗色模式本来就有，只是要点四五下进设置。

**设置页分三页签**（#19）——显示 / 数据来源 / 同步与更新。Agent 卡片竖堆 16 行会把整排撑出空白，分页后高卡片只影响自己那页；同时修好卡内双栏失效，高度减半。

**macOS `ps` 截断修复**（#17）——macOS 的 `ps` 默认按终端宽度截断，`--csrf_token` 被切掉导致 Antigravity 端点发现静默失败。改用 `ps -axww`。**未在 mac 实机验证**，见 issue #18 与 `docs/MACOS-HANDOFF.md`。

## 发布前检查（按 AGENTS.md）
- [ ] 双平台 CI 绿
- [ ] **同一 tag 只有一个 draft**（两个平台 job 会竞态创建出各带一半产物的两个 draft）
- [ ] `latest.json` 七个平台键齐全且签名完整

🤖 Generated with [Claude Code](https://claude.com/claude-code)
