### PR TITLE
Release 0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.10.0"
+version = "0.10.1"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
只改五个版本文件，0.10.0 → 0.10.1。tag `v0.10.1` 已在同一会话推送。

## 内容

- **美元符号被裁**（#25）：成本估算的大数字 `line-height: 1`，而 Newsreader 的 `$` 比数字高，34px 下被切成一根竖线。改为 1.15。
- **首个 AGPL-3.0 版本**（#24）：v0.10.0 及更早版本仍适用 MIT，换证只对之后的版本生效。
- **README 精简**（#23、#25）：删掉写给自己的开发笔记（验收边界、路线），保留用户会踩到的限制；「设计原则」改为正面陈述。

## 发布前检查（按 AGPL.md 协议）
- [ ] 双平台 CI 绿
- [ ] **合并本 PR 用 merge commit，不能 squash**（squash 会让 tag 脱离 main 历史，v0.10.0 踩过）
- [ ] 同一 tag 只有一个 draft
- [ ] `latest.json` 七个平台键齐全且签名完整

🤖 Generated with [Claude Code](https://claude.com/claude-code)
