### PR TITLE
Kimi Work 配额源 + 悬浮形态等比拖拽缩放 + Claude 重置时间哨兵修复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ When implementing from a selected generated mock, treat that image as the source
 - The interface should feel Apple-like through restraint, typography, material depth, spacing, and motion; do not imitate Apple branding or proprietary screens.
 - The default desktop form is a compact approximately 380 x 440 widget. Full analytics remain available through a one-click expanded view; pinning above other windows is opt-in, not forced.
 - Gemini CLI is explicitly out of scope. The initial adapters are Codex and Claude Code; future agents must use the adapter contract.
+- Kimi Work (kimi-desktop) is a quota-only provider: official quota comes from the plaintext kimi.com Web token in `kimi-desktop/bridge-store/token-store.json` (mirrored in the daimon `config.json`) via `MembershipService/GetSubscriptionStats`; only the 5h/7d windows and the monthly OMNI subscription cycle are reported — gift balances and booster wallets stay hidden. Parsing the daimon runtime's local wire.jsonl is a deliberate follow-up, and macOS menu-bar specs were not extended (same precedent as workbuddy/qoder).
 - Statistics must distinguish official quota, locally parsed usage, and estimated cost. Never present estimates as official billing.
 - Never synthesize a comparison curve or silently replace a failed desktop read with demo numbers. Missing or stale data must be labeled explicitly.
 - The product is local-first. Multi-device sync is optional and must not upload prompts, conversation text, credentials, or raw tool output.
@@ -24,7 +25,7 @@ When implementing from a selected generated mock, treat that image as the source
 - The strip's window size is derived from the rendered content (measure the main-axis length after layout and resize to fit), never from hand-maintained size constants. Constants may seed the first frame only — they drifted out of sync with the CSS once and clipped the vertical strip's buttons on other DPI/font/scale combinations.
 - The compact widget's primary content is per-agent official quota windows (5h/weekly remaining + reset countdown), not local token summaries; token analytics live in the expanded view. Missing or stale quota stays explicitly labeled.
 - The strip prefers the five-hour window per cell, falling back to the first available ranked window.
-- UI scale is continuous and per-form: compact uses `metrik:uiScale` [0.75–2.0]; the strip has its own `metrik:stripScale` [0.75–2.0]. Both are settings-page sliders that apply on next form entry. The expanded view has no scale setting — its window is freely resizable and webview zoom stays 1.
+- UI scale is continuous and per-form: compact uses `metrik:uiScale` [0.75–2.0]; the strip has its own `metrik:stripScale` [0.75–2.0]. Both are settings-page sliders that apply on next form entry. Both floating forms also support border-drag scaling: dragging any edge or corner of the compact card, or the main axis of the strip, maps to the same scale factor (window snaps back to proportional size; the card can never be stretched out of proportion). The expanded view has no scale setting — its window is freely resizable and webview zoom stays 1.
 - Manual refresh triggers `usage_snapshot` with `force: true`, bypassing quota TTL caches; failure still retains and stale-labels old rows — never clears them.
 
 ## Durable cross-platform development workflow

--- a/src-tauri/src/claude_hook.rs
+++ b/src-tauri/src/claude_hook.rs
@@ -1,4 +1,4 @@
-use crate::domain::QuotaSample;
+use crate::domain::{sane_resets_at_ms, QuotaSample};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -380,7 +380,10 @@ impl ClaudeHook {
                 adapter_id: "claude",
                 window_key: key.clone(),
                 remaining_percent: (100.0 - window.used_percentage).clamp(0.0, 100.0),
-                resets_at_ms: window.resets_at.map(|value| (value * 1000.0) as i64),
+                resets_at_ms: window
+                    .resets_at
+                    .map(|value| (value * 1000.0) as i64)
+                    .and_then(|value| sane_resets_at_ms(key, value, file.received_at_ms)),
                 collected_at_ms: file.received_at_ms,
                 source_label: "statusLine 钩子".into(),
                 quality: "official_snapshot",
@@ -553,5 +556,39 @@ mod tests {
         // 缺失文件 → 空，不猜测。
         let empty = ClaudeHook::with_dir(test.path().join("missing"));
         assert!(empty.quota_samples().is_empty());
+    }
+
+    #[test]
+    fn sentinel_resets_at_is_dropped_but_plausible_kept() {
+        let test = TestDirectory::new("sentinel");
+        // Claude Code 在重置时间未知时下发哨兵值（1900000000 秒 ≈ 2030 年），
+        // 展示出来是"1331 天后重置"（用户实测）。超出窗口语义的重置时间丢弃。
+        fs::write(
+            test.path().join(QUOTA_FILE),
+            r#"{"receivedAtMs": 1784938548385,
+                "windows": {
+                    "five_hour": {"usedPercentage": 42.3, "resetsAt": 1900000000},
+                    "seven_day": {"usedPercentage": 18.7, "resetsAt": 1900000000}
+                }}"#,
+        )
+        .unwrap();
+        let hook = ClaudeHook::with_dir(test.path().to_path_buf());
+        let samples = hook.quota_samples();
+        assert_eq!(samples.len(), 2);
+        assert!(samples.iter().all(|sample| sample.resets_at_ms.is_none()));
+
+        // 窗口语义内的重置时间保留：5h 窗 +2 小时、7d 窗 +3 天。
+        fs::write(
+            test.path().join(QUOTA_FILE),
+            r#"{"receivedAtMs": 1784938548385,
+                "windows": {
+                    "five_hour": {"usedPercentage": 42.3, "resetsAt": 1784945748.0},
+                    "seven_day": {"usedPercentage": 18.7, "resetsAt": 1785197748.0}
+                }}"#,
+        )
+        .unwrap();
+        let samples = hook.quota_samples();
+        assert_eq!(samples[0].resets_at_ms, Some(1_784_945_748_000));
+        assert_eq!(samples[1].resets_at_ms, Some(1_785_197_748_000));
     }
 }

--- a/src-tauri/src/claude_oauth.rs
+++ b/src-tauri/src/claude_oauth.rs
@@ -1,4 +1,4 @@
-use crate::domain::QuotaSample;
+use crate::domain::{sane_resets_at_ms, QuotaSample};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -353,9 +353,13 @@ fn samples_from_usage(usage: UsageResponse, now: i64) -> Vec<QuotaSample> {
             let used = window.utilization?;
             Some(QuotaSample {
                 adapter_id: "claude",
-                window_key: key,
+                window_key: key.clone(),
                 remaining_percent: (100.0 - used).clamp(0.0, 100.0),
-                resets_at_ms: window.resets_at.as_deref().and_then(parse_iso8601_ms),
+                resets_at_ms: window
+                    .resets_at
+                    .as_deref()
+                    .and_then(parse_iso8601_ms)
+                    .and_then(|value| sane_resets_at_ms(&key, value, now)),
                 collected_at_ms: now,
                 source_label: SOURCE_LABEL.to_owned(),
                 quality: "official_snapshot",
@@ -456,7 +460,9 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let samples = samples_from_usage(usage, 1);
+        // 采集时刻用真实量级（2026-07-14T00:00Z）：重置时间的合理性校验
+        // 依赖它与重置时刻的相对关系。
+        let samples = samples_from_usage(usage, 1_783_987_200_000);
         assert_eq!(
             samples
                 .iter()
@@ -494,7 +500,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let samples = samples_from_usage(usage, 1);
+        let samples = samples_from_usage(usage, 1_783_987_200_000);
         let keys = samples
             .iter()
             .map(|sample| sample.window_key.as_str())
@@ -514,5 +520,20 @@ mod tests {
         assert_eq!(opus.remaining_percent, 70.0);
         assert_eq!(opus.resets_at_ms, parse_iso8601_ms("2026-07-18T21:00:00Z"));
         assert_eq!(samples[3].remaining_percent, 92.5);
+    }
+
+    #[test]
+    fn absurd_resets_at_is_dropped() {
+        // 与 statusLine 钩子同源的哨兵：重置时间未知时后端可能下发远未来
+        // 时间（实测 2030 年），超出窗口语义的一律丢弃，不显示"1331 天后重置"。
+        let usage: UsageResponse = serde_json::from_str(
+            r#"{"five_hour": {"utilization": 42.3, "resets_at": "2030-03-17T07:23:20Z"}}"#,
+        )
+        .unwrap();
+        let samples = samples_from_usage(usage, 1_783_987_200_000);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].resets_at_ms, None);
+        // 百分比不受影响，照常展示。
+        assert!((samples[0].remaining_percent - 57.7).abs() < f64::EPSILON);
     }
 }

--- a/src-tauri/src/coding_quota.rs
+++ b/src-tauri/src/coding_quota.rs
@@ -427,8 +427,7 @@ pub fn fetch_kimiwork_quota(timeout: Duration) -> Result<Vec<QuotaSample>> {
     let body = response
         .into_string()
         .context("读取 Kimi Work 配额响应失败")?;
-    let json: Value =
-        serde_json::from_str(&body).context("Kimi Work 配额响应不是预期的 JSON")?;
+    let json: Value = serde_json::from_str(&body).context("Kimi Work 配额响应不是预期的 JSON")?;
     let samples = parse_kimiwork_quota(&json, chrono::Utc::now().timestamp_millis());
     if samples.is_empty() {
         bail!("Kimi Work 配额响应缺少可用窗口");
@@ -1121,7 +1120,10 @@ fn kimi_window_key(entry: &Value) -> &'static str {
 /// 钱包（boosterWallets）键语义不同，先不展示。形状据真机核验（2026-07）。
 fn parse_kimiwork_quota(value: &Value, now: i64) -> Vec<QuotaSample> {
     let mut samples = Vec::new();
-    for (field, key) in [("ratelimitCode5h", "five_hour"), ("ratelimitCode7d", "seven_day")] {
+    for (field, key) in [
+        ("ratelimitCode5h", "five_hour"),
+        ("ratelimitCode7d", "seven_day"),
+    ] {
         let Some(window) = value.get(field) else {
             continue;
         };
@@ -1132,7 +1134,12 @@ fn parse_kimiwork_quota(value: &Value, now: i64) -> Vec<QuotaSample> {
         let Some(ratio) = window.get("ratio").and_then(Value::as_f64) else {
             continue;
         };
-        samples.push(kimiwork_sample(key, ratio, first_time(window, &["resetTime"]), now));
+        samples.push(kimiwork_sample(
+            key,
+            ratio,
+            first_time(window, &["resetTime"]),
+            now,
+        ));
     }
     if let Some(balance) = value.get("subscriptionBalance") {
         if balance.get("feature").and_then(Value::as_str) == Some("FEATURE_OMNI")

--- a/src-tauri/src/coding_quota.rs
+++ b/src-tauri/src/coding_quota.rs
@@ -36,6 +36,16 @@
 //! `QoderUsageFetcher.swift`）的一致行为。cookie 只认环境变量
 //! `QODER_COOKIE`/`METRIK_QODER_COOKIE`（浏览器 dashboard 抓取后由用户主动
 //! 提供），`QODER_SITE=cn|global` 指定站点，缺省时国内站优先逐个尝试。
+//!
+//! Kimi Work（kimi-desktop 桌面 Agent）：**已按真机核验**（2026-07，国内账号）。
+//! 桌面端把 kimi.com 的 Web 凭据明文存在 userData 目录——Windows 是
+//! `%APPDATA%/kimi-desktop/bridge-store/token-store.json`，daimon 的
+//! `config.json` 里也镜像了一份。配额走 connect-RPC：POST
+//! `www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats`，
+//! 空 JSON body + Bearer 即通（实测 x-msh-* 头不是必需的）。响应里
+//! `ratelimitCode5h/7d` 是滚动限流窗，`subscriptionBalance`（FEATURE_OMNI +
+//! SUBSCRIPTION）是订阅周期额度池；礼品余额与加速钱包键语义不同，先不展示。
+//! 令牌由 Kimi Work 自行续期，Metrik 每次拉取都重读文件，过期照实报错。
 
 use crate::domain::QuotaSample;
 use anyhow::{anyhow, bail, Context, Result};
@@ -54,6 +64,11 @@ const GLM_ZAI_URL: &str = "https://api.z.ai/api/monitor/usage/quota/limit";
 // `authentication.method` 回 METHOD_ACCESS_TOKEN），也认控制台 key；开放平台
 // key 不是这套。
 const KIMI_USAGE_URL: &str = "https://api.kimi.com/coding/v1/usages";
+// Kimi Work 订阅配额端点（connect-RPC）：空 JSON body + Bearer 即通，实测
+// x-msh-* 头非必需（2026-07 真机核验）。5h/7d 滚动窗与订阅周期额度池都在
+// GetSubscriptionStats 的响应里。
+const KIMIWORK_STATS_URL: &str =
+    "https://www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats";
 
 // ── 拉取入口（供 engine 层带缓存调用） ─────────────────────────
 
@@ -389,6 +404,34 @@ pub fn fetch_kimi_quota(timeout: Duration) -> Result<Vec<QuotaSample>> {
     let samples = parse_kimi_quota(&json);
     if samples.is_empty() {
         bail!("Kimi 配额响应缺少可用窗口");
+    }
+    Ok(samples)
+}
+
+/// Kimi Work（kimi-desktop 桌面 Agent）的官方配额：5h/7d 滚动限流窗外加
+/// 订阅周期的 OMNI 额度池。凭据是桌面端明文存的 kimi.com Web access_token，
+/// 只读不刷新（续期是 Kimi Work 自己的事）；过期按凭据失效如实报错。
+pub fn fetch_kimiwork_quota(timeout: Duration) -> Result<Vec<QuotaSample>> {
+    let token = resolve_kimiwork_credential().context(
+        "未找到 Kimi Work 的凭据（kimi-desktop 的 bridge-store/token-store.json，需先登录 Kimi Work）",
+    )?;
+    let agent = ureq::AgentBuilder::new().timeout(timeout).build();
+    let response = agent
+        .post(KIMIWORK_STATS_URL)
+        .set("Authorization", &format!("Bearer {token}"))
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json")
+        // connect-RPC 的 JSON 模式：空对象 body。
+        .send_string("{}")
+        .map_err(|error| map_ureq_error("Kimi Work", error))?;
+    let body = response
+        .into_string()
+        .context("读取 Kimi Work 配额响应失败")?;
+    let json: Value =
+        serde_json::from_str(&body).context("Kimi Work 配额响应不是预期的 JSON")?;
+    let samples = parse_kimiwork_quota(&json, chrono::Utc::now().timestamp_millis());
+    if samples.is_empty() {
+        bail!("Kimi Work 配额响应缺少可用窗口");
     }
     Ok(samples)
 }
@@ -786,6 +829,41 @@ fn kimi_oauth_paths() -> Vec<PathBuf> {
         .collect()
 }
 
+/// Kimi Work（kimi-desktop）的凭据落点：Electron userData 目录（Windows 是
+/// %APPDATA%，macOS 是 ~/Library/Application Support）下，bridge-store 的
+/// token-store.json 存 kimi.com Web 令牌（`tokens.access_token`，真机核验
+/// 2026-07），daimon 的 config.json 里也镜像了一份（`credentials.kimiWeb.
+/// accessToken`）。都是明文，符合"只接主动暴露明文凭据"的原则；令牌由
+/// Kimi Work 自行续期，只读不写，每次拉取重读文件。
+fn kimiwork_token_paths() -> Vec<PathBuf> {
+    let Some(config) = dirs::config_dir() else {
+        return Vec::new();
+    };
+    let desktop = config.join("kimi-desktop");
+    vec![
+        desktop.join("bridge-store").join("token-store.json"),
+        desktop
+            .join("daimon-share")
+            .join("daimon")
+            .join("config.json"),
+    ]
+}
+
+fn resolve_kimiwork_credential() -> Option<String> {
+    for path in kimiwork_token_paths() {
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        // token-store.json 是 snake_case，daimon config.json 是 camelCase。
+        for field in ["access_token", "accessToken"] {
+            if let Some(token) = extract_scalar(&raw, field) {
+                return Some(token);
+            }
+        }
+    }
+    None
+}
+
 #[derive(Deserialize)]
 struct AuthEntry {
     key: Option<String>,
@@ -1034,6 +1112,55 @@ fn kimi_window_key(entry: &Value) -> &'static str {
         }
     }
     "five_hour"
+}
+
+/// Kimi Work：`GetSubscriptionStats` 的 `ratelimitCode5h/7d` 是滚动限流窗
+/// （`ratio` = 已用比例 0–1，`resetTime` = 窗口重置时刻）；`subscriptionBalance`
+/// 里 FEATURE_OMNI + SUBSCRIPTION 那条是订阅周期额度池（`amountUsedRatio` =
+/// 已用比例，`expireTime` = 周期重置/到期）。礼品余额（giftBalances）与加速
+/// 钱包（boosterWallets）键语义不同，先不展示。形状据真机核验（2026-07）。
+fn parse_kimiwork_quota(value: &Value, now: i64) -> Vec<QuotaSample> {
+    let mut samples = Vec::new();
+    for (field, key) in [("ratelimitCode5h", "five_hour"), ("ratelimitCode7d", "seven_day")] {
+        let Some(window) = value.get(field) else {
+            continue;
+        };
+        // enabled=false 的窗口未生效，不展示。
+        if window.get("enabled").and_then(Value::as_bool) == Some(false) {
+            continue;
+        }
+        let Some(ratio) = window.get("ratio").and_then(Value::as_f64) else {
+            continue;
+        };
+        samples.push(kimiwork_sample(key, ratio, first_time(window, &["resetTime"]), now));
+    }
+    if let Some(balance) = value.get("subscriptionBalance") {
+        if balance.get("feature").and_then(Value::as_str) == Some("FEATURE_OMNI")
+            && balance.get("type").and_then(Value::as_str) == Some("SUBSCRIPTION")
+        {
+            if let Some(ratio) = balance.get("amountUsedRatio").and_then(Value::as_f64) {
+                samples.push(kimiwork_sample(
+                    "monthly_cycle",
+                    ratio,
+                    first_time(balance, &["expireTime"]),
+                    now,
+                ));
+            }
+        }
+    }
+    samples
+}
+
+fn kimiwork_sample(key: &str, used_ratio: f64, reset: Option<i64>, now: i64) -> QuotaSample {
+    QuotaSample {
+        adapter_id: "kimiwork",
+        window_key: key.to_owned(),
+        remaining_percent: ((1.0 - used_ratio) * 100.0).clamp(0.0, 100.0),
+        resets_at_ms: reset.and_then(|value| crate::domain::sane_resets_at_ms(key, value, now)),
+        collected_at_ms: now,
+        source_label: "Kimi Work 官方配额".into(),
+        quality: "official_live",
+    }
 }
 
 fn first_f64(value: &Value, names: &[&str]) -> Option<f64> {
@@ -1286,6 +1413,89 @@ mod tests {
         let json: Value =
             serde_json::from_str(r#"{"usage": {"limit": "0", "remaining": "0"}}"#).unwrap();
         assert!(parse_kimi_quota(&json).is_empty());
+    }
+
+    /// 真机核验（2026-07，kimi-desktop 国内账号，GetSubscriptionStats）：
+    /// 只把订阅/用户/余额标识换成占位符。ratelimitCode5h/7d 是滚动窗；
+    /// subscriptionBalance 是订阅周期额度池；礼品余额与加速钱包不展示。
+    const KIMIWORK_LIVE_RESPONSE: &str = r#"{
+        "ratelimitCode5h": {"ratio": 0.6108, "enabled": true, "resetTime": "2026-07-25T16:31:18.819233697Z"},
+        "ratelimitCode7d": {"ratio": 0.1222, "enabled": true, "resetTime": "2026-07-31T08:31:18.819233697Z"},
+        "subscriptionBalance": {"id": "test-balance", "feature": "FEATURE_OMNI", "type": "SUBSCRIPTION",
+            "unit": "UNIT_CREDIT", "amountUsedRatio": 0.2194, "kimiCodeUsedRatio": 0.218,
+            "expireTime": "2026-08-17T08:31:19.805580Z"},
+        "giftBalances": [{"id": "test-gift", "feature": "FEATURE_OMNI", "type": "GIFT",
+            "unit": "UNIT_CREDIT", "amountUsedRatio": 0.0439, "expireTime": "2026-12-31T15:59:59Z"}],
+        "boosterWallets": [{"id": "test-wallet", "userId": "test-user", "status": "STATUS_DISABLED"}]
+    }"#;
+
+    #[test]
+    fn kimiwork_quota_reads_the_live_shape() {
+        let json: Value = serde_json::from_str(KIMIWORK_LIVE_RESPONSE).unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-07-25T15:00:00Z")
+            .unwrap()
+            .timestamp_millis();
+        let samples = parse_kimiwork_quota(&json, now);
+        assert_eq!(samples.len(), 3);
+        assert_eq!(samples[0].window_key, "five_hour");
+        assert!((samples[0].remaining_percent - 38.92).abs() < 0.001);
+        assert_eq!(
+            samples[0].resets_at_ms,
+            chrono::DateTime::parse_from_rfc3339("2026-07-25T16:31:18.819233697Z")
+                .ok()
+                .map(|value| value.timestamp_millis())
+        );
+        assert_eq!(samples[1].window_key, "seven_day");
+        assert!((samples[1].remaining_percent - 87.78).abs() < 0.001);
+        assert_eq!(samples[2].window_key, "monthly_cycle");
+        assert!((samples[2].remaining_percent - 78.06).abs() < 0.001);
+        assert_eq!(
+            samples[2].resets_at_ms,
+            chrono::DateTime::parse_from_rfc3339("2026-08-17T08:31:19.805580Z")
+                .ok()
+                .map(|value| value.timestamp_millis())
+        );
+        assert!(samples
+            .iter()
+            .all(|sample| sample.adapter_id == "kimiwork" && sample.quality == "official_live"));
+    }
+
+    #[test]
+    fn kimiwork_quota_skips_disabled_and_missing_windows() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-07-25T15:00:00Z")
+            .unwrap()
+            .timestamp_millis();
+        // 5h 窗禁用、无订阅余额 → 只剩 7d 一扇（无 resetTime 则为 None）。
+        let json: Value = serde_json::from_str(
+            r#"{"ratelimitCode5h": {"ratio": 0.5, "enabled": false},
+                "ratelimitCode7d": {"ratio": 0.25, "enabled": true}}"#,
+        )
+        .unwrap();
+        let samples = parse_kimiwork_quota(&json, now);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].window_key, "seven_day");
+        assert_eq!(samples[0].remaining_percent, 75.0);
+        assert!(samples[0].resets_at_ms.is_none());
+        // 全空 → 空，不编造。
+        let json: Value = serde_json::from_str(r#"{"boosterWallets": []}"#).unwrap();
+        assert!(parse_kimiwork_quota(&json, now).is_empty());
+    }
+
+    /// 打真实 MembershipService 接口的烟测（解析器只能证明"对得上夹具"）。
+    /// 需要本机装了 Kimi Work 并已登录。
+    #[test]
+    #[ignore = "reads the current user's Kimi Work credential and calls the live quota API"]
+    fn live_kimiwork_quota_smoke_test() {
+        let samples = fetch_kimiwork_quota(Duration::from_secs(15)).expect("fetch kimiwork quota");
+        assert!(!samples.is_empty(), "配额响应里没有可用窗口");
+        for sample in &samples {
+            println!(
+                "kimiwork quota: window={} remaining={:.1}% resets_at={:?}",
+                sample.window_key, sample.remaining_percent, sample.resets_at_ms
+            );
+            assert_eq!(sample.adapter_id, "kimiwork");
+            assert!((0.0..=100.0).contains(&sample.remaining_percent));
+        }
     }
 
     #[test]

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -7,12 +7,15 @@ use std::path::PathBuf;
 /// 所有已启用 adapter 的 ID，前端 series 与汇总按此顺序输出。
 /// qoder 是配额-only：本地不落可解析的 token 用量（QoderWork agents.db
 /// 字段恒 0），只有官网 Credits 配额来源，没有对应的日志 adapter。
-pub const AGENT_IDS: [&str; 8] = [
+/// kimiwork 同样是配额-only：Kimi Work 桌面端的本地 token 用量在它的
+/// daimon 运行时里（wire.jsonl 与 Kimi 同格式），接入本地解析是后续项。
+pub const AGENT_IDS: [&str; 9] = [
     "codex",
     "claude",
     "zcode",
     "opencode",
     "kimi",
+    "kimiwork",
     "antigravity",
     "workbuddy",
     "qoder",
@@ -120,6 +123,26 @@ pub struct QuotaSample {
     pub collected_at_ms: i64,
     pub source_label: String,
     pub quality: &'static str,
+}
+
+/// 重置时间的合理性校验：实测 Claude Code 在重置时间未知时会下发哨兵值
+/// （1900000000 秒 ≈ 2030 年），直接展示就是"1331 天后重置"。重置时间必然
+/// 落在窗口语义内（5h 窗 ~6h、7d 窗 ~8d、月级窗口 ~35 天），越界一律丢弃
+/// ——宁可不显示倒计时，也不显示错的。
+pub fn sane_resets_at_ms(window_key: &str, resets_at_ms: i64, collected_at_ms: i64) -> Option<i64> {
+    const HOUR_MS: i64 = 3_600_000;
+    const DAY_MS: i64 = 86_400_000;
+    let max_span_ms = if window_key == "five_hour" {
+        6 * HOUR_MS
+    } else if window_key.starts_with("seven_day") {
+        8 * DAY_MS
+    } else {
+        35 * DAY_MS
+    };
+    // 下界放宽 10 分钟：采集时刻与负载内时间戳之间有合理的时钟/排程差。
+    let plausible = resets_at_ms >= collected_at_ms - 10 * 60_000
+        && resets_at_ms <= collected_at_ms + max_span_ms;
+    plausible.then_some(resets_at_ms)
 }
 
 /// Codex 的 primary/secondary 只是槽位，不是窗口语义：套餐不同，同一个槽位

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -167,6 +167,7 @@ pub fn build_snapshot(
             coding_quota::fetch_zcode_quota as fn(StdDuration) -> Result<Vec<QuotaSample>>,
         ),
         ("kimi", coding_quota::fetch_kimi_quota),
+        ("kimiwork", coding_quota::fetch_kimiwork_quota),
         ("qoder", coding_quota::fetch_qoder_quota),
         ("workbuddy", coding_quota::fetch_workbuddy_quota),
     ] {
@@ -1041,6 +1042,8 @@ fn quota_window_label(adapter_id: &str, key: &str) -> String {
         }
         // Claude 套餐外按量付费的已用比例（月度预算）。
         "extra_usage" => "超额用量".into(),
+        // Kimi Work 订阅周期的 OMNI 额度池。
+        "monthly_cycle" => "月度周期".into(),
         other => {
             let model = other.strip_prefix("seven_day_").unwrap_or(other);
             let mut chars = model.chars();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,8 +59,10 @@ import {
   closeWindow,
   getAutostart,
   installUpdate,
+  isCompactUserResizing,
   isDesktop,
   isMacPlatform,
+  isStripUserResizing,
   minimizeWindow,
   onScaleFactorChanged,
   onTrayShowExpanded,
@@ -76,6 +78,7 @@ import {
   setNativeTheme,
   setStripScale,
   startCompactResizeScale,
+  startStripResizeScale,
   updateMacStatusItems,
   setWindowGlass,
   setWindowPinned,
@@ -138,6 +141,15 @@ const AGENT_META = {
     label: "Kimi",
     // 品红：与 codex 蓝彻底拉开（原来 #3f74f2 和 ChatGPT 的蓝在图里分不清）。
     accent: "#c6538c",
+    iconSrc: kimiAppIcon,
+    iconClass: "agent-icon--kimi",
+  },
+  kimiwork: {
+    // 配额-only：Kimi Work 桌面端（kimi-desktop）。本地 token 用量在它的
+    // daimon 运行时里（wire.jsonl 与 Kimi 同格式），接入本地解析是后续项。
+    label: "Kimi Work",
+    // 紫罗兰：与 kimi 的品红同族，但偏向紫，与 zcode 的蓝紫也拉开。
+    accent: "#a055d6",
     iconSrc: kimiAppIcon,
     iconClass: "agent-icon--kimi",
   },
@@ -338,6 +350,7 @@ function shortWindowLabel(key) {
   if (key === "seven_day" || key === "secondary") return "7d";
   if (key === "extra_usage") return "超额";
   if (key === "credits") return "额度";
+  if (key === "monthly_cycle") return "月度";
   return key.replace(/^seven_day_/, "").slice(0, 4);
 }
 
@@ -985,6 +998,7 @@ function StripBar({
   onExpand,
   availableUpdate,
   onOpenUpdate,
+  onStripScaleDragged,
 }) {
   // 用户自选的 agent 一律占格；没有官方配额数据的显示 "--"，不伪造数字。
   const cells = agents.map((agentId) => ({
@@ -1005,6 +1019,9 @@ function StripBar({
     let timer = null;
     const fit = () => {
       timer = null;
+      // 用户拖主轴＝等比缩放的手势期间不弹回（startStripResizeScale 会收敛
+      // 到等比尺寸）；副轴-only 拖拽不标记，量出偏差立即弹回设计常量。
+      if (isStripUserResizing()) return;
       const isVertical = shell.classList.contains("strip-shell--vertical");
       if (isVertical) {
         const targetHeight = measureStripVerticalContent(shell);
@@ -1030,16 +1047,42 @@ function StripBar({
       timer = window.setTimeout(fit, 60);
     };
     schedule();
+    // webfont 换字可能发生在 60ms 首次 fit 之后（没有触发器补测就会留下
+    // 测量空窗，竖条底部按钮被裁）：字体就绪补测一次，再兜底一个 450ms
+    // 的二次测量。
+    let disposed = false;
+    document.fonts?.ready?.then(() => {
+      if (!disposed) schedule();
+    });
+    const lateTimer = window.setTimeout(schedule, 450);
     if (typeof ResizeObserver === "undefined") {
-      return () => window.clearTimeout(timer);
+      return () => {
+        disposed = true;
+        window.clearTimeout(timer);
+        window.clearTimeout(lateTimer);
+      };
     }
     const observer = new ResizeObserver(schedule);
     observer.observe(shell);
     return () => {
+      disposed = true;
       window.clearTimeout(timer);
+      window.clearTimeout(lateTimer);
       observer.disconnect();
     };
   });
+  // 拖窗口边缘 → 缩放系数（windowClient 负责去抖、归一化与窗口回弹）；
+  // 系数回写根状态，设置页的滑杆随之同步（持久化在拖拽路径内部已完成）。
+  useEffect(() => {
+    if (!isDesktop()) return undefined;
+    let cancel = null;
+    startStripResizeScale(onStripScaleDragged).then((fn) => {
+      cancel = fn;
+    });
+    return () => {
+      cancel?.();
+    };
+  }, [onStripScaleDragged]);
   return (
     <main
       ref={shellRef}
@@ -1198,15 +1241,17 @@ function CompactWidget({
   const comparisonIsLower = snapshot.comparisonPercent < -0.5;
   const ComparisonArrow = comparisonIsLower ? ArrowDown : ArrowUp;
   const shellRef = useRef(null);
-  // 宽度失配自愈的重试计数：跨屏/DPI 变化时清零重试（双屏场景下上限 3 次
-  // 在旧屏耗尽后，新屏就没机会自愈了）。重应用本身由根组件的
-  // reassertCompactSize 订阅负责，这里只负责让自愈资格恢复。
-  const desyncAttemptsRef = useRef(0);
+  // 宽度失配自愈的节流时间戳：失配不消失时观察器会一直触发，没有节流会
+  // 每 120ms 整窗重应用一次；距上次不足 2s 不再重复愈（失配消失即止），
+  // 替代旧的 3 次终身上限——上限烧完后失配就永远留着了。跨屏/DPI 变化时
+  // 清零，让新显示器上的自愈立即恢复资格（双屏场景下旧屏烧完上限、新屏
+  // 没机会自愈的坑）。重应用本身由根组件的 reassertCompactSize 订阅负责。
+  const lastDesyncHealRef = useRef(0);
   useEffect(() => {
     if (!isDesktop()) return undefined;
     let cancel = null;
     onScaleFactorChanged(() => {
-      desyncAttemptsRef.current = 0;
+      lastDesyncHealRef.current = 0;
     }).then((fn) => {
       cancel = fn;
     });
@@ -1227,10 +1272,13 @@ function CompactWidget({
     };
   }, [onUiScaleDragged]);
   // 一个观察器承担两条自愈：
-  // 1) 宽度失配（zoom×物理尺寸失配，视口 < 320，右侧被裁）→ 整窗重应用（≤3 次）；
+  // 1) 宽度失配（zoom×物理尺寸失配，视口 < 320，右侧被裁）→ 整窗重应用
+  //    （节流到 2s 一次，失配消失即止）；
   // 2) Agent 行数变化 → 窗口高度跟随内容（1-2 行回 320，更多行加高，
   //    工作区装不下的部分由列表内部滚动承担）。行数变化不改外壳尺寸，
   //    ResizeObserver 感知不到，所以每次渲染后再主动复核一次。
+  // 用户拖拽＝等比缩放的手势期间（isCompactUserResizing）两条都不介入：
+  // 这里 120ms 的自愈比拖拽缩放的 260ms 去抖跑得快，不回避会把拖拽回弹。
   useEffect(() => {
     if (!isDesktop()) return undefined;
     const shell = shellRef.current;
@@ -1238,18 +1286,19 @@ function CompactWidget({
     let timer = null;
     const check = () => {
       timer = null;
+      if (isCompactUserResizing()) return;
       const rect = shell.getBoundingClientRect();
       // 宽度失配（zoom×物理尺寸失配，视口 < 320，右侧被裁）是 Windows 单窗口
       // 变形独有的问题；macOS 面板没有 zoom，不会失配。
       const widthDesynced =
         shell.scrollWidth > shell.clientWidth + 1 || rect.width > window.innerWidth + 1;
       if (!IS_MAC && widthDesynced) {
-        if (desyncAttemptsRef.current >= 3) return;
-        desyncAttemptsRef.current += 1;
+        const now = Date.now();
+        if (now - lastDesyncHealRef.current < 2000) return;
+        lastDesyncHealRef.current = now;
         runWindowAction(() => applyWindowMode("compact"));
         return;
       }
-      desyncAttemptsRef.current = 0;
       const list = shell.querySelector(".widget-agent-list");
       if (!list) return;
       // 内容自然高 = 实际行高之和（getBoundingClientRect，与窗口大小无关）。
@@ -2083,7 +2132,7 @@ function AppearanceCard({ theme, onThemeChange, glassAlpha, onGlassAlpha, uiScal
       {!IS_MAC && (
         <SliderRow
           label="胶囊条缩放"
-          hint="等比缩放胶囊条，与小组件互不影响；下次进入时生效。"
+          hint="等比缩放胶囊条，也可直接拖胶囊条边缘调整；与小组件互不影响，滑杆改动下次进入时生效。"
           min={UI_SCALE_RANGE.min * 100}
           max={UI_SCALE_RANGE.max * 100}
           step={5}
@@ -3768,6 +3817,7 @@ export function App() {
         onExpand={() => handleWindowMode("expanded")}
         availableUpdate={availableUpdate}
         onOpenUpdate={handleOpenUpdate}
+        onStripScaleDragged={setStripScaleState}
       />
     );
   }

--- a/src/usageClient.js
+++ b/src/usageClient.js
@@ -137,6 +137,14 @@ function demoSnapshot(period = "today") {
           { key: "seven_day", label: "每周", view: demoQuotaView(76, 4_320) },
         ],
       },
+      {
+        agent: "kimiwork",
+        windows: [
+          { key: "five_hour", label: "Session", view: demoQuotaView(39, 92) },
+          { key: "seven_day", label: "每周", view: demoQuotaView(88, 5_490) },
+          { key: "monthly_cycle", label: "月度周期", view: demoQuotaView(78, 33_120) },
+        ],
+      },
       // OpenCode 与 WorkBuddy 现实中没有官方配额来源：窗口列表保持为空。
       { agent: "opencode", windows: [] },
       {
@@ -195,6 +203,7 @@ function demoSnapshot(period = "today") {
       { id: "antigravity-live", kind: "local", label: "Antigravity 用量", detail: "来自本机 language server 实时 RPC；IDE 未运行时为 0，不估算。尚未实机验收。", quality: "exact", qualityLabel: "精确解析" },
       { id: "workbuddy-local", kind: "local", label: "WorkBuddy 本地 Token", detail: "读取 CodeBuddy/WorkBuddy 会话转录的 usage 字段并以消息标识去重；未安装时保持为 0。", quality: "exact", qualityLabel: "精确解析" },
       { id: "qoder-quota", kind: "official", label: "Qoder 官方 Credits", detail: "设置 QODER_COOKIE 环境变量后读取官网额度；本地不落 token 用量，无本地统计。", quality: "official", qualityLabel: "官方" },
+      { id: "kimiwork-quota", kind: "official", label: "Kimi Work 官方配额", detail: "读取本机 Kimi Work 桌面端明文存储的 Web 凭据，查询订阅配额接口；本地 token 用量解析是后续项。", quality: "official", qualityLabel: "官方" },
     ],
     indexing: { pending: 0 },
   };

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -154,7 +154,10 @@ async function applyWebviewZoom(factor) {
   await api
     .getCurrentWebview()
     .setZoom(factor)
-    .catch(() => {});
+    .catch((error) => {
+      // zoom 失败会让视口与物理尺寸失配（320 内容被裁），不能静默吞掉。
+      console.warn("Unable to apply the webview zoom.", error);
+    });
 }
 
 /// 启动时就地应用缩放系数（不走 applyWindowMode 的 hide/show，避免闪烁）。
@@ -169,22 +172,25 @@ async function applyStartupUiScale(mode) {
   if (mode !== "compact" || uiScale === 1) return;
   const appWindow = api.getCurrentWindow();
   const size = WINDOW_SIZES.compact;
-  await appWindow.setSize(
-    await scaledPhysicalSize(api, appWindow, size.width, compactContentHeight(size.height)),
-  );
-  await clampIntoWorkArea(api, appWindow);
+  const physical = await scaledPhysicalSize(api, appWindow, size.width, compactContentHeight(size.height));
+  expectedPhysical.compact = physical;
+  await appWindow.setSize(physical);
+  await clampIntoWorkArea(api, appWindow, physical);
 }
 
 /// 窗口重设尺寸后可能伸出屏幕（固定状态下竖条切横条最典型：位置不动、
 /// 宽度暴涨，控制按钮全在屏幕外，固定态又没有拖拽区，用户就被锁死了）。
 /// 把窗口钳回重叠面积最大的显示器工作区内；完全不与任何屏幕重叠时
 /// 返回 false，由调用方居中。
-async function clampIntoWorkArea(api, appWindow) {
-  const [pos, outer, monitors] = await Promise.all([
+/// knownOuter：调用方刚算出的物理尺寸。setSize 异步生效，紧接着读 outerSize
+/// 会拿到旧值（实测拿到过 ~0），把变高的窗口钳错——传入时跳过 outerSize 读取。
+async function clampIntoWorkArea(api, appWindow, knownOuter = null) {
+  const [pos, readOuter, monitors] = await Promise.all([
     appWindow.outerPosition().catch(() => null),
-    appWindow.outerSize().catch(() => null),
+    knownOuter ? null : appWindow.outerSize().catch(() => null),
     api.availableMonitors().catch(() => []),
   ]);
+  const outer = knownOuter || readOuter;
   if (!pos || !outer || !(monitors || []).length) return false;
   let best = null;
   let bestOverlap = 0;
@@ -411,10 +417,34 @@ async function updateMacStatusItems(items) {
   });
 }
 
-// 当前窗口形态：拖宽→缩放的 onResized 监听靠它区分"用户拖卡片"与
-// "形态切换的程序性 resize"（后者宽度必然剧变，误判会把 zoom 写崩——
+// 当前窗口形态：拖拽→缩放的 onResized 监听靠它区分"用户拖悬浮窗"与
+// "形态切换的程序性 resize"（后者尺寸必然剧变，误判会把 zoom 写崩——
 // 完整视图 1120 宽会被当成拖到 2 倍，实测踩过）。同步赋值，先于任何 await。
 let activeWindowMode = null;
+
+// 最近一次程序性 setSize 下发的物理尺寸（按悬浮形态分记）：onResized 是同步
+// 回调，等不起异步的 scaleFactor，靠它同步区分"用户拖出的尺寸差"与"程序性
+// resize 的回声"；也充当胶囊条当前方向的推断依据（竖条恒窄高、横条恒宽矮）。
+const expectedPhysical = { compact: null, strip: null };
+
+// 用户拖拽标记的时长要覆盖 260ms 去抖 + 缩放应用的异步耗时：内容自愈/测量
+// 观察器（60–120ms）比去抖跑得快，不标记就会抢先把拖拽回弹。
+const USER_RESIZE_MARK_MS = 700;
+// 手势结束（程序化 setSize 回弹完成）后再留 400ms，观察器才恢复介入。
+const USER_RESIZE_TAIL_MS = 400;
+
+let compactUserResizeUntil = 0;
+let stripUserResizeUntil = 0;
+
+/// 卡片是否处于用户拖拽（等比缩放手势）中：期间内容自愈观察器一律不介入。
+function isCompactUserResizing() {
+  return Date.now() < compactUserResizeUntil;
+}
+
+/// 胶囊条是否处于用户拖拽（等比缩放手势）中：期间内容测量观察器不弹回。
+function isStripUserResizing() {
+  return Date.now() < stripUserResizeUntil;
+}
 
 async function applyWindowMode(mode, options = {}) {
   activeWindowMode = mode;
@@ -487,8 +517,15 @@ async function applyWindowMode(mode, options = {}) {
   if (mode === "strip") {
     const width = Math.max(size.minWidth, Math.round(options.width || size.width));
     const height = Math.max(size.minHeight, Math.round(options.height || size.height));
-    await appWindow.setSize(await scaledPhysicalSize(api, appWindow, width, height, stripScale));
-    await appWindow.setResizable(false);
+    const physical = await scaledPhysicalSize(api, appWindow, width, height, stripScale);
+    expectedPhysical.strip = physical;
+    await appWindow.setSize(physical);
+    // 胶囊条开放拖拽调整：拖主轴映射为缩放系数（startStripResizeScale），
+    // 副轴-only 拖拽由内容测量观察器弹回设计常量；最小尺寸跟随当前系数。
+    await appWindow.setResizable(true);
+    await appWindow.setMinSize(
+      new api.LogicalSize(size.minWidth * stripScale, size.minHeight * stripScale),
+    );
     // 有记忆位置回记忆位置；首次进入保持当前位置（出现在卡片原地）。
     const storedStrip = readStoredPosition("strip");
     const stripTarget =
@@ -507,11 +544,22 @@ async function applyWindowMode(mode, options = {}) {
     return;
   }
 
-  await appWindow.setSize(
-    await scaledPhysicalSize(api, appWindow, size.width, compactContentHeight(size.height)),
+  const compactPhysical = await scaledPhysicalSize(
+    api,
+    appWindow,
+    size.width,
+    compactContentHeight(size.height),
   );
-  // 卡片开放拖拽调整：拖宽度映射为缩放系数（startCompactResizeScale），
-  // 高度拖动会被内容自愈观察器收敛回去。
+  expectedPhysical.compact = compactPhysical;
+  // setSize 失败不能中断 apply（窗口会停在 hidden 状态）：告警后继续，
+  // 尺寸偏差由内容自愈观察器收敛。
+  try {
+    await appWindow.setSize(compactPhysical);
+  } catch (error) {
+    console.warn("Unable to apply the compact window size.", error);
+  }
+  // 卡片开放拖拽调整：拖任意边/角都等比映射为缩放系数
+  // （startCompactResizeScale），窗口随即回弹到等比尺寸，卡片永远不会被拉变形。
   await appWindow.setResizable(true);
   await appWindow.setMinSize(new api.LogicalSize(size.minWidth * uiScale, size.minHeight * uiScale));
 
@@ -559,7 +607,10 @@ async function resizeStripWindow({ width, height }) {
     anchor.bottom = Math.abs(pos.y + outer.height - workBottom) <= 8;
   }
   const physical = await scaledPhysicalSize(api, appWindow, targetWidth, targetHeight, stripScale);
-  await appWindow.setSize(physical).catch(() => {});
+  expectedPhysical.strip = physical;
+  await appWindow.setSize(physical).catch((error) => {
+    console.warn("Unable to resize the strip window.", error);
+  });
   // 测量收敛出的尺寸记作下次变形的首帧（否则首帧永远是常量估计）。
   rememberStripSize(targetWidth, targetHeight);
   if ((anchor.right || anchor.bottom) && pos && workArea) {
@@ -574,8 +625,9 @@ async function resizeStripWindow({ width, height }) {
       .catch(() => {});
   }
   // 变宽/变高可能把窗口顶出屏幕（固定态没有拖拽区，一出去就够不着了）；
+  // 钳位用刚算出的 physical（setSize 异步生效，此刻读 outerSize 是旧值）；
   // 完全掉出所有屏幕时居中找回，胶囊条永远看得见、够得着。
-  const clamped = await clampIntoWorkArea(api, appWindow);
+  const clamped = await clampIntoWorkArea(api, appWindow, physical);
   if (!clamped) await appWindow.center().catch(() => {});
 }
 
@@ -596,13 +648,16 @@ async function resizeCompactWindow({ height }) {
     const capCss = monitor.workArea.size.height / factor / uiScale - 48;
     targetHeight = Math.min(targetHeight, Math.max(size.minHeight, Math.floor(capCss)));
   }
-  await appWindow
-    .setSize(await scaledPhysicalSize(api, appWindow, size.width, targetHeight))
-    .catch(() => {});
+  const physical = await scaledPhysicalSize(api, appWindow, size.width, targetHeight);
+  expectedPhysical.compact = physical;
+  await appWindow.setSize(physical).catch((error) => {
+    console.warn("Unable to resize the compact window.", error);
+  });
   // 高度收敛值记作下次变形的首帧。
   rememberCompactHeight(targetHeight);
-  // 变高可能把窗口底边顶出屏幕；完全掉出所有屏幕时居中找回。
-  const clamped = await clampIntoWorkArea(api, appWindow);
+  // 变高可能把窗口底边顶出屏幕；钳位用刚算出的 physical（setSize 异步生效，
+  // 此刻读 outerSize 是旧值）；完全掉出所有屏幕时居中找回。
+  const clamped = await clampIntoWorkArea(api, appWindow, physical);
   if (!clamped) await appWindow.center().catch(() => {});
 }
 
@@ -615,12 +670,17 @@ async function reassertCompactSize() {
   if (!api) return;
   const appWindow = api.getCurrentWindow();
   const size = WINDOW_SIZES.compact;
-  await appWindow
-    .setSize(
-      await scaledPhysicalSize(api, appWindow, size.width, compactContentHeight(size.height)),
-    )
-    .catch(() => {});
-  await clampIntoWorkArea(api, appWindow);
+  const physical = await scaledPhysicalSize(
+    api,
+    appWindow,
+    size.width,
+    compactContentHeight(size.height),
+  );
+  expectedPhysical.compact = physical;
+  await appWindow.setSize(physical).catch((error) => {
+    console.warn("Unable to reassert the compact window size.", error);
+  });
+  await clampIntoWorkArea(api, appWindow, physical);
 }
 
 /// macOS 菜单栏面板的高度跟随内容（宽度恒为 compact 设计宽）。
@@ -631,12 +691,16 @@ async function resizeMacosPanel({ width, height }) {
   await invoke("resize_macos_panel", { width, height }).catch(() => {});
 }
 
-/// 卡片宽度拖拽 → 缩放系数：用户拖窗口边缘改宽度时，把新宽度映射为
-/// uiScale（新宽 / 320 设计宽），内容 zoom 跟随，高度仍由内容自愈观察器
-/// 收敛——与设置页滑杆共用同一持久化与归一化路径。
-/// 程序性 setSize 也会触发 onResized：宽度与当前缩放的期望值一致（±2 物理
-/// 像素）就忽略，只有用户真拖出的宽度差才生效；去抖到拖拽停止后再应用，
-/// 避免拖动过程中反复 setZoom。
+/// 卡片任意边/角拖拽 → 等比缩放系数：原生无边框窗口无法禁用单边拖拽，所以
+/// 让任意边拖拽都产生"对角拖"的等比结果——新尺寸偏离期望值（宽 = 320×系数、
+/// 高 = 内容×系数）超过 2 物理像素时，把偏离轴映射回 uiScale（宽度优先，
+/// 其次高度），内容 zoom 跟随、窗口回弹到等比尺寸，卡片永远不会被拉变形。
+/// 与设置页滑杆共用同一持久化与归一化路径。
+/// 程序性 setSize 也会触发 onResized：与刚下发的物理尺寸一致（±2 物理像素）
+/// 的回声直接忽略。用户拖出尺寸差的瞬间要同步记下 compactUserResizeUntil——
+/// 内容自愈观察器（120ms）比去抖（260ms）跑得快，不标记就会把拖拽中途回弹；
+/// 手势彻底结束（程序化回弹完成）后再留 400ms 尾巴，观察器才恢复介入。
+/// 去抖到拖拽停止后再应用，避免拖动过程中反复 setZoom。
 async function startCompactResizeScale(onScale) {
   if (!isDesktop() || isMacPlatform()) return () => {};
   const api = await windowApi();
@@ -645,32 +709,118 @@ async function startCompactResizeScale(onScale) {
   let timer = null;
   const unlistenPromise = appWindow.onResized(({ payload }) => {
     // 只认卡片形态下的 resize；形态切换（→expanded/strip）的程序性调整
-    // 宽度剧变，绝不能映射成缩放系数。
+    // 尺寸剧变，绝不能映射成缩放系数。
     if (activeWindowMode !== "compact") return;
+    // 与刚下发尺寸不符的 resize 是用户拖出来的：立即标记拖拽中（同步，
+    // 在去抖之外），内容自愈观察器整个手势期间都不介入。
+    const expected = expectedPhysical.compact;
+    if (
+      expected &&
+      (Math.abs(payload.width - expected.width) > 2 ||
+        Math.abs(payload.height - expected.height) > 2)
+    ) {
+      compactUserResizeUntil = Date.now() + USER_RESIZE_MARK_MS;
+    }
     window.clearTimeout(timer);
     timer = window.setTimeout(async () => {
       // 去抖窗口期内可能已切走形态，再核对一次。
       if (activeWindowMode !== "compact") return;
       const factor = await appWindow.scaleFactor().catch(() => 1);
       const size = WINDOW_SIZES.compact;
-      const expected = Math.round(size.width * uiScale * factor);
-      if (Math.abs(payload.width - expected) <= 2) return;
-      const next = normalizeUiScale(payload.width / factor / size.width);
+      const contentHeight = compactContentHeight(size.height);
+      const expectedWidth = Math.round(size.width * uiScale * factor);
+      const expectedHeight = Math.round(contentHeight * uiScale * factor);
+      // 宽度偏离优先取宽比，其次高比；两轴都符合期望 = 程序性回声，忽略。
+      let ratio;
+      if (Math.abs(payload.width - expectedWidth) > 2) {
+        ratio = payload.width / factor / size.width;
+      } else if (Math.abs(payload.height - expectedHeight) > 2) {
+        ratio = payload.height / factor / contentHeight;
+      } else {
+        return;
+      }
+      const next = normalizeUiScale(ratio);
       if (Math.abs(next - uiScale) < 0.01) return;
       setWindowUiScale(next);
       await applyWebviewZoom(next);
-      // 宽度按归一化后的系数取整回标准值（钳到 0.75–2.0 的边界会体现在这里）；
-      // 高度先沿用缓存值，zoom 变化触发的内容自愈随后精修。
-      await appWindow
-        .setSize(
-          await scaledPhysicalSize(
-            api,
-            appWindow,
-            size.width,
-            compactContentHeight(size.height),
-          ),
-        )
-        .catch(() => {});
+      // 两轴都按归一化后的系数回弹到等比尺寸（钳到 0.75–2.0 的边界会体现在
+      // 这里）；高度先沿用缓存值，zoom 变化触发的内容自愈随后精修。
+      const physical = await scaledPhysicalSize(api, appWindow, size.width, contentHeight);
+      expectedPhysical.compact = physical;
+      await appWindow.setSize(physical).catch((error) => {
+        console.warn("Unable to apply the compact window size.", error);
+      });
+      // 程序化回弹落地后再留一段尾巴，自愈观察器不在手势中途介入。
+      compactUserResizeUntil = Date.now() + USER_RESIZE_TAIL_MS;
+      onScale?.(next);
+    }, 260);
+  });
+  return async () => {
+    window.clearTimeout(timer);
+    const unlisten = await unlistenPromise.catch(() => null);
+    unlisten?.();
+  };
+}
+
+/// 胶囊条拖拽 → 等比缩放系数：与卡片同一思路。主轴（竖条 = 高、横条 = 宽）
+/// 偏离期望值（内容×系数）超过 2 物理像素时映射回 stripScale，内容 zoom
+/// 跟随、窗口回弹到等比尺寸；副轴-only 拖拽不处理，由 StripBar 的内容测量
+/// 观察器弹回设计常量（它不标记拖拽中，所以观察器会立即介入）。与设置页
+/// 滑杆共用同一持久化与归一化路径。
+async function startStripResizeScale(onScale) {
+  if (!isDesktop() || isMacPlatform()) return () => {};
+  const api = await windowApi();
+  if (!api) return () => {};
+  const appWindow = api.getCurrentWindow();
+  let timer = null;
+  const unlistenPromise = appWindow.onResized(({ payload }) => {
+    if (activeWindowMode !== "strip") return;
+    // 只有主轴被拖才标记拖拽中：副轴-only 拖拽要留给内容测量观察器立即
+    // 弹回（一旦标记，它就袖手旁观了）。
+    const expected = expectedPhysical.strip;
+    if (expected) {
+      const vertical = expected.height > expected.width;
+      const mainDiff = vertical
+        ? Math.abs(payload.height - expected.height)
+        : Math.abs(payload.width - expected.width);
+      if (mainDiff > 2) stripUserResizeUntil = Date.now() + USER_RESIZE_MARK_MS;
+    }
+    window.clearTimeout(timer);
+    timer = window.setTimeout(async () => {
+      // 去抖窗口期内可能已切走形态，再核对一次。
+      if (activeWindowMode !== "strip") return;
+      const factor = await appWindow.scaleFactor().catch(() => 1);
+      // 方向从当前窗口尺寸推断（竖条恒窄高、横条恒宽矮，与 rememberStripSize
+      // 一致）；尺寸记录缺失时用 payload 宽高比兜底。
+      const current = expectedPhysical.strip;
+      const vertical = current
+        ? current.height > current.width
+        : payload.height > payload.width;
+      const orientation = vertical ? "vertical" : "horizontal";
+      const constants = WINDOW_SIZES.strip;
+      const css = stripContentSize(orientation, {
+        width: vertical ? constants.minWidth : constants.width,
+        height: vertical ? constants.width : constants.height,
+      });
+      const cssMain = vertical ? css.height : css.width;
+      const payloadMain = vertical ? payload.height : payload.width;
+      const expectedMain = Math.round(cssMain * stripScale * factor);
+      // 副轴-only 拖拽：忽略，由内容测量观察器弹回设计常量。
+      if (Math.abs(payloadMain - expectedMain) <= 2) return;
+      const next = normalizeUiScale(payloadMain / factor / cssMain);
+      if (Math.abs(next - stripScale) < 0.01) return;
+      setStripScale(next);
+      await applyWebviewZoom(next);
+      // 两轴都按归一化后的系数回弹到内容等比尺寸。
+      const physical = new api.PhysicalSize(
+        Math.round(css.width * next * factor),
+        Math.round(css.height * next * factor),
+      );
+      expectedPhysical.strip = physical;
+      await appWindow.setSize(physical).catch((error) => {
+        console.warn("Unable to apply the strip window size.", error);
+      });
+      stripUserResizeUntil = Date.now() + USER_RESIZE_TAIL_MS;
       onScale?.(next);
     }, 260);
   });
@@ -977,8 +1127,10 @@ export {
   closeWindow,
   getAutostart,
   installUpdate,
+  isCompactUserResizing,
   isDesktop,
   isMacPlatform,
+  isStripUserResizing,
   minimizeWindow,
   normalizeUiScale,
   onScaleFactorChanged,
@@ -1001,6 +1153,7 @@ export {
   startCompactResizeScale,
   startEdgeDock,
   startPositionMemory,
+  startStripResizeScale,
   stripContentSize,
   toggleMaximizeWindow,
 };


### PR DESCRIPTION
## Scope

shared + Windows（按 AGENTS.md 申报的组合范围；macOS 未触碰——菜单栏 spec 按 workbuddy/qoder 先例不扩展）

## 内容

### shared：新 provider Kimi Work（kimiwork，配额-only）
- 凭据：kimi-desktop userData 里明文存的 kimi.com Web token（bridge-store/token-store.json 主，daimon config.json 备），只读不刷新。
- 接口：`POST www.kimi.com/apiv2/kimi.gateway.membership.v2.MembershipService/GetSubscriptionStats`（connect-RPC，空 JSON body + Bearer，x-msh-* 头实测非必需）。**已在本机真实账号调通**（5h 窗/7d 窗/月度 OMNI 周期三个窗口）。
- 礼品余额（GIFT）与加速钱包（boosterWallets）键语义不同，先不展示；daimon 运行时的本地 wire.jsonl 解析是后续项（与 Kimi 同格式）。
- 真机夹具测试 + ignored live 烟测；失败照 qoder/kimi 先例保留旧行并标陈旧，绝不合成数字。

### shared：Claude 重置时间哨兵修复
- 实机发现 Claude Code statusLine 在重置时间未知时下发 `resets_at=1900000000`（≈2030 年），UI 显示"1331 天后重置"。
- `domain::sane_resets_at_ms`：重置时间必须落在窗口语义内（5h ~6h、7d ~8d、其他 ~35 天），越界丢弃——宁可不显示倒计时。hook 与 OAuth 两条来源都接入，kimiwork 同样走这个校验。

### Windows：悬浮形态缩放与裁切修复
- 卡片拖任意边/角都等比缩放（原来只有横向有效、纵向被弹回）；胶囊条新增主轴拖拽等比缩放（持久化到 `metrik:stripScale`）；手势期间内容自愈/测量观察器回避，不再互相抢。
- 卡片右侧裁切（zoom×物理尺寸失配）：自愈从"3 次终身上限"改为 2s 节流重试；`setZoom/setSize` 失败不再静默；`applyWindowMode` 的 `setSize` 失败不会把窗口撂在隐藏态。
- 竖条底部裁切：`clampIntoWorkArea` 改用刚算出的尺寸（不再读异步 `setSize` 后的旧 `outerSize`）；webfont 换字后补测一次。

## 验证

- `npm test` 3/3、`vite build` 通过；浏览器预览三种形态 + Kimi Work 卡片/竖条格截图确认。
- Kimi Work 端点与凭据提取已真机实测（HTTP 200）。
- **注意：本机没有 Rust 工具链，`cargo test`/`cargo fmt`/`clippy` 未在本地跑过，CI 是编译门禁。** 新增 Rust 测试（哨兵修复 ×2、kimiwork 夹具 ×2）随 CI 执行。
- 窗口边框拖拽属于原生手势，浏览器无法自动化；合入后随 0.11.0 在 Windows 真机验收。

## 不发版说明

本 PR 不含版本号变更；发布走随后的 release/v0.11.0（0.10.1 的遗留问题已先修复：PR #26 合入 main，tag 重回历史线）。
