### PR TITLE
Release 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.10.1"
+version = "0.11.0"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Release 0.11.0

版本五件套（package.json / package-lock.json / tauri.conf.json / Cargo.toml / Cargo.lock）0.10.1 → 0.11.0，tag v0.11.0 已推送（Release 构建并行进行中）。

### 内容（来自 #27，scope: shared + Windows）

- **新 provider Kimi Work**（配额-only）：kimi-desktop 明文 Web token → MembershipService/GetSubscriptionStats，5h/7d 滚动窗 + 月度 OMNI 周期；已真机账号调通。
- **Claude 重置时间哨兵修复**：statusLine 下发 1900000000s（≈2030 年）导致 "1331 天后重置"，现按窗口语义丢弃不合理重置时间。
- **Windows 悬浮形态**：卡片任意边/角拖拽等比缩放；胶囊条新增主轴拖拽缩放；卡片右侧裁切与竖条底部裁切两处加固。

### 已知边界

- macOS 未实机验收（与既有声明一致），Kimi Work 未加菜单栏 spec（同 workbuddy/qoder 先例）。
- 窗口边框拖拽为原生手势，合入后在 Windows 真机验收。
- v0.10.1 的 Release 草稿从未发布（资产齐全）；本版本发布后它即作废，可随手清理。
