### PR TITLE
Release 0.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.11.0"
+version = "0.11.1"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Release 0.11.1

版本五件套 0.11.0 → 0.11.1，tag v0.11.1 已推送（Release 构建并行进行中）。

### 内容（来自 #29，scope: Windows）

- 卡片只在四角拖拽缩放（向外放大、向内缩小）；单边拖拽一律回弹——修掉 0.11.0 验收反馈的"顶边向上拖反而放大"。
- 左/上侧角拖时窗口不再"走路"（对角锚点）；胶囊条主轴拖拽同样补锚点；最小尺寸即时跟随新系数。