### PR TITLE
Release 0.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.11.1"
+version = "0.11.2"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Release 0.11.2

版本五件套 0.11.1 → 0.11.2，tag v0.11.2 已推送（Release 构建并行进行中）。

### 内容（来自 #31，scope: Windows）

- **移除拖拽缩放**（0.11.0–0.11.1 两轮真机验收结论：无边框窗口无法把原生 resize 命中区限制在四角，拖动过程边缘始终可拉，"只能四角"名实不符）。缩放统一走设置页滑杆（小组件缩放 / 胶囊条缩放，0.75–2.0）。
- 保留 0.11.x 全部加固：卡片右侧裁切与竖条底部裁切修复、Claude 重置时间哨兵修复、Kimi Work 配额源。
