### PR TITLE
Release 0.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.11.2"
+version = "0.11.3"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Release 0.11.3

版本五件套 0.11.2 → 0.11.3，tag v0.11.3 已推送（Release 构建并行进行中）。

### 内容（来自 #33，scope: Windows）

- 修复 statusLine 串联委托在 Windows PowerShell 5.1 下随机整段丢输出：有自定义 statusLine（bash/exe 等）的用户，重装 Metrik 钩子后原 statusLine 会消失只剩配额尾巴。非 ps1 委托改用临时文件 + Start-Process 重定向传输（真机验证），配额采集与用户自定义 statusLine 显示现在可以同时工作。
- 提示：在设置里开启 Claude OAuth 配额来源的用户不受钩子/串联影响（OAuth 优先、钩子回落）。
