### PR TITLE
Release 0.11.6: fix silent statusLine breakage on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.11.5"
+version = "0.11.6"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/src/claude_hook.rs
+++ b/src-tauri/src/claude_hook.rs
@@ -263,11 +263,42 @@ impl ClaudeHook {
         }
     }
 
+    /// `render_script` 的逆操作：从已安装的脚本里回读被串联的原命令。
+    ///
+    /// 备份文件是用户可见的普通文件，会被清理 `.claude`、同步工具或杀软
+    /// 删掉。备份没了而 statusLine 仍是我们的时，重装若把 delegate 当成空，
+    /// 用户原有的 statusLine 就永久消失（备份已不在，卸载也还原不回来）。
+    /// 脚本本身带着 delegate，是这种情况下唯一的真相源。
+    fn installed_delegate(&self) -> Option<String> {
+        let script = std::fs::read_to_string(self.script_path()).ok()?;
+        #[cfg(windows)]
+        {
+            // 生成时 `'` 转义成 `''`，这里反向还原。
+            let line = script
+                .lines()
+                .find_map(|l| l.strip_prefix("$delegate = '"))?;
+            Some(line.strip_suffix('\'')?.replace("''", "'"))
+        }
+        #[cfg(not(windows))]
+        {
+            let line = script.lines().find_map(|l| l.strip_prefix("DELEGATE = "))?;
+            serde_json::from_str::<String>(line).ok()
+        }
+    }
+
+    /// Windows 上必须是「带引号的绝对路径」，两个条件缺一不可：
+    /// 绝对路径——Path 被写成 REG_SZ 的机器上 `%SystemRoot%` 不展开，
+    /// System32 不在任何进程的 PATH 里，裸 `powershell` 解析不到；
+    /// 引号——Claude Code 经 Git Bash 执行 statusLine，裸路径的反斜杠
+    /// 会被 bash 当转义符吃掉（C:\Windows\... → C:Windows...）。
+    /// 两种失败都是 exit 127 + 零输出，状态栏只表现为空白。
     fn hook_command(&self) -> String {
         let script = self.script_path();
         if cfg!(windows) {
+            let system_root =
+                std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_owned());
             format!(
-                "powershell -NoProfile -ExecutionPolicy Bypass -File \"{}\"",
+                "\"{system_root}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -NoProfile -ExecutionPolicy Bypass -File \"{}\"",
                 script.display()
             )
         } else {
@@ -332,14 +363,16 @@ impl ClaudeHook {
         // 已有他人 statusLine：备份原设置并串联其 command；重装时沿用已备份的命令。
         let mut delegate = String::new();
         if self.status_line_is_ours(&settings) {
-            if let Some(command) = self
+            delegate = self
                 .read_backup()
                 .as_ref()
                 .and_then(|backup| backup.get("command"))
                 .and_then(Value::as_str)
-            {
-                delegate = command.to_owned();
-            }
+                .map(str::to_owned)
+                // 备份被删而脚本还在：从脚本回读。否则这里会把 delegate 当成
+                // 空的重装成「无委托」，用户原有的 statusLine 就永久没了。
+                .or_else(|| self.installed_delegate())
+                .unwrap_or_default();
         } else if let Some(existing) = settings
             .get("statusLine")
             .filter(|value| !value.is_null())
@@ -384,7 +417,13 @@ impl ClaudeHook {
                 .as_object_mut()
                 .context("settings.json 顶层不是对象")?;
             // 串联安装的：把用户原有的 statusLine 原样恢复。
-            match self.read_backup() {
+            // 备份被删时退而求其次，用脚本里的原命令重建——宁可丢 padding
+            // 之类的次要字段，也不能把用户的 statusLine 整个删掉。
+            let restored = self.read_backup().or_else(|| {
+                let delegate = self.installed_delegate().filter(|d| !d.is_empty())?;
+                Some(json!({ "type": "command", "command": delegate, "padding": 0 }))
+            });
+            match restored {
                 Some(backup) => {
                     root.insert("statusLine".into(), backup);
                 }
@@ -493,6 +532,26 @@ mod tests {
         assert!(!hook.script_path().exists());
     }
 
+    /// 回归：statusLine 由 Git Bash 执行，命令必须是带引号的绝对路径。
+    /// 裸 `powershell`（PATH 解析不到）和不带引号的绝对路径（反斜杠被
+    /// bash 吃掉）都会静默 exit 127，状态栏空白且钩子从不落盘。
+    #[cfg(windows)]
+    #[test]
+    fn windows_hook_command_is_quoted_absolute_path() {
+        let test = TestDirectory::new("hookcmd");
+        let command = ClaudeHook::with_dir(test.path().to_path_buf()).hook_command();
+        assert!(command.starts_with('"'), "exe 路径必须加引号: {command}");
+        let exe = command[1..].split('"').next().unwrap();
+        assert!(
+            exe.to_ascii_lowercase().ends_with("powershell.exe"),
+            "第一个 token 应是 powershell.exe: {command}"
+        );
+        assert!(
+            std::path::Path::new(exe).is_absolute(),
+            "必须用绝对路径，不能依赖 PATH: {command}"
+        );
+    }
+
     #[test]
     fn existing_foreign_status_line_is_chained_and_restored() {
         let test = TestDirectory::new("chain");
@@ -543,6 +602,36 @@ mod tests {
         assert_eq!(settings["statusLine"]["command"], "my-own-line 'quoted'");
         assert_eq!(settings["statusLine"]["padding"], 0);
         assert!(!test.path().join(BACKUP_FILE).exists());
+    }
+
+    /// 回归：备份文件被删掉（用户清理 .claude、同步工具、杀软）之后，
+    /// 重装不能把用户原有的 statusLine 静默降级成「无委托」，卸载也不能
+    /// 把 statusLine 整个删掉——两者都会让原配置永久消失。
+    #[test]
+    fn deleted_backup_recovers_delegate_from_installed_script() {
+        let test = TestDirectory::new("lostbackup");
+        fs::write(
+            test.path().join("settings.json"),
+            r#"{"statusLine": {"type": "command", "command": "my-own-line 'quoted'", "padding": 0}}"#,
+        )
+        .unwrap();
+        let hook = ClaudeHook::with_dir(test.path().to_path_buf());
+        hook.install().unwrap();
+
+        // 备份没了，但 statusLine 仍指向 Metrik 脚本。
+        fs::remove_file(test.path().join(BACKUP_FILE)).unwrap();
+
+        // 重装：delegate 必须从脚本回读，不能退化成无委托。
+        hook.install().unwrap();
+        let script = fs::read_to_string(hook.script_path()).unwrap();
+        assert!(script.contains("my-own-line"), "重装丢了 delegate");
+
+        // 卸载：按脚本里的原命令还原，而不是删掉 statusLine。
+        hook.uninstall().unwrap();
+        let settings: Value =
+            serde_json::from_str(&fs::read_to_string(test.path().join("settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(settings["statusLine"]["command"], "my-own-line 'quoted'");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
**Scope: shared**（改动落在 `claude_hook.rs`，Windows 分支是行为变化，非 Windows 分支只是新增回读逻辑、行为不变）

## 问题

生成的 statusLine 命令在部分 Windows 机器上静默失效——状态栏空白、钩子也从不落盘。两个独立原因，都表现为 exit 127 + 零输出，所以从表象上完全分不出来：

- **裸 `powershell` 解析不到。** 系统 `Path` 被写成 `REG_SZ`（而不是 `REG_EXPAND_SZ`）的机器上 `%SystemRoot%` 不展开，System32 不在任何进程的 PATH 里。
- **只换成绝对路径也不够。** Claude Code 经 Git Bash 执行 statusLine，没引号的 `C:\Windows\...` 反斜杠会被 bash 当转义符吃掉（`C:\Windows\...` → `C:Windows...`）。

`hook_command` 现在生成「带引号的绝对路径」，两个条件同时满足。

## 顺带堵住两条会永久丢用户配置的路径

备份文件 `metrik-statusline.backup.json` 是用户可见的普通文件，会被清理 `.claude`、同步工具或杀软删掉。备份没了而 statusLine 仍是我们的时：

- **重装**会把 delegate 当成空，退化成「无委托」——用户原有的 statusLine 就此消失，且卸载也还原不回来（备份已不在）。
- **卸载**会把 `statusLine` 整个从 settings.json 删掉。

已安装的脚本本身带着 delegate，`installed_delegate()` 把它当作第二真相源回读（`render_script` 的逆操作，Windows 走 `$delegate = '...'`，其他平台走 `DELEGATE = "..."`）。

## 验证

两条新回归测试覆盖上述两处。**把三处修复退回原样后重跑，精确只有这两条失败**，其余 5 条既有测试照过——原来的测试覆盖不到这两条路径，这就是 bug 能发出去的原因。

本机 `cargo test` 因工具链问题跑不起来（GNU 的测试 exe 启动即 `0xC0000409`，MSVC 缺 `link.exe`），测试是把 `claude_hook.rs` 逐字节复制进一个独立 crate 跑的（`cmp` 确认一致），7/7 通过。**CI 的 windows-latest 用的是正常 MSVC，这两条测试会在这里真跑，以 CI 结果为准。**

本地已过：`npm run build`、`npm test` 7/7、`cargo fmt --check`、`cargo clippy -- -D warnings`。

## 已知遗留（不在本 PR）

装上 0.11.6 **不会**自动修好已经坏掉的 `settings.json`——`install()` 只有 UI 开关一个入口，升级和开机都不重跑它。受影响的用户得手动关一次再开。是否加开机自愈另议。

🤖 Generated with [Claude Code](https://claude.com/claude-code)