### PR TITLE
Release 0.12.0: 启动时自愈已经写坏的 statusLine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.11.6",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.11.6",
+      "version": "0.12.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.11.6",
+  "version": "0.12.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.11.6"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.11.6"
+version = "0.12.0"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/src/claude_hook.rs
+++ b/src-tauri/src/claude_hook.rs
@@ -410,6 +410,32 @@ impl ClaudeHook {
         self.status()
     }
 
+    /// 启动时自愈：statusLine 已经属于 Metrik，但命令过时或脚本不在了，重装一次。
+    ///
+    /// `install()` 只有界面上那个开关会调，升级和开机都不会。所以旧版本写坏的
+    /// statusLine 升级之后依然是坏的：用户看到空白状态栏，而 Metrik 界面显示
+    /// 「已安装」，没有任何线索提示他去关一次开关再打开。修一版生成器救不了
+    /// 已经写坏的那批人，得在启动时回头补一次。
+    ///
+    /// 两条边界：statusLine 不属于 Metrik 时一律不碰，这是别人的配置；命令已经
+    /// 正确且脚本在位时不写盘，否则每次启动都动 settings.json。
+    pub fn repair(&self) -> Result<bool> {
+        let settings = self.read_settings()?;
+        if !self.status_line_is_ours(&settings) {
+            return Ok(false);
+        }
+        let installed_command = settings
+            .get("statusLine")
+            .and_then(|value| value.get("command"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if installed_command == self.hook_command() && self.script_path().exists() {
+            return Ok(false);
+        }
+        self.install()?;
+        Ok(true)
+    }
+
     pub fn uninstall(&self) -> Result<ClaudeHookStatus> {
         let mut settings = self.read_settings()?;
         if self.status_line_is_ours(&settings) {
@@ -602,6 +628,68 @@ mod tests {
         assert_eq!(settings["statusLine"]["command"], "my-own-line 'quoted'");
         assert_eq!(settings["statusLine"]["padding"], 0);
         assert!(!test.path().join(BACKUP_FILE).exists());
+    }
+
+    /// 启动自愈：旧版本写坏的命令要修好，串联的原命令不能在修复中丢掉。
+    #[test]
+    fn repair_rewrites_a_stale_command_and_keeps_the_delegate() {
+        let test = TestDirectory::new("repairstale");
+        fs::write(
+            test.path().join("settings.json"),
+            r#"{"statusLine": {"type": "command", "command": "my-own-line", "padding": 0}}"#,
+        )
+        .unwrap();
+        let hook = ClaudeHook::with_dir(test.path().to_path_buf());
+        hook.install().unwrap();
+
+        // 模拟旧版本留下的坏命令：仍指向 Metrik 脚本，但不是当前生成器的产物。
+        let stale = format!("powershell -File {}", hook.script_path().display());
+        fs::write(
+            test.path().join("settings.json"),
+            format!(
+                r#"{{"statusLine": {{"type": "command", "command": {}, "padding": 0}}}}"#,
+                serde_json::to_string(&stale).unwrap()
+            ),
+        )
+        .unwrap();
+
+        assert!(hook.repair().unwrap(), "过时的命令应该被修复");
+        let settings: Value =
+            serde_json::from_str(&fs::read_to_string(test.path().join("settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(settings["statusLine"]["command"], hook.hook_command());
+        let script = fs::read_to_string(hook.script_path()).unwrap();
+        assert!(script.contains("my-own-line"), "自愈把 delegate 丢了");
+
+        // 已经正确：不再写盘，否则每次启动都动 settings.json。
+        assert!(!hook.repair().unwrap(), "命令正确时不该重写");
+
+        // 命令没问题但脚本被删掉了，状态栏同样是空的，也要补回来。
+        fs::remove_file(hook.script_path()).unwrap();
+        assert!(hook.repair().unwrap(), "脚本丢失应该被补回");
+        assert!(hook.script_path().exists());
+    }
+
+    /// 自愈只修 Metrik 自己的 statusLine。别人的配置——包括用户压根没装钩子
+    /// 的情况——一律不碰，否则自愈本身就变成了这次要修的那种覆盖。
+    #[test]
+    fn repair_never_touches_a_foreign_or_absent_status_line() {
+        let test = TestDirectory::new("repairforeign");
+        let hook = ClaudeHook::with_dir(test.path().to_path_buf());
+
+        // 没有 settings.json：不该无中生有装一个钩子。
+        assert!(!hook.repair().unwrap());
+        assert!(!test.path().join("settings.json").exists());
+
+        // 别人的 statusLine：原样保留。
+        let foreign = r#"{"statusLine": {"type": "command", "command": "my-own-line"}}"#;
+        fs::write(test.path().join("settings.json"), foreign).unwrap();
+        assert!(!hook.repair().unwrap());
+        let settings: Value =
+            serde_json::from_str(&fs::read_to_string(test.path().join("settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(settings["statusLine"]["command"], "my-own-line");
+        assert!(!hook.script_path().exists());
     }
 
     /// 回归：备份文件被删掉（用户清理 .claude、同步工具、杀软）之后，

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1266,6 +1266,17 @@ pub fn run() {
                     emergency_database_path()
                 }
             };
+            // 旧版本写坏的 statusLine 只有用户手动关一次开关才会重写，而界面显示
+            // 的是「已安装」，没人会想到去切。启动时静默补一次，坏在旧版本上的人
+            // 升级即恢复。不属于 Metrik 的 statusLine 不会被碰。
+            match claude_hook::ClaudeHook::detected().repair() {
+                Ok(true) => eprintln!("Metrik repaired a stale Claude Code statusLine hook"),
+                Ok(false) => {}
+                Err(error) => eprintln!(
+                    "Metrik could not check the Claude Code statusLine hook ({error:#})"
+                ),
+            }
+
             app.manage(AppState {
                 database_path,
                 scan_gate: Arc::new(Mutex::new(())),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.11.6",
+  "version": "0.12.0",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
**Scope: shared**

## 为什么 0.11.6 不够

0.11.6 修好了 statusLine 命令的生成器，但**救不了已经被写坏的那批人**。`install()` 只有界面上那个开关一个入口，升级和开机都不重跑它——所以旧版本写进去的坏命令升级之后依然是坏的。

用户那边看到的是：状态栏空白，而 Metrik 界面显示「已安装」，没有任何线索提示他去关一次开关再打开。挨个通知用户手动切一次不现实。

## 做法

`ClaudeHook::repair()`，在 `lib.rs` 的 `.setup()` 里启动时调一次。三条边界都是刻意的：

- **statusLine 不属于 Metrik 时一律不碰。** 否则自愈本身就成了这次要修的那种覆盖，是这里最要命的失败模式。
- **命令已经正确且脚本在位时不写盘。** 不然每次启动都动 `settings.json`，还会去撞并发写的丢更新窗口。
- **命令没问题但脚本被删掉时同样算坏**——状态栏一样是空的，顺手补回来。

修复走既有的 `install()`，所以 0.11.6 那套「备份没了就从脚本回读 delegate」的兜底自动生效：自愈不会把用户串联的原命令弄丢，有断言盯着。失败只打日志，不影响启动。

## 验证

两条新测试分别盯着「修好过时命令且不丢 delegate」和「不碰别人的/不存在的配置」。

**变异测试证明它们有牙：**

| 破坏的东西 | 失败的测试 |
|---|---|
| 去掉「不碰别人配置」守卫 | `repair_never_touches_a_foreign_or_absent_status_line` |
| 把自愈改成空操作（即 0.11.6 的行为） | `repair_rewrites_a_stale_command_and_keeps_the_delegate` |

两次都是精确只有对应那一条失败，其余 8 条照过。第二条尤其说明这组测试能抓住 0.11.6 的缺口本身。

本机 `cargo test` 因工具链问题跑不起来（GNU 测试 exe 启动即 `0xC0000409`，MSVC 缺 `link.exe`），上述 9/9 是把 `claude_hook.rs` 逐字节复制进独立 crate 跑的（`cmp` 确认一致）。**以 CI 的 windows-latest（正常 MSVC）结果为准。**

本地已过：`cargo fmt --check`、`cargo clippy -- -D warnings`（都直接读退出码确认）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)