### PR TITLE
Release 0.12.2: 生成的 .ps1 补 UTF-8 BOM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.12.0",
+      "version": "0.12.2",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.12.0"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.12.0"
+version = "0.12.2"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
只有版本号 bump。代码改动是 #41，已合入 `main`，CI 双平台绿过。

## 这一版修什么

PowerShell 5.1 读**没有 BOM** 的 `.ps1` 时按系统 ANSI 代码页解码。中文（936）、日文（932）等非 UTF-8 代码页上，`SCRIPT_BODY` 里的中文注释被解成乱码，乱码里冒出的引号把后面的行吃掉；串联那段整个包在 `try {} catch {}` 里，于是一声不响地失败——用户原有的 statusLine 消失，状态栏只剩 `5h xx% 7d xx%`。

`repair()` 也一并加强：原来只看脚本文件在不在，命令从外面看对、脚本也在、正文却是旧版本产物时会直接跳过——正是这个 bug 的形状，升级用户永远修不好。现在拿回读的 delegate 重新渲染作期望值比对整份正文。

## 与 0.12.0 的关系

0.11.6 / 0.12.0 修的是 statusLine **命令**（引号 + 绝对路径）与启动自愈。装上 0.12.0 之后命令确实修对了，但用户自己的 statusLine 内容依然不出现——这一版补的是后半段。

## 版本号说明

`v0.12.1` 已烧掉：那一版把 bump 和 tag 跟代码一起推，CI 才发现测试里有平台依赖（用「去掉 BOM」模拟正文过时，在 macOS 上退化成空操作）。产品代码本身没问题，但 tag 指向的提交不会进 `main`，按协议不能复用版本号。这次按协议拆两步：代码先过 CI 双平台并合入 `main`（#41），再单独 bump。

🤖 Generated with [Claude Code](https://claude.com/claude-code)