### PR TITLE
Release 0.12.3: statusLine 路径上的四处静默失败

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.12.2"
+version = "0.12.3"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
只有版本号 bump，diff 恰好是协议规定的五个版本文件。代码改动是 #44，已合入 `main`，`main` 提交本身双平台 CI 全绿。

## 这一版修什么

接着 statusLine 那条线往下挖出的四处问题，全部属于同一家族——**Metrik 自己出岔子，代价却由用户的 statusLine 承担，而且不出声**。

| # | 问题 | 用户看到的现象 |
|---|---|---|
| 1 | 临时文件泄漏：状态栏调用被 Claude Code 杀掉，`finally` 执行不到 | `%TEMP%` 无限堆积（真机 5 分半 20 个），每个 Windows 用户 |
| 2 | 扫尸实现用 cmdlet | 每次渲染多花约 60 ms（冷进程 cmdlet 加载） |
| 3 | `CLAUDE_CONFIG_DIR` 用户的钩子装进了 Claude Code 不读的 settings.json | 界面显示「已安装」，永远没有数据 |
| 4 | 负载解析失败时 `exit 0` | 用户原有的 statusLine 整个消失 |

第 1 条一开始的假设（`Remove-Item` 撞未释放句柄失败被 `-ErrorAction SilentlyContinue` 吞掉）**写复现证伪了**：`cmd.exe` 与真实 bash 委托各跑若干轮，加不加 `$proc.Dispose()`，残留都是 0。真因是进程被杀。

第 3 条顺带把额度落盘路径改成生成时烘进脚本——原来 Windows 用 `$env:USERPROFILE`、Python 用 `~`，而 Rust 侧按配置目录读，两边可能对不上。

## 验证

四条集成测试**真的启动 PowerShell 跑生成的脚本**，`USERPROFILE` 与 `TEMP` 都隔离到临时目录。

**变异测试逐条退回，每次都精确只有对应那一条失败：**

| 退回的修复 | 失败的测试 |
|---|---|
| 落盘路径改回 `USERPROFILE` 现推 | `windows_script_writes_quota_to_the_installed_dir_not_userprofile` |
| 解析失败改回 `exit 0` | `windows_script_still_renders_delegate_when_payload_is_unparsable` |
| 去掉扫尸 | `windows_script_sweeps_temp_files_orphaned_by_a_killed_run` |
| 去掉 BOM（0.12.2 那条） | `windows_script_is_written_as_utf8_with_bom` |

CI（#44）：windows-latest 154 tests / 149 passed，macOS 150 tests / 145 passed，四条新集成测试在真 MSVC 上全部执行。

## 已知遗留，不在本版

- **PowerShell 5.1 冷启动约 1017 ms**，占整条链路（实测 2954/3321/3574 ms）的三分之一，直接决定有多少次渲染能跑完。根治需要自带原生 statusline 可执行文件替代 `powershell -File`，属于设计改动，单独做。
- `app_server::tests::managed_child_terminates_windows_process_tree_after_descendant_is_ready` flaky：单独跑 4/4 过，全量并行约 2/3 过，失败报 `Os { code: 32 }`。
- `adapters/antigravity.rs:706` 的 `identity_op`，仅 `clippy --all-targets` 可见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)