### PR TITLE
stabilize Rust test verification

### DIFF
--- a/src-tauri/src/adapters/antigravity.rs
+++ b/src-tauri/src/adapters/antigravity.rs
@@ -703,7 +703,11 @@ mod tests {
         let events = normalize_generator_metadata(&value, "cascade-1", i64::MIN);
         assert_eq!(events.len(), 2);
         // processed = input + cache_read + cache_write(0) + output；reasoning 不叠加。
-        assert_eq!(events[0].tokens.processed(), 100 + 900 + 0 + 40);
+        // 那个 `+ 0` 是 cache_write 这一项，写出来才对得上公式；clippy 的
+        // identity_op 只在 --all-targets 下看得到，为它删掉反而丢了意图。
+        #[allow(clippy::identity_op)]
+        let expected_processed = 100 + 900 + 0 + 40;
+        assert_eq!(events[0].tokens.processed(), expected_processed);
         assert_eq!(events[0].tokens.reasoning_output, 12);
         assert_eq!(events[0].tokens.cache_write, 0);
         assert_eq!(events[0].event_key, "response:resp-a");

--- a/src-tauri/src/app_server.rs
+++ b/src-tauri/src/app_server.rs
@@ -372,18 +372,25 @@ mod tests {
                 .expect("test PowerShell process should start"),
         );
         let ready_deadline = Instant::now() + Duration::from_secs(10);
-        while !marker.is_file() && Instant::now() < ready_deadline {
+        // 只等「文件存在」会撞上写入方还占着句柄（os error 32，"另一个程序正在
+        // 使用此文件"），或者读到 Set-Content 还没写完的空内容——两种都真实
+        // 发生过，全量并行跑约三成失败。直接等到「能读出一个 pid」为止。
+        let descendant_pid = loop {
             if let Ok(Some(status)) = child.child_mut().try_wait() {
                 panic!("test PowerShell process exited before recording its descendant: {status}");
             }
+            if let Some(pid) = std::fs::read_to_string(&marker)
+                .ok()
+                .and_then(|raw| raw.trim().parse::<u32>().ok())
+            {
+                break pid;
+            }
+            assert!(
+                Instant::now() < ready_deadline,
+                "test child never recorded a readable descendant pid"
+            );
             std::thread::sleep(Duration::from_millis(50));
-        }
-
-        let descendant_pid = std::fs::read_to_string(&marker)
-            .expect("test child should record its descendant pid")
-            .trim()
-            .parse::<u32>()
-            .expect("recorded descendant pid should be numeric");
+        };
         child.terminate();
 
         let filter = format!("PID eq {descendant_pid}");


### PR DESCRIPTION
## What changed

- wait until the app-server termination test can read and parse its descendant PID instead of treating file existence as readiness
- preserve the four-term processed-token formula in the Antigravity fixture while documenting the intentional zero cache-write term

## Why

The Windows test could race the writer and either hit sharing violation 32 or read an empty marker. `cargo clippy --all-targets -- -D warnings` also flagged the intentional `+ 0` unless its purpose was made explicit.

## Scope

Shared Rust test reliability; no application behavior or version changes.

## Validation

- `cargo test --lib`: 149 passed
- repeated full parallel library suite after the race fix: 6/6 green
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-targets -- -D warnings`