### PR TITLE
run Windows statusLine natively

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ Kimi legacy StatusUpdates carry no scope marker and it is not documented whether
 Quota rows are replaced wholesale, never merged, so a window a plan no longer has cannot linger as a stale row:
 
 - **Codex**: `primary` and `secondary` are slots, not window semantics — a plan may carry a weekly window in the `primary` slot and have no `secondary` at all. Windows are classified by `windowDurationMins` (≤ 1440 minutes is a session window, otherwise weekly); the slot name is only a fallback when the duration is absent. A successful `app-server` read replaces the whole Codex row set.
-- **Claude**: the statusLine hook file is the zero-credential source. The opt-in OAuth source (off by default) reads the token Claude Code already stores and queries the official usage endpoint; the token is never persisted, uploaded, or logged. A successful read from either source replaces the whole Claude row set; a failed OAuth read falls back to the hook file rather than to a guess.
+- **Claude**: the statusLine hook file is the zero-credential source. Windows handles the hook inside `metrik.exe --statusline` before desktop initialization; macOS and Linux use the generated Python hook. The opt-in OAuth source (off by default) reads the token Claude Code already stores and queries the official usage endpoint; the token is never persisted, uploaded, or logged. A successful read from either source replaces the whole Claude row set; a failed OAuth read falls back to the hook file rather than to a guess.
 - A window whose reset time has passed without fresh data renders as `--`, not as its last known percentage.
 
 ## Storage

--- a/src-tauri/src/app_server.rs
+++ b/src-tauri/src/app_server.rs
@@ -130,7 +130,7 @@ impl Drop for ManagedChild {
     }
 }
 
-fn terminate_process_tree(child: &mut Child) {
+pub(crate) fn terminate_process_tree(child: &mut Child) {
     if matches!(child.try_wait(), Ok(Some(_))) {
         return;
     }

--- a/src-tauri/src/claude_hook.rs
+++ b/src-tauri/src/claude_hook.rs
@@ -2,6 +2,8 @@ use crate::domain::{sane_resets_at_ms, QuotaSample};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+#[cfg(windows)]
+use std::path::Path;
 use std::path::PathBuf;
 
 /// Claude Code 官方配额的零凭据来源：statusLine 钩子。
@@ -13,137 +15,24 @@ use std::path::PathBuf;
 /// 不读取、不保存对话内容或凭据。
 ///
 /// 用户已有自定义 statusLine 时不覆盖而是串联：原命令备份到
-/// `metrik-statusline.backup.json`，脚本落完额度数据后把 stdin 原样转给
+/// `metrik-statusline.backup.json`，钩子落完额度数据后把 stdin 原样转给
 /// 原命令渲染显示；单行输出在行尾追加 5h/7d 百分比，多行输出原样透传
 /// （多行 statusLine 自带排版）。卸载时原样恢复备份。
-/// 委托命令的执行方式：ps1 脚本走进程内 SetIn 喂 stdin；其他命令（bash/exe
-/// 等）走临时文件 + Start-Process 标准输入/输出重定向——PS 5.1 的 `$input|&`
-/// 原生管道会随机整段丢输出（真机实测），Start-Process 重定向是唯一稳定
-/// 传输；委托挂死时 10 秒超时强杀，不冻结状态栏。
+/// Windows 由 `metrik.exe --statusline` 直接用管道执行委托，10 秒超时后终止
+/// 进程树；非 Windows 仍由生成的 Python 脚本处理。
 const QUOTA_FILE: &str = "metrik-quota.json";
 const BACKUP_FILE: &str = "metrik-statusline.backup.json";
+#[cfg(windows)]
+const METADATA_FILE: &str = "metrik-statusline.json";
+#[cfg(not(windows))]
 const DELEGATE_PLACEHOLDER: &str = "{{DELEGATE}}";
+#[cfg(not(windows))]
 const QUOTA_PATH_PLACEHOLDER: &str = "{{QUOTA_PATH}}";
 
 #[cfg(windows)]
 const SCRIPT_FILE: &str = "metrik-statusline.ps1";
 #[cfg(not(windows))]
 const SCRIPT_FILE: &str = "metrik-statusline.py";
-
-#[cfg(windows)]
-const SCRIPT_BODY: &str = r#"# Metrik statusLine hook: persist Claude Code rate limits, no content is stored.
-$delegate = '{{DELEGATE}}'
-$raw = [Console]::In.ReadToEnd()
-# 解析失败不能连累用户：额度抓不到是我们的事，用户原有的 statusLine 不该
-# 因此消失。所以这里只记下失败，照样往下走把 stdin 转给委托渲染。
-$data = $null
-try { $data = $raw | ConvertFrom-Json } catch {}
-$payload = @{ receivedAtMs = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() }
-if ($null -ne $data) {
-  $rl = $data.rate_limits
-  if ($null -ne $rl) {
-    $windows = @{}
-    foreach ($prop in $rl.PSObject.Properties) {
-      $entry = $prop.Value
-      if ($null -ne $entry -and $null -ne $entry.used_percentage) {
-        $windows[$prop.Name] = @{ usedPercentage = [double]$entry.used_percentage }
-        if ($null -ne $entry.resets_at) { $windows[$prop.Name].resetsAt = [double]$entry.resets_at }
-      }
-    }
-    $payload.windows = $windows
-  }
-}
-# 落盘位置在生成时烘进来，不再从 $env:USERPROFILE 现推：设了
-# CLAUDE_CONFIG_DIR 的用户，配置目录并不在 ~/.claude，现推会写到 Metrik
-# 根本不读的地方。
-$target = '{{QUOTA_PATH}}'
-if ($null -ne $data) {
-  $tmp = "$target.tmp-$PID"
-  ($payload | ConvertTo-Json -Depth 5 -Compress) | Out-File -FilePath $tmp -Encoding utf8
-  Move-Item -Force $tmp $target
-}
-# Claude Code 每次重渲染状态栏都会杀掉上一次调用，而串联一个委托要好几秒，
-# 所以绝大多数调用是中途被 kill 的——finally 根本执行不到，临时文件就永远
-# 留在盘上（真机实测 5 分半漏 20 个，每个 Windows 用户都在漏）。被 kill 的
-# 进程救不了自己，只能由下一次调用替它收尸。委托最长跑 10 秒，5 分钟以上
-# 的必然是孤儿，不会误删正在用的文件。
-# 走 .NET 而不是 Get-ChildItem/Remove-Item：状态栏每次渲染都是全新的
-# PowerShell 进程，cmdlet 永远是冷的，首次加载实测 55~85 ms；同样的活
-# 用 .NET 只要 14~22 ms。这条路径跑得很频繁，省下来的是真的。
-$stale = (Get-Date).AddMinutes(-5)
-foreach ($sweep in @(@($env:TEMP, 'metrik-statusline-*'), @([IO.Path]::GetDirectoryName($target), 'metrik-quota.json.tmp-*'))) {
-  if ($sweep[0]) {
-    try {
-      foreach ($orphan in [IO.Directory]::GetFiles($sweep[0], $sweep[1])) {
-        try { if ([IO.File]::GetLastWriteTime($orphan) -lt $stale) { [IO.File]::Delete($orphan) } } catch {}
-      }
-    } catch {}
-  }
-}
-$quotaParts = @()
-if ($payload.windows -and $payload.windows.five_hour) { $quotaParts += ('5h ' + [math]::Round($payload.windows.five_hour.usedPercentage) + '%') }
-if ($payload.windows -and $payload.windows.seven_day) { $quotaParts += ('7d ' + [math]::Round($payload.windows.seven_day.usedPercentage) + '%') }
-if ($delegate) {
-  # 串联模式：显示交给用户原有的 statusLine 命令。单行输出在行尾追加额度；
-  # 多行输出原样透传（多行 statusLine 自带排版，追加会把它压坏）。
-  # PowerShell 脚本走进程内执行（SetIn 喂 stdin），零编码转换；
-  # 其他命令走临时文件 + Start-Process 重定向——PS 5.1 的 $input|& 原生
-  # 管道会随机整段丢输出（真机实测），Start-Process 的重定向是唯一稳定传输。
-  $lines = @()
-  try {
-    $psFile = [regex]::Match($delegate, '-File\s+"?([^"]+\.ps1)"?')
-    if ($psFile.Success -and (Test-Path $psFile.Groups[1].Value)) {
-      [Console]::SetIn((New-Object System.IO.StringReader($raw)))
-      $lines = @(& $psFile.Groups[1].Value 2>$null)
-    } else {
-      # 委托拆成 exe + 参数行："引号 exe + 参数" 或 "裸 exe + 参数"。
-      $exe = $null
-      $argLine = ""
-      $m = [regex]::Match($delegate, '^\s*"([^"]+)"\s*(.*)$')
-      if ($m.Success) {
-        $exe = $m.Groups[1].Value
-        $argLine = $m.Groups[2].Value
-      } else {
-        $m = [regex]::Match($delegate, '^\s*(\S+)\s*(.*)$')
-        if ($m.Success) {
-          $exe = $m.Groups[1].Value
-          $argLine = $m.Groups[2].Value
-        }
-      }
-      if ($exe -and (Test-Path $exe)) {
-        $tmpIn = Join-Path $env:TEMP "metrik-statusline-in-$PID.json"
-        $tmpOut = Join-Path $env:TEMP "metrik-statusline-out-$PID.txt"
-        try {
-          [IO.File]::WriteAllText($tmpIn, $raw)
-          try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
-          $proc = Start-Process -FilePath $exe -ArgumentList $argLine `
-            -RedirectStandardInput $tmpIn -RedirectStandardOutput $tmpOut `
-            -NoNewWindow -PassThru
-          # 委托挂死不能冻结状态栏：10 秒超时强杀。
-          if (-not $proc.WaitForExit(10000)) { try { $proc.Kill() } catch {} }
-          if (Test-Path $tmpOut) { $lines = @(Get-Content $tmpOut -Encoding UTF8) }
-        } finally {
-          Remove-Item -Force $tmpIn, $tmpOut -ErrorAction SilentlyContinue
-        }
-      } else {
-        # exe 拆不出/不在盘上（PATH 里的裸命令、复合命令）：尽力走旧管道，
-        # '& ' 调用运算符必不可少——委托以带引号的 exe 路径开头时，没有它
-        # scriptblock 创建会直接抛管道语法错误。
-        try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
-        $lines = @($raw | & ([scriptblock]::Create('$input | & ' + $delegate)) 2>$null)
-      }
-    }
-  } catch {}
-  $lines = @($lines | ForEach-Object { [string]$_ })
-  $out = $lines -join "`n"
-  if ($lines.Count -eq 1 -and $out -and $quotaParts) { "$out | " + ($quotaParts -join ' ') }
-  elseif ($out) { $out }
-  elseif ($quotaParts) { $quotaParts -join ' ' }
-} else {
-  $model = if ($null -ne $data -and $data.model.display_name) { $data.model.display_name } else { 'Claude' }
-  (@($model) + $quotaParts) -join ' | '
-}
-"#;
 
 #[cfg(not(windows))]
 const SCRIPT_BODY: &str = r#"#!/usr/bin/env python3
@@ -245,6 +134,297 @@ struct QuotaWindow {
     resets_at: Option<f64>,
 }
 
+#[cfg(windows)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusLineMetadata {
+    delegate: String,
+    quota_path: PathBuf,
+}
+
+#[cfg(windows)]
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusLinePayload {
+    received_at_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    windows: Option<std::collections::BTreeMap<String, StatusLineWindow>>,
+}
+
+#[cfg(windows)]
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusLineWindow {
+    used_percentage: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resets_at: Option<f64>,
+}
+
+#[cfg(windows)]
+fn numeric_value(value: &Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_str()?.parse::<f64>().ok())
+}
+
+#[cfg(windows)]
+fn payload_from_input(input: &Value) -> StatusLinePayload {
+    let windows = input
+        .get("rate_limits")
+        .and_then(Value::as_object)
+        .map(|rate_limits| {
+            rate_limits
+                .iter()
+                .filter_map(|(key, entry)| {
+                    let used_percentage = numeric_value(entry.get("used_percentage")?)?;
+                    let resets_at = entry.get("resets_at").and_then(numeric_value);
+                    Some((
+                        key.clone(),
+                        StatusLineWindow {
+                            used_percentage,
+                            resets_at,
+                        },
+                    ))
+                })
+                .collect()
+        });
+    StatusLinePayload {
+        received_at_ms: chrono::Utc::now().timestamp_millis(),
+        windows,
+    }
+}
+
+#[cfg(windows)]
+fn quota_parts(payload: &StatusLinePayload) -> Vec<String> {
+    let Some(windows) = payload.windows.as_ref() else {
+        return Vec::new();
+    };
+    [("five_hour", "5h"), ("seven_day", "7d")]
+        .into_iter()
+        .filter_map(|(key, label)| {
+            windows
+                .get(key)
+                .map(|window| format!("{label} {:.0}%", window.used_percentage))
+        })
+        .collect()
+}
+
+#[cfg(windows)]
+fn write_quota_atomically(path: &Path, payload: &StatusLinePayload) -> Result<()> {
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .context("Claude quota path has no file name")?;
+    let staged = path.with_file_name(format!("{file_name}.tmp-{}", std::process::id()));
+    std::fs::write(&staged, serde_json::to_vec(payload)?)
+        .context("unable to stage Claude quota snapshot")?;
+    let installed = std::fs::rename(&staged, path);
+    if installed.is_err() {
+        let _ = std::fs::remove_file(&staged);
+    }
+    installed.context("unable to install Claude quota snapshot")
+}
+
+#[cfg(windows)]
+fn sweep_stale_files(directory: &Path, prefix: &str, stale_before: std::time::SystemTime) {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_name().to_string_lossy().starts_with(prefix) {
+            continue;
+        }
+        let is_stale = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .is_ok_and(|modified| modified < stale_before);
+        if is_stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[cfg(windows)]
+fn command_has_shell_syntax(command: &str) -> bool {
+    let mut quoted = false;
+    command.chars().any(|character| match character {
+        '"' => {
+            quoted = !quoted;
+            false
+        }
+        '|' | '&' | ';' | '<' | '>' | '(' | ')' if !quoted => true,
+        _ => false,
+    })
+}
+
+#[cfg(windows)]
+fn split_delegate_command(command: &str) -> Option<(&str, &str)> {
+    let command = command.trim();
+    if let Some(quoted) = command.strip_prefix('"') {
+        let end = quoted.find('"')?;
+        return Some((&quoted[..end], quoted[end + 1..].trim_start()));
+    }
+    let end = command.find(char::is_whitespace).unwrap_or(command.len());
+    Some((&command[..end], command[end..].trim_start()))
+}
+
+#[cfg(windows)]
+fn delegate_process(delegate: &str) -> std::process::Command {
+    use std::os::windows::process::CommandExt;
+
+    let direct = split_delegate_command(delegate);
+    let needs_shell = command_has_shell_syntax(delegate)
+        || direct.is_some_and(|(executable, _)| {
+            matches!(
+                Path::new(executable)
+                    .extension()
+                    .and_then(|value| value.to_str())
+                    .map(str::to_ascii_lowercase)
+                    .as_deref(),
+                Some("bat" | "cmd")
+            )
+        });
+    let mut command = if needs_shell {
+        let comspec = std::env::var_os("COMSPEC")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                let system_root =
+                    std::env::var_os("SystemRoot").unwrap_or_else(|| r"C:\Windows".into());
+                PathBuf::from(system_root).join("System32").join("cmd.exe")
+            });
+        let mut command = std::process::Command::new(comspec);
+        command.args(["/D", "/S", "/C"]).raw_arg(delegate);
+        command
+    } else if let Some((executable, arguments)) = direct {
+        let mut command = std::process::Command::new(executable);
+        if !arguments.is_empty() {
+            command.raw_arg(arguments);
+        }
+        command
+    } else {
+        std::process::Command::new(delegate)
+    };
+    command
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .creation_flags(0x0800_0000);
+    command
+}
+
+#[cfg(windows)]
+fn run_delegate(delegate: &str, input: &[u8], timeout: std::time::Duration) -> String {
+    use std::io::{Read, Write};
+
+    let Ok(mut child) = delegate_process(delegate).spawn() else {
+        return String::new();
+    };
+    let output = child.stdout.take();
+    let reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        if let Some(mut output) = output {
+            let _ = output.read_to_end(&mut bytes);
+        }
+        bytes
+    });
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(input);
+    }
+
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            _ => {
+                crate::app_server::terminate_process_tree(&mut child);
+                break;
+            }
+        }
+    }
+    let bytes = reader.join().unwrap_or_default();
+    String::from_utf8_lossy(&bytes)
+        .trim_end_matches(['\r', '\n'])
+        .to_owned()
+}
+
+#[cfg(windows)]
+fn render_statusline(
+    hook: &ClaudeHook,
+    input: &[u8],
+    temp_dir: &Path,
+    delegate_timeout: std::time::Duration,
+) -> String {
+    let metadata = hook.read_metadata();
+    let data = serde_json::from_slice::<Value>(input).ok();
+    let payload = data.as_ref().map(payload_from_input);
+
+    if let (Some(metadata), Some(payload)) = (metadata.as_ref(), payload.as_ref()) {
+        let _ = write_quota_atomically(&metadata.quota_path, payload);
+    }
+
+    let stale_before = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(5 * 60))
+        .unwrap_or(std::time::UNIX_EPOCH);
+    sweep_stale_files(temp_dir, "metrik-statusline-", stale_before);
+    if let Some(quota_dir) = metadata
+        .as_ref()
+        .and_then(|metadata| metadata.quota_path.parent())
+    {
+        sweep_stale_files(quota_dir, "metrik-quota.json.tmp-", stale_before);
+    }
+
+    let quota_parts = payload.as_ref().map(quota_parts).unwrap_or_default();
+    if let Some(delegate) = metadata
+        .as_ref()
+        .map(|metadata| metadata.delegate.trim())
+        .filter(|delegate| !delegate.is_empty())
+    {
+        let delegated = run_delegate(delegate, input, delegate_timeout);
+        if !delegated.is_empty() {
+            if !delegated.contains('\r') && !delegated.contains('\n') && !quota_parts.is_empty() {
+                return format!("{delegated} | {}", quota_parts.join(" "));
+            }
+            return delegated;
+        }
+        return quota_parts.join(" ");
+    }
+
+    let model = data
+        .as_ref()
+        .and_then(|value| value.get("model"))
+        .and_then(|value| value.get("display_name"))
+        .and_then(Value::as_str)
+        .filter(|model| !model.is_empty())
+        .unwrap_or("Claude");
+    if quota_parts.is_empty() {
+        model.to_owned()
+    } else {
+        format!("{model} | {}", quota_parts.join(" "))
+    }
+}
+
+#[cfg(windows)]
+pub fn run_statusline() {
+    use std::io::{Read, Write};
+
+    let mut input = Vec::new();
+    let _ = std::io::stdin().read_to_end(&mut input);
+    let output = render_statusline(
+        &ClaudeHook::detected(),
+        &input,
+        &std::env::temp_dir(),
+        std::time::Duration::from_secs(10),
+    );
+    if !output.is_empty() {
+        let mut stdout = std::io::stdout().lock();
+        let _ = stdout.write_all(output.as_bytes());
+        let _ = stdout.write_all(b"\n");
+    }
+}
+
 /// 现有非 Metrik statusLine 的 command 原文（可串联时返回）。
 fn foreign_command(settings: &Value) -> Option<String> {
     settings
@@ -296,58 +476,80 @@ impl ClaudeHook {
         self.claude_dir.join(BACKUP_FILE)
     }
 
+    #[cfg(windows)]
+    fn metadata_path(&self) -> PathBuf {
+        self.claude_dir.join(METADATA_FILE)
+    }
+
     fn read_backup(&self) -> Option<Value> {
         let raw = std::fs::read_to_string(self.backup_path()).ok()?;
         serde_json::from_str(raw.trim_start_matches('\u{feff}')).ok()
     }
 
-    /// 把被串联的原命令和额度落盘路径嵌入脚本。Windows 走 PowerShell 单引号
-    /// 转义；其他平台用 JSON 字符串字面量（与 Python 字面量兼容）。
+    #[cfg(windows)]
+    fn read_metadata(&self) -> Option<StatusLineMetadata> {
+        let raw = std::fs::read_to_string(self.metadata_path()).ok()?;
+        serde_json::from_str(raw.trim_start_matches('\u{feff}')).ok()
+    }
+
+    #[cfg(windows)]
+    fn expected_metadata(&self, delegate: String) -> Result<StatusLineMetadata> {
+        let quota_path = self.quota_path();
+        let quota_path = if quota_path.is_absolute() {
+            quota_path
+        } else {
+            std::env::current_dir()
+                .context("无法确定 Claude quota 文件的绝对路径")?
+                .join(quota_path)
+        };
+        Ok(StatusLineMetadata {
+            delegate,
+            quota_path,
+        })
+    }
+
+    #[cfg(windows)]
+    fn write_metadata(&self, metadata: &StatusLineMetadata) -> Result<()> {
+        let path = self.metadata_path();
+        let staged = path.with_extension(format!("json.metrik-{}", std::process::id()));
+        std::fs::write(&staged, serde_json::to_vec_pretty(metadata)?)
+            .context("无法写入 Windows statusLine 元数据")?;
+        let installed = std::fs::rename(&staged, &path);
+        if installed.is_err() {
+            let _ = std::fs::remove_file(&staged);
+        }
+        installed.context("无法安装 Windows statusLine 元数据")
+    }
+
+    /// 把被串联的原命令和额度落盘路径嵌入非 Windows 的 Python 脚本。
+    #[cfg(not(windows))]
     fn render_script(&self, delegate: &str) -> String {
         let quota = self.quota_path();
         let quota = quota.to_string_lossy();
-        #[cfg(windows)]
-        {
-            SCRIPT_BODY
-                .replace(DELEGATE_PLACEHOLDER, &delegate.replace('\'', "''"))
-                .replace(QUOTA_PATH_PLACEHOLDER, &quota.replace('\'', "''"))
-        }
-        #[cfg(not(windows))]
-        {
-            let quote =
-                |value: &str| serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_owned());
-            SCRIPT_BODY
-                .replace(&format!("\"{DELEGATE_PLACEHOLDER}\""), &quote(delegate))
-                .replace(&format!("\"{QUOTA_PATH_PLACEHOLDER}\""), &quote(&quota))
-        }
+        let quote =
+            |value: &str| serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_owned());
+        SCRIPT_BODY
+            .replace(&format!("\"{DELEGATE_PLACEHOLDER}\""), &quote(delegate))
+            .replace(&format!("\"{QUOTA_PATH_PLACEHOLDER}\""), &quote(&quota))
     }
 
-    /// 落盘的脚本正文。Windows 上必须带 UTF-8 BOM。
-    ///
-    /// PowerShell 5.1 读没有 BOM 的 `.ps1` 时按系统 ANSI 代码页解码。中文
-    /// （936）、日文（932）等非 UTF-8 代码页上，脚本里的非 ASCII 注释会被解成
-    /// 乱码，乱码里冒出的引号把后面的行吃掉；串联那段整个包在 `try {} catch {}`
-    /// 里，于是一声不响地失败——用户原有的 statusLine 消失，状态栏只剩额度。
-    /// BOM 是让 5.1 按 UTF-8 读的唯一开关。
+    #[cfg(not(windows))]
     fn script_text(&self, delegate: &str) -> String {
-        let body = self.render_script(delegate);
-        if cfg!(windows) {
-            format!("\u{feff}{body}")
-        } else {
-            body
-        }
+        self.render_script(delegate)
     }
 
-    /// `render_script` 的逆操作：从已安装的脚本里回读被串联的原命令。
-    ///
     /// 备份文件是用户可见的普通文件，会被清理 `.claude`、同步工具或杀软
     /// 删掉。备份没了而 statusLine 仍是我们的时，重装若把 delegate 当成空，
     /// 用户原有的 statusLine 就永久消失（备份已不在，卸载也还原不回来）。
-    /// 脚本本身带着 delegate，是这种情况下唯一的真相源。
+    /// Windows 原生安装从元数据读取；升级迁移时再退回旧 `.ps1`。其他平台
+    /// 仍从生成的 Python 脚本读取。
     fn installed_delegate(&self) -> Option<String> {
-        let script = std::fs::read_to_string(self.script_path()).ok()?;
         #[cfg(windows)]
         {
+            if let Some(metadata) = self.read_metadata() {
+                return Some(metadata.delegate);
+            }
+            let script = std::fs::read_to_string(self.script_path()).ok()?;
             // 生成时 `'` 转义成 `''`，这里反向还原。
             let line = script
                 .lines()
@@ -356,6 +558,7 @@ impl ClaudeHook {
         }
         #[cfg(not(windows))]
         {
+            let script = std::fs::read_to_string(self.script_path()).ok()?;
             let line = script.lines().find_map(|l| l.strip_prefix("DELEGATE = "))?;
             serde_json::from_str::<String>(line).ok()
         }
@@ -367,17 +570,15 @@ impl ClaudeHook {
     /// 引号——Claude Code 经 Git Bash 执行 statusLine，裸路径的反斜杠
     /// 会被 bash 当转义符吃掉（C:\Windows\... → C:Windows...）。
     /// 两种失败都是 exit 127 + 零输出，状态栏只表现为空白。
-    fn hook_command(&self) -> String {
-        let script = self.script_path();
-        if cfg!(windows) {
-            let system_root =
-                std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_owned());
-            format!(
-                "\"{system_root}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -NoProfile -ExecutionPolicy Bypass -File \"{}\"",
-                script.display()
-            )
-        } else {
-            format!("python3 \"{}\"", script.display())
+    fn hook_command(&self) -> Result<String> {
+        #[cfg(windows)]
+        {
+            let executable = std::env::current_exe().context("无法确定 metrik.exe 的绝对路径")?;
+            Ok(format!("\"{}\" --statusline", executable.display()))
+        }
+        #[cfg(not(windows))]
+        {
+            Ok(format!("python3 \"{}\"", self.script_path().display()))
         }
     }
 
@@ -405,11 +606,37 @@ impl ClaudeHook {
     }
 
     fn status_line_is_ours(&self, settings: &Value) -> bool {
-        settings
+        let Some(command) = settings
             .get("statusLine")
             .and_then(|value| value.get("command"))
             .and_then(Value::as_str)
-            .is_some_and(|command| command.contains(SCRIPT_FILE))
+        else {
+            return false;
+        };
+        if command.contains(SCRIPT_FILE) {
+            return true;
+        }
+        #[cfg(windows)]
+        {
+            if self
+                .hook_command()
+                .is_ok_and(|expected| command == expected)
+            {
+                return true;
+            }
+            let executable = split_delegate_command(command).map(|(executable, _)| executable);
+            command.trim_end().ends_with("--statusline")
+                && executable.is_some_and(|executable| {
+                    Path::new(executable)
+                        .file_name()
+                        .and_then(|value| value.to_str())
+                        .is_some_and(|name| name.eq_ignore_ascii_case("metrik.exe"))
+                })
+        }
+        #[cfg(not(windows))]
+        {
+            false
+        }
     }
 
     pub fn status(&self) -> Result<ClaudeHookStatus> {
@@ -421,7 +648,11 @@ impl ClaudeHook {
                 .get("statusLine")
                 .is_some_and(|value| !value.is_null())
             && foreign_command(&settings).is_none();
-        let chained = installed && self.read_backup().is_some();
+        let chained = installed
+            && (self.read_backup().is_some()
+                || self
+                    .installed_delegate()
+                    .is_some_and(|value| !value.is_empty()));
         let last_data_at_ms = self.read_quota_file().map(|file| file.received_at_ms);
         Ok(ClaudeHookStatus {
             installed,
@@ -463,6 +694,10 @@ impl ClaudeHook {
             delegate = command;
         }
 
+        #[cfg(windows)]
+        self.write_metadata(&self.expected_metadata(delegate.clone())?)?;
+
+        #[cfg(not(windows))]
         std::fs::write(self.script_path(), self.script_text(&delegate))
             .context("无法写入钩子脚本")?;
         #[cfg(unix)]
@@ -479,9 +714,11 @@ impl ClaudeHook {
             .context("settings.json 顶层不是对象")?;
         root.insert(
             "statusLine".into(),
-            json!({ "type": "command", "command": self.hook_command(), "padding": 0 }),
+            json!({ "type": "command", "command": self.hook_command()?, "padding": 0 }),
         );
         self.write_settings(&settings)?;
+        #[cfg(windows)]
+        let _ = std::fs::remove_file(self.script_path());
         self.status()
     }
 
@@ -504,13 +741,27 @@ impl ClaudeHook {
             .and_then(|value| value.get("command"))
             .and_then(Value::as_str)
             .unwrap_or_default();
-        // 脚本正文一并比对，不能只看文件在不在：命令从外面看是对的，脚本正文
-        // 却可能是旧版本生成的（缺 BOM 就会让串联静默失效）。拿回读出来的
-        // delegate 重新渲染一遍作为期望值，以后改 SCRIPT_BODY 也能自动补上。
-        let installed_script = std::fs::read_to_string(self.script_path()).unwrap_or_default();
-        let expected_script = self.script_text(&self.installed_delegate().unwrap_or_default());
-        if installed_command == self.hook_command() && installed_script == expected_script {
-            return Ok(false);
+        #[cfg(windows)]
+        {
+            let delegate = self.installed_delegate().unwrap_or_default();
+            let expected_metadata = self.expected_metadata(delegate)?;
+            if installed_command == self.hook_command()?
+                && self.read_metadata().as_ref() == Some(&expected_metadata)
+                && !self.script_path().exists()
+            {
+                return Ok(false);
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            // 脚本正文一并比对，不能只看文件在不在：命令从外面看是对的，脚本
+            // 正文却可能是旧版本生成的。拿回读出来的 delegate 重新渲染一遍，
+            // 以后改 SCRIPT_BODY 也能自动补上。
+            let installed_script = std::fs::read_to_string(self.script_path()).unwrap_or_default();
+            let expected_script = self.script_text(&self.installed_delegate().unwrap_or_default());
+            if installed_command == self.hook_command()? && installed_script == expected_script {
+                return Ok(false);
+            }
         }
         self.install()?;
         Ok(true)
@@ -540,6 +791,8 @@ impl ClaudeHook {
             self.write_settings(&settings)?;
         }
         let _ = std::fs::remove_file(self.script_path());
+        #[cfg(windows)]
+        let _ = std::fs::remove_file(self.metadata_path());
         let _ = std::fs::remove_file(self.quota_path());
         let _ = std::fs::remove_file(self.backup_path());
         self.status()
@@ -605,7 +858,7 @@ mod tests {
     }
 
     #[test]
-    fn install_writes_script_and_status_line_then_uninstall_restores() {
+    fn install_writes_hook_and_status_line_then_uninstall_restores() {
         let test = TestDirectory::new("roundtrip");
         fs::write(
             test.path().join("settings.json"),
@@ -622,11 +875,23 @@ mod tests {
                 .unwrap();
         assert_eq!(settings["model"], "opus");
         assert_eq!(settings["env"]["KEY"], "value");
-        assert!(settings["statusLine"]["command"]
-            .as_str()
-            .unwrap()
-            .contains("metrik-statusline"));
-        assert!(hook.script_path().exists());
+        #[cfg(windows)]
+        {
+            assert!(settings["statusLine"]["command"]
+                .as_str()
+                .unwrap()
+                .ends_with(" --statusline"));
+            assert!(hook.metadata_path().exists());
+            assert!(!hook.script_path().exists());
+        }
+        #[cfg(not(windows))]
+        {
+            assert!(settings["statusLine"]["command"]
+                .as_str()
+                .unwrap()
+                .contains("metrik-statusline"));
+            assert!(hook.script_path().exists());
+        }
 
         let status = hook.uninstall().unwrap();
         assert!(!status.installed);
@@ -636,6 +901,8 @@ mod tests {
         assert!(settings.get("statusLine").is_none());
         assert_eq!(settings["model"], "opus");
         assert!(!hook.script_path().exists());
+        #[cfg(windows)]
+        assert!(!hook.metadata_path().exists());
     }
 
     /// 回归：statusLine 由 Git Bash 执行，命令必须是带引号的绝对路径。
@@ -645,12 +912,14 @@ mod tests {
     #[test]
     fn windows_hook_command_is_quoted_absolute_path() {
         let test = TestDirectory::new("hookcmd");
-        let command = ClaudeHook::with_dir(test.path().to_path_buf()).hook_command();
+        let command = ClaudeHook::with_dir(test.path().to_path_buf())
+            .hook_command()
+            .unwrap();
         assert!(command.starts_with('"'), "exe 路径必须加引号: {command}");
         let exe = command[1..].split('"').next().unwrap();
         assert!(
-            exe.to_ascii_lowercase().ends_with("powershell.exe"),
-            "第一个 token 应是 powershell.exe: {command}"
+            command.ends_with("\" --statusline"),
+            "第一个 token 后只能是原生模式参数: {command}"
         );
         assert!(
             std::path::Path::new(exe).is_absolute(),
@@ -673,13 +942,21 @@ mod tests {
         assert!(!status.conflict);
         assert!(!status.chained);
 
-        // 安装：备份原设置、脚本嵌入原命令、statusLine 指向 Metrik 脚本。
+        // 安装：备份原设置、持久化原命令、statusLine 指向 Metrik。
         let status = hook.install().unwrap();
         assert!(status.installed);
         assert!(status.chained);
-        let script = fs::read_to_string(hook.script_path()).unwrap();
-        assert!(script.contains("my-own-line"));
-        assert!(!script.contains(DELEGATE_PLACEHOLDER));
+        #[cfg(windows)]
+        assert_eq!(
+            hook.read_metadata().unwrap().delegate,
+            "my-own-line 'quoted'"
+        );
+        #[cfg(not(windows))]
+        {
+            let script = fs::read_to_string(hook.script_path()).unwrap();
+            assert!(script.contains("my-own-line"));
+            assert!(!script.contains(DELEGATE_PLACEHOLDER));
+        }
         let backup: Value =
             serde_json::from_str(&fs::read_to_string(test.path().join(BACKUP_FILE)).unwrap())
                 .unwrap();
@@ -687,16 +964,15 @@ mod tests {
         let settings: Value =
             serde_json::from_str(&fs::read_to_string(test.path().join("settings.json")).unwrap())
                 .unwrap();
-        assert!(settings["statusLine"]["command"]
-            .as_str()
-            .unwrap()
-            .contains("metrik-statusline"));
+        assert_eq!(
+            settings["statusLine"]["command"],
+            hook.hook_command().unwrap()
+        );
 
         // 重装不丢串联：statusLine 已是我们的，命令沿用备份。
         let status = hook.install().unwrap();
         assert!(status.chained);
-        let script = fs::read_to_string(hook.script_path()).unwrap();
-        assert!(script.contains("my-own-line"));
+        assert_eq!(hook.installed_delegate().unwrap(), "my-own-line 'quoted'");
 
         // 卸载：原有 statusLine 原样恢复，备份清理。
         let status = hook.uninstall().unwrap();
@@ -710,39 +986,19 @@ mod tests {
         assert!(!test.path().join(BACKUP_FILE).exists());
     }
 
-    /// 在隔离环境里跑生成的脚本，返回它的 stdout。
-    ///
-    /// `USERPROFILE` 故意指向一个与安装目录无关的地方：脚本必须用生成时烘进去
-    /// 的绝对路径落盘，而不是现推 `~/.claude`。
+    /// 在隔离环境里运行 Windows 原生 statusLine 逻辑。
     #[cfg(windows)]
-    fn run_script(hook: &ClaudeHook, temp: &std::path::Path, payload: &[u8]) -> String {
-        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_owned());
-        let mut child = std::process::Command::new(format!(
-            r"{system_root}\System32\WindowsPowerShell\v1.0\powershell.exe"
-        ))
-        .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
-        .arg(hook.script_path())
-        .env("USERPROFILE", temp.join("elsewhere"))
-        .env("TEMP", temp)
-        .env("TMP", temp)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .expect("生成的脚本应该能跑起来");
-        std::io::Write::write_all(&mut child.stdin.take().unwrap(), payload).unwrap();
-        let out = child.wait_with_output().unwrap();
-        assert!(out.status.success(), "脚本不该以非零码退出");
-        String::from_utf8_lossy(&out.stdout).into_owned()
+    fn run_native(hook: &ClaudeHook, temp: &Path, payload: &[u8]) -> String {
+        render_statusline(hook, payload, temp, std::time::Duration::from_secs(10))
     }
 
-    /// 回归：额度落盘位置必须是生成时烘进去的绝对路径。
+    /// 回归：额度落盘位置必须是安装元数据保存的绝对路径。
     ///
-    /// 原来脚本里写死 `$env:USERPROFILE\.claude\metrik-quota.json`，而 Rust 侧
-    /// 现在认 `CLAUDE_CONFIG_DIR`。两边一旦对不上，脚本把额度写到 Metrik 根本
-    /// 不读的地方，界面显示「已安装」却永远没有数据。
+    /// 不能从运行时的 USERPROFILE 现推，否则设置了 CLAUDE_CONFIG_DIR 的用户
+    /// 会显示「已安装」却永远没有数据。
     #[cfg(windows)]
     #[test]
-    fn windows_script_writes_quota_to_the_installed_dir_not_userprofile() {
+    fn windows_native_writes_quota_to_the_installed_absolute_path() {
         let test = TestDirectory::new("quotapath");
         let temp = test.path().join("temp");
         fs::create_dir_all(&temp).unwrap();
@@ -750,19 +1006,33 @@ mod tests {
         fs::create_dir_all(test.path().join("cfg")).unwrap();
         hook.install().unwrap();
 
-        run_script(
+        let mut metadata = hook.read_metadata().unwrap();
+        assert!(metadata.quota_path.is_absolute());
+        assert_eq!(metadata.quota_path, hook.quota_path());
+        let installed_quota_dir = test.path().join("installed-quota");
+        fs::create_dir_all(&installed_quota_dir).unwrap();
+        metadata.quota_path = installed_quota_dir.join(QUOTA_FILE);
+        hook.write_metadata(&metadata).unwrap();
+        let output = run_native(
             &hook,
             &temp,
-            br#"{"rate_limits":{"five_hour":{"used_percentage":42}}}"#,
+            br#"{"model":{"display_name":"Sonnet"},"rate_limits":{"five_hour":{"used_percentage":42},"seven_day":{"used_percentage":19.6,"resets_at":1785197748}}}"#,
         );
+        assert_eq!(output, "Sonnet | 5h 42% 7d 20%");
 
-        let written = fs::read_to_string(hook.quota_path())
-            .expect("额度必须写进安装目录，而不是 USERPROFILE 推出来的路径");
-        assert!(written.contains("42"), "额度内容不对: {written}");
+        let written =
+            fs::read_to_string(&metadata.quota_path).expect("额度必须写进安装时确定的目录");
+        let quota: Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(quota["windows"]["five_hour"]["usedPercentage"], 42.0);
+        assert_eq!(quota["windows"]["seven_day"]["resetsAt"], 1785197748.0);
         assert!(
-            !test.path().join("elsewhere").exists(),
-            "不该在 USERPROFILE 下留下任何东西"
+            !hook.quota_path().exists(),
+            "不能从运行时 hook 目录重推落盘路径"
         );
+        assert!(!metadata
+            .quota_path
+            .with_file_name(format!("{QUOTA_FILE}.tmp-{}", std::process::id()))
+            .exists());
     }
 
     /// 回归：负载解析失败时，用户原有的 statusLine 仍然要渲染。
@@ -771,7 +1041,7 @@ mod tests {
     /// statusLine 一起带走了。额度抓不到是我们的事，不该由用户承担。
     #[cfg(windows)]
     #[test]
-    fn windows_script_still_renders_delegate_when_payload_is_unparsable() {
+    fn windows_native_forwards_unparsable_input_to_delegate() {
         let test = TestDirectory::new("badjson");
         let temp = test.path().join("temp");
         fs::create_dir_all(&temp).unwrap();
@@ -781,7 +1051,7 @@ mod tests {
             json!({
                 "statusLine": {
                     "type": "command",
-                    "command": format!(r"{system_root}\System32\cmd.exe /c echo METRIK-DELEGATE-OK"),
+                    "command": format!(r#""{system_root}\System32\cmd.exe" /D /C findstr /R ".*""#),
                 }
             })
             .to_string(),
@@ -790,21 +1060,62 @@ mod tests {
         let hook = ClaudeHook::with_dir(test.path().to_path_buf());
         hook.install().unwrap();
 
-        let out = run_script(&hook, &temp, b"this is not json at all");
-        assert!(
-            out.contains("METRIK-DELEGATE-OK"),
-            "解析失败不该连累用户的 statusLine，实际输出: {out:?}"
-        );
+        let out = run_native(&hook, &temp, b"this is not json at all");
+        assert_eq!(out, "this is not json at all");
+        assert!(!hook.quota_path().exists(), "无效 JSON 不应写入额度文件");
     }
 
-    /// 回归：脚本必须替上一次被杀的调用收尸。
-    ///
-    /// Claude Code 每次重渲染状态栏都会杀掉上一次调用，而串联一个委托要好几秒，
-    /// 所以绝大多数调用是中途被 kill 的，`finally` 执行不到，临时文件永远留在盘上
-    /// （真机实测 5 分半漏 20 个）。这条直接跑生成的脚本，环境隔离到临时目录。
+    /// 单行委托追加额度；多行面板保持自己的排版，不能被压成一行。
     #[cfg(windows)]
     #[test]
-    fn windows_script_sweeps_temp_files_orphaned_by_a_killed_run() {
+    fn windows_native_preserves_multiline_delegate_layout() {
+        let test = TestDirectory::new("multiline");
+        let temp = test.path().join("temp");
+        fs::create_dir_all(&temp).unwrap();
+        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_owned());
+        let settings = |command: String| {
+            json!({
+                "statusLine": {
+                    "type": "command",
+                    "command": command,
+                }
+            })
+            .to_string()
+        };
+        let payload = br#"{"rate_limits":{"five_hour":{"used_percentage":7}}}"#;
+
+        fs::write(
+            test.path().join("settings.json"),
+            settings(format!(
+                r#""{system_root}\System32\cmd.exe" /D /C echo ONE"#
+            )),
+        )
+        .unwrap();
+        let hook = ClaudeHook::with_dir(test.path().to_path_buf());
+        hook.install().unwrap();
+        assert_eq!(run_native(&hook, &temp, payload), "ONE | 5h 7%");
+
+        let multiline_script = test.path().join("multiline.cmd");
+        fs::write(
+            &multiline_script,
+            "@echo off\r\necho FIRST\r\necho SECOND\r\n",
+        )
+        .unwrap();
+        let multiline = format!(r#""{}""#, multiline_script.display());
+        let mut metadata = hook.read_metadata().unwrap();
+        metadata.delegate = multiline;
+        hook.write_metadata(&metadata).unwrap();
+        assert_eq!(run_native(&hook, &temp, payload), "FIRST\r\nSECOND");
+    }
+
+    /// 回归：原生路径必须清理上一次调用被终止后留下的旧临时文件。
+    ///
+    /// Claude Code 每次重渲染状态栏都会终止上一次调用，而串联一个委托要好几秒，
+    /// 所以绝大多数调用都是中途被终止的，`finally` 没有机会执行，临时文件永远留在
+    /// 盘上（真机实测 50 分钟残留 124 个）。
+    #[cfg(windows)]
+    #[test]
+    fn windows_native_sweeps_temp_files_from_terminated_runs() {
         use std::time::{Duration, SystemTime};
 
         let test = TestDirectory::new("tempsweep");
@@ -815,7 +1126,7 @@ mod tests {
         let hook = ClaudeHook::with_dir(home.join(".claude"));
         hook.install().unwrap();
 
-        // 上一次被 kill 留下的孤儿，以及一份正在被别的调用使用的新文件。
+        // 上一次被终止后留下的残留，以及一份正在被别的调用使用的新文件。
         let orphans = [
             temp.join("metrik-statusline-in-999999.json"),
             temp.join("metrik-statusline-out-999999.txt"),
@@ -835,25 +1146,11 @@ mod tests {
                 .unwrap();
         }
 
-        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_owned());
-        let mut child = std::process::Command::new(format!(
-            r"{system_root}\System32\WindowsPowerShell\v1.0\powershell.exe"
-        ))
-        .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
-        .arg(hook.script_path())
-        .env("USERPROFILE", &home)
-        .env("TEMP", &temp)
-        .env("TMP", &temp)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .expect("生成的脚本应该能跑起来");
-        std::io::Write::write_all(
-            &mut child.stdin.take().unwrap(),
+        run_native(
+            &hook,
+            &temp,
             br#"{"rate_limits":{"five_hour":{"used_percentage":7}}}"#,
-        )
-        .unwrap();
-        assert!(child.wait().unwrap().success());
+        );
 
         for path in &orphans {
             assert!(!path.exists(), "过期的临时文件没被清掉: {}", path.display());
@@ -861,32 +1158,122 @@ mod tests {
         assert!(live.exists(), "还在用的临时文件不能被误删");
     }
 
-    /// 回归：Windows 上生成的 `.ps1` 必须带 UTF-8 BOM。没有 BOM 时 PS 5.1 按系统
-    /// ANSI 代码页解码，中文（936）、日文（932）等代码页会把脚本里的非 ASCII
-    /// 注释解成乱码、把后面的行吃掉，串联那段死在 `try {} catch {}` 里不出声，
-    /// 用户原有的 statusLine 就此消失，状态栏只剩额度。
+    /// 回归：委托超过时限时要终止整个进程树，不能冻结状态栏或留下后代进程。
     #[cfg(windows)]
     #[test]
-    fn windows_script_is_written_as_utf8_with_bom() {
-        let test = TestDirectory::new("scriptbom");
+    fn windows_native_times_out_and_terminates_delegate_tree() {
+        use std::os::windows::process::CommandExt;
+        use std::time::{Duration, Instant};
+
+        let test = TestDirectory::new("timeout");
+        let temp = test.path().join("temp");
+        fs::create_dir_all(&temp).unwrap();
+        let marker = test.path().join("descendant.txt");
+        let script = test.path().join("delegate.ps1");
+        fs::write(
+            &script,
+            r#"$child = Start-Process -FilePath "$env:SystemRoot\System32\PING.EXE" -ArgumentList "-n","12","127.0.0.1" -WindowStyle Hidden -PassThru
+$child.Id | Set-Content -LiteralPath $args[0] -Encoding ascii
+Wait-Process -Id $child.Id
+"#,
+        )
+        .unwrap();
+        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_owned());
+        fs::write(
+            test.path().join("settings.json"),
+            json!({
+                "statusLine": {
+                    "type": "command",
+                    "command": format!(
+                        r#""{system_root}\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "{}" "{}""#,
+                        script.display(),
+                        marker.display()
+                    ),
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
         let hook = ClaudeHook::with_dir(test.path().to_path_buf());
         hook.install().unwrap();
 
-        let bytes = fs::read(hook.script_path()).unwrap();
+        let started = Instant::now();
+        let output = render_statusline(&hook, b"{}", &temp, Duration::from_secs(2));
+        assert_eq!(output, "");
+        assert!(started.elapsed() < Duration::from_secs(6));
+
+        let descendant_pid = fs::read_to_string(&marker)
+            .expect("delegate should record its descendant before timing out")
+            .trim()
+            .parse::<u32>()
+            .unwrap();
+        let listing = std::process::Command::new("tasklist.exe")
+            .args([
+                "/FI",
+                &format!("PID eq {descendant_pid}"),
+                "/FO",
+                "CSV",
+                "/NH",
+            ])
+            .creation_flags(0x0800_0000)
+            .output()
+            .unwrap();
+        let descendant_alive =
+            String::from_utf8_lossy(&listing.stdout).contains(&format!("\"{descendant_pid}\""));
+        if descendant_alive {
+            let _ = std::process::Command::new("taskkill.exe")
+                .args(["/PID", &descendant_pid.to_string(), "/T", "/F"])
+                .creation_flags(0x0800_0000)
+                .status();
+        }
+        assert!(!descendant_alive, "超时后代进程仍在运行: {descendant_pid}");
+    }
+
+    /// Windows 升级自愈：旧 `.ps1` 仍是第二真相源时，把 delegate 迁入元数据，
+    /// 改写 settings.json 指向原生入口，并删除旧脚本。
+    #[cfg(windows)]
+    #[test]
+    fn repair_migrates_legacy_windows_script_to_native_metadata() {
+        let test = TestDirectory::new("migratelegacy");
+        let hook = ClaudeHook::with_dir(test.path().to_path_buf());
+        fs::write(
+            hook.script_path(),
+            "\u{feff}# legacy hook\r\n$delegate = 'my-own-line ''quoted'''\r\n",
+        )
+        .unwrap();
+        fs::write(
+            test.path().join("settings.json"),
+            json!({
+                "statusLine": {
+                    "type": "command",
+                    "command": format!(
+                        r#"powershell.exe -NoProfile -File "{}""#,
+                        hook.script_path().display()
+                    ),
+                    "padding": 0,
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        assert!(hook.repair().unwrap());
+        let settings: Value =
+            serde_json::from_str(&fs::read_to_string(test.path().join("settings.json")).unwrap())
+                .unwrap();
         assert_eq!(
-            &bytes[..3],
-            &[0xEF, 0xBB, 0xBF],
-            "脚本必须以 UTF-8 BOM 开头，否则 PS 5.1 会按 ANSI 代码页解码"
+            settings["statusLine"]["command"],
+            hook.hook_command().unwrap()
         );
-        // BOM 只有在正文含非 ASCII 时才真正起作用；正文变成纯 ASCII 之后
-        // 这条回归就失去了意义，所以一并盯住。
-        assert!(
-            SCRIPT_BODY.bytes().any(|b| !b.is_ascii()),
-            "SCRIPT_BODY 已无非 ASCII 内容，BOM 断言不再能防住这个 bug，请重新审视"
-        );
+        let metadata = hook.read_metadata().unwrap();
+        assert_eq!(metadata.delegate, "my-own-line 'quoted'");
+        assert!(metadata.quota_path.is_absolute());
+        assert!(!hook.script_path().exists());
+        assert!(!hook.repair().unwrap(), "迁移完成后不应每次启动都重写");
     }
 
     /// 启动自愈：旧版本写坏的命令要修好，串联的原命令不能在修复中丢掉。
+    #[cfg(not(windows))]
     #[test]
     fn repair_rewrites_a_stale_command_and_keeps_the_delegate() {
         let test = TestDirectory::new("repairstale");
@@ -913,7 +1300,10 @@ mod tests {
         let settings: Value =
             serde_json::from_str(&fs::read_to_string(test.path().join("settings.json")).unwrap())
                 .unwrap();
-        assert_eq!(settings["statusLine"]["command"], hook.hook_command());
+        assert_eq!(
+            settings["statusLine"]["command"],
+            hook.hook_command().unwrap()
+        );
         let script = fs::read_to_string(hook.script_path()).unwrap();
         assert!(script.contains("my-own-line"), "自愈把 delegate 丢了");
 
@@ -970,7 +1360,7 @@ mod tests {
     /// 重装不能把用户原有的 statusLine 静默降级成「无委托」，卸载也不能
     /// 把 statusLine 整个删掉——两者都会让原配置永久消失。
     #[test]
-    fn deleted_backup_recovers_delegate_from_installed_script() {
+    fn deleted_backup_recovers_delegate_from_installation_state() {
         let test = TestDirectory::new("lostbackup");
         fs::write(
             test.path().join("settings.json"),
@@ -980,15 +1370,18 @@ mod tests {
         let hook = ClaudeHook::with_dir(test.path().to_path_buf());
         hook.install().unwrap();
 
-        // 备份没了，但 statusLine 仍指向 Metrik 脚本。
+        // 备份没了，但 statusLine 仍指向 Metrik。
         fs::remove_file(test.path().join(BACKUP_FILE)).unwrap();
 
-        // 重装：delegate 必须从脚本回读，不能退化成无委托。
+        // 重装：delegate 必须从安装状态回读，不能退化成无委托。
         hook.install().unwrap();
-        let script = fs::read_to_string(hook.script_path()).unwrap();
-        assert!(script.contains("my-own-line"), "重装丢了 delegate");
+        assert_eq!(
+            hook.installed_delegate().unwrap(),
+            "my-own-line 'quoted'",
+            "重装丢了 delegate"
+        );
 
-        // 卸载：按脚本里的原命令还原，而不是删掉 statusLine。
+        // 卸载：按持久化的原命令还原，而不是删掉 statusLine。
         hook.uninstall().unwrap();
         let settings: Value =
             serde_json::from_str(&fs::read_to_string(test.path().join("settings.json")).unwrap())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1322,6 +1322,11 @@ pub fn run() {
         .expect("error while running Metrik");
 }
 
+#[cfg(windows)]
+pub fn run_statusline() {
+    claude_hook::run_statusline();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    #[cfg(windows)]
+    if std::env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new("--statusline")) {
+        metrik_lib::run_statusline();
+        return;
+    }
+
     metrik_lib::run();
 }


### PR DESCRIPTION
## What changed

- handle `--statusline` at the start of `main()` and return before Tauri desktop/single-instance initialization
- replace the generated Windows PowerShell hook with native Rust quota parsing, atomic persistence, delegate piping, 10-second process-tree timeout, single/multiline output handling, and stale-temp cleanup
- store the delegate and installation-time absolute quota path in `metrik-statusline.json`
- migrate existing Windows `.ps1` installations during startup repair without requiring the settings toggle
- retain the generated Python hook unchanged on macOS/Linux
- document the platform split in the architecture

## Why

PowerShell startup and cold cmdlet loading add avoidable latency, while keeping the behavior in a generated script made encoding, temporary-file, and swallowed-error failures difficult to test. The native path removes those Windows-only failure classes without adding another executable or changing packaging.

## Scope

Windows shell plus the shared Claude hook installation contract. Non-Windows execution remains the existing Python hook. No version files changed.

## Validation

- `cargo test --lib`: 150 passed, 0 failed, 5 ignored
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-targets -- -D warnings`
- `npm test`: 7 passed
- `npm run build`
- mutation validation: each of 8 Windows behavior regressions produced exactly one corresponding failure in the full library suite before restoration
- actual debug `metrik.exe --statusline` with an existing GUI instance: early return and redirected stdout confirmed
- real user delegate A/B with the same synthetic, content-free payload: 4 lines / 459 bytes / identical normalized SHA-256; old PowerShell chain 2802 ms, native chain 2191 ms
- `%TEMP%` before/after native invocation: 2 existing files, 2 after, 0 added