### PR TITLE
Fix mixed-DPI floating window clipping

### DIFF
--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -59,6 +59,9 @@ change.
 - Floating-form size uses the destination monitor's DPI. Compact and strip
   reassert size from native DPI-change payloads, and window mutations are
   serialized so stale resizes cannot overwrite corrections.
+- The rendered CSS viewport is the final sizing authority for Windows floating
+  forms. After native resize, compact and strip must compensate WebView zoom
+  drift and verify the full design viewport rather than trusting HWND size alone.
 - Strip window size is measured from rendered content. Constants may seed the
   first frame but are not the source of truth.
 - Compact and strip have independent continuous UI scales in the range

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,7 @@ import opencodeAppIcon from "./assets/opencode-app-icon.png";
 import qoderAppIcon from "./assets/qoder-app-icon.png";
 import workbuddyAppIcon from "./assets/workbuddy-app-icon.svg";
 import zcodeAppIcon from "./assets/zcode-app-icon.png";
+import { horizontalStripTargetWidth } from "./windowGeometry";
 import {
   configureQoderCookie,
   configureSync,
@@ -227,10 +228,14 @@ function measureStripHorizontalTarget(shell) {
   const style = window.getComputedStyle(shell);
   const cellCount = Math.max(1, shell.querySelectorAll(".strip-cell").length);
   const controlsWidth = controls.getBoundingClientRect().width;
-  return (
-    STRIP_CELL_WIDTH * cellCount + controlsWidth +
-    parseFloat(style.paddingLeft) + parseFloat(style.paddingRight) + 1
-  );
+  return horizontalStripTargetWidth({
+    cellCount,
+    cellWidth: STRIP_CELL_WIDTH,
+    controlsWidth,
+    paddingLeft: parseFloat(style.paddingLeft),
+    paddingRight: parseFloat(style.paddingRight),
+    gap: parseFloat(style.columnGap || style.gap) || 0,
+  });
 }
 
 const AGENT_LABELS = Object.fromEntries(
@@ -809,6 +814,7 @@ function Inspector({ snapshot, selectedAgent, onSelectAgent, onOpenSources }) {
 }
 
 let windowActionQueue = Promise.resolve();
+let latestWindowCorrection = 0;
 
 function runWindowAction(action) {
   // hide/move/zoom/resize/show 是一条事务；并发执行时旧屏幕 factor 算出的迟到
@@ -817,6 +823,14 @@ function runWindowAction(action) {
     console.warn("Unable to update the desktop window.", error);
   });
   return windowActionQueue;
+}
+
+function runLatestWindowCorrection(action) {
+  const correction = ++latestWindowCorrection;
+  return runWindowAction(() => {
+    if (correction !== latestWindowCorrection) return undefined;
+    return action();
+  });
 }
 
 /// 标题栏的主题快捷键：单击在亮/暗之间切换，右键（或长按）弹出含「自动」的
@@ -1027,7 +1041,7 @@ function StripBar({
         if (!targetHeight) return;
         // 交叉轴是设计常量：竖条恒为 52 宽（方向切换后窗口可能还停在横条宽度）。
         if (Math.abs(targetHeight - shell.clientHeight) < 1 && shell.clientWidth === STRIP_VERTICAL_WIDTH) return;
-        runWindowAction(() =>
+        runLatestWindowCorrection(() =>
           resizeStripWindow({ width: STRIP_VERTICAL_WIDTH, height: Math.ceil(targetHeight) }),
         );
         return;
@@ -1036,7 +1050,7 @@ function StripBar({
       if (!targetWidth) return;
       // 交叉轴是设计常量：横条恒为 40 高。
       if (Math.abs(targetWidth - shell.clientWidth) < 1 && shell.clientHeight === STRIP_BAR_HEIGHT) return;
-      runWindowAction(() =>
+      runLatestWindowCorrection(() =>
         resizeStripWindow({ width: Math.ceil(targetWidth), height: STRIP_BAR_HEIGHT }),
       );
     };
@@ -1228,10 +1242,10 @@ function CompactWidget({
   const ComparisonArrow = comparisonIsLower ? ArrowDown : ArrowUp;
   const shellRef = useRef(null);
   // 宽度失配自愈的节流时间戳：失配不消失时观察器会一直触发，没有节流会
-  // 每 120ms 整窗重应用一次；距上次不足 2s 不再重复愈（失配消失即止），
+  // 每 120ms 重断言一次尺寸；距上次不足 2s 不再重复自愈（失配消失即止），
   // 替代旧的 3 次终身上限——上限烧完后失配就永远留着了。跨屏/DPI 变化时
-  // 清零，让新显示器上的自愈立即恢复资格（双屏场景下旧屏烧完上限、新屏
-  // 没机会自愈的坑）。重应用本身由根组件的 reassertCompactSize 订阅负责。
+  // 清零，让新显示器上的自愈立即恢复资格。自愈只重断言当前尺寸，不再完整
+  // hide/show 窗口或恢复记忆位置，避免旧显示器状态覆盖新 DPI。
   const lastDesyncHealRef = useRef(0);
   useEffect(() => {
     if (!isDesktop()) return undefined;
@@ -1246,8 +1260,8 @@ function CompactWidget({
     };
   }, []);
   // 一个观察器承担两条自愈：
-  // 1) 宽度失配（zoom×物理尺寸失配，视口 < 320，右侧被裁）→ 整窗重应用
-  //    （节流到 2s 一次，失配消失即止）；
+  // 1) 宽度失配（zoom×物理尺寸失配，视口 < 320，右侧被裁）→ 按当前 DPI
+  //    重断言尺寸（节流到 2s 一次，失配消失即止）；
   // 2) Agent 行数变化 → 窗口高度跟随内容（1-2 行回 320，更多行加高，
   //    工作区装不下的部分由列表内部滚动承担）。行数变化不改外壳尺寸，
   //    ResizeObserver 感知不到，所以每次渲染后再主动复核一次。
@@ -1267,7 +1281,7 @@ function CompactWidget({
         const now = Date.now();
         if (now - lastDesyncHealRef.current < 2000) return;
         lastDesyncHealRef.current = now;
-        runWindowAction(() => applyWindowMode("compact"));
+        runLatestWindowCorrection(() => reassertCompactSize());
         return;
       }
       const list = shell.querySelector(".widget-agent-list");
@@ -1299,7 +1313,7 @@ function CompactWidget({
         return;
       }
       if (Math.abs(target - shell.clientHeight) >= 2) {
-        runWindowAction(() => resizeCompactWindow({ height: target }));
+        runLatestWindowCorrection(() => resizeCompactWindow({ height: target }));
       }
     };
     const schedule = () => {
@@ -3549,14 +3563,14 @@ export function App() {
   useEffect(() => {
     const stopPromise = onScaleFactorChanged(({ scaleFactor } = {}) => {
       if (viewModeRef.current === "compact") {
-        runWindowAction(() => reassertCompactSize(scaleFactor));
+        runLatestWindowCorrection(() => reassertCompactSize(scaleFactor));
         return;
       }
       if (viewModeRef.current === "strip") {
         const layout = stripLayoutRef.current;
         const estimate = stripWindowSize(layout.orientation, layout.count);
         const content = stripContentSize(layout.orientation, estimate);
-        runWindowAction(() =>
+        runLatestWindowCorrection(() =>
           reassertStripSize({ ...content, scaleFactor }),
         );
       }

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -1,7 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 import { platform as tauriPlatform } from "@tauri-apps/plugin-os";
 import { detectRuntimePlatform } from "./platformDetection";
-import { monitorForWindowPosition, physicalWindowSize } from "./windowGeometry";
+import {
+  monitorForWindowPosition,
+  physicalWindowSize,
+  viewportCorrectedPhysicalSize,
+  viewportCorrectedZoom,
+} from "./windowGeometry";
 
 const WINDOW_SIZES = {
   // minHeight 260 = 标题栏+周期签+摘要双块+底栏（约 208）+ 单行 Agent（52）：
@@ -199,7 +204,14 @@ async function applyStartupUiScale(mode) {
     placement.monitor?.scaleFactor,
   );
   await appWindow.setSize(physical);
-  await clampIntoWorkArea(api, appWindow, physical);
+  await reconcileFloatingSizeAfterShow(
+    api,
+    appWindow,
+    size.width,
+    height,
+    uiScale,
+    physical,
+  );
 }
 
 /// 窗口重设尺寸后可能伸出屏幕（固定状态下竖条切横条最典型：位置不动、
@@ -278,8 +290,28 @@ async function floatingPlacement(api, mode, logicalSize, contentScale) {
   };
 }
 
+async function settleWebviewLayout() {
+  if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
+    return;
+  }
+  await new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      resolve();
+    };
+    const timeout = window.setTimeout(finish, 120);
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(finish);
+    });
+  });
+}
+
 /// Windows 偶尔丢弃隐藏窗口的 setPosition，或在 show 后才完成 DPI 切换。
-/// 显示并补发位置后再读一次最终 factor；若与预计算目标不一致，重设物理尺寸。
+/// 最终以 CSS 视口为准：若 WebView2 还残留系统/浏览器 zoom，就用当前物理尺寸
+/// 与实测视口反算窗口尺寸。只重复两次，避免异常瞬时值形成无限 resize 循环。
 async function reconcileFloatingSizeAfterShow(
   api,
   appWindow,
@@ -288,9 +320,10 @@ async function reconcileFloatingSizeAfterShow(
   contentScale,
   previousPhysical,
 ) {
+  await settleWebviewLayout();
   const factor = await appWindow.scaleFactor().catch(() => null);
   if (!Number.isFinite(factor) || factor <= 0) return previousPhysical;
-  const physical = await scaledPhysicalSize(
+  const formulaPhysical = await scaledPhysicalSize(
     api,
     appWindow,
     width,
@@ -298,24 +331,105 @@ async function reconcileFloatingSizeAfterShow(
     contentScale,
     factor,
   );
-  const current = await appWindow.innerSize().catch(() => null);
-  const sizeMatches =
+  let current = await appWindow.innerSize().catch(() => null);
+  let appliedPhysical = current || previousPhysical || formulaPhysical;
+
+  const formulaMatches =
     current &&
-    Math.abs(current.width - physical.width) <= 1 &&
-    Math.abs(current.height - physical.height) <= 1;
-  if (
-    previousPhysical &&
-    physical.width === previousPhysical.width &&
-    physical.height === previousPhysical.height &&
-    sizeMatches
-  ) {
-    return previousPhysical;
+    Math.abs(current.width - formulaPhysical.width) <= 1 &&
+    Math.abs(current.height - formulaPhysical.height) <= 1;
+  if (!formulaMatches) {
+    appliedPhysical = formulaPhysical;
+    await appWindow.setSize(formulaPhysical).catch((error) => {
+      console.warn("Unable to apply the calculated floating window size.", error);
+    });
+    await settleWebviewLayout();
+    current = await appWindow.innerSize().catch(() => null);
   }
-  await appWindow.setSize(physical).catch((error) => {
-    console.warn("Unable to reconcile the floating window size.", error);
+
+  const initialViewportWidth = window.innerWidth;
+  const initialViewportHeight = window.innerHeight;
+  if (
+    Math.abs(initialViewportWidth - width) <= 1 &&
+    Math.abs(initialViewportHeight - height) <= 1
+  ) {
+    await clampIntoWorkArea(api, appWindow, current || appliedPhysical);
+    return current || appliedPhysical;
+  }
+
+  // 外框已经是设计尺寸 × 应用比例 × DPI，但视口仍偏小时，优先抵消 WebView2
+  // 额外保留的 zoom。这样不会为了显示完整内容而把整个卡片无端放大。
+  const correctedZoom = viewportCorrectedZoom({
+    contentScale,
+    viewportWidth: initialViewportWidth,
+    viewportHeight: initialViewportHeight,
+    expectedWidth: width,
+    expectedHeight: height,
   });
-  await clampIntoWorkArea(api, appWindow, physical);
-  return physical;
+  if (correctedZoom) {
+    await applyWebviewZoom(correctedZoom);
+    await settleWebviewLayout();
+    current = await appWindow.innerSize().catch(() => current);
+    if (
+      Math.abs(window.innerWidth - width) <= 1 &&
+      Math.abs(window.innerHeight - height) <= 1
+    ) {
+      await clampIntoWorkArea(api, appWindow, current || appliedPhysical);
+      return current || appliedPhysical;
+    }
+  }
+
+  for (let pass = 0; pass < 2; pass += 1) {
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    if (
+      Math.abs(viewportWidth - width) <= 1 &&
+      Math.abs(viewportHeight - height) <= 1
+    ) {
+      await clampIntoWorkArea(api, appWindow, appliedPhysical);
+      return appliedPhysical;
+    }
+
+    const corrected = current
+      ? viewportCorrectedPhysicalSize({
+          currentPhysicalWidth: current.width,
+          currentPhysicalHeight: current.height,
+          viewportWidth,
+          viewportHeight,
+          expectedWidth: width,
+          expectedHeight: height,
+        })
+      : null;
+    appliedPhysical = corrected
+      ? new api.PhysicalSize(corrected.width, corrected.height)
+      : formulaPhysical;
+    await appWindow.setSize(appliedPhysical).catch((error) => {
+      console.warn("Unable to reconcile the floating window size.", error);
+    });
+    await settleWebviewLayout();
+    current = await appWindow.innerSize().catch(() => null);
+  }
+
+  if (
+    Math.abs(window.innerWidth - width) <= 1 &&
+    Math.abs(window.innerHeight - height) <= 1
+  ) {
+    await clampIntoWorkArea(api, appWindow, current || appliedPhysical);
+    return current || appliedPhysical;
+  }
+
+  console.warn("Floating window viewport remains desynchronized.", {
+    expectedWidth: width,
+    expectedHeight: height,
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+    contentScale,
+    scaleFactor: factor,
+    targetPhysicalWidth: appliedPhysical.width,
+    targetPhysicalHeight: appliedPhysical.height,
+  });
+  await clampIntoWorkArea(api, appWindow, appliedPhysical);
+  return appliedPhysical;
 }
 
 // compact 与 strip 各自记位，互不覆盖；expanded 不记位。
@@ -694,7 +808,7 @@ async function resizeStripWindow({ width, height }) {
     anchor.right = Math.abs(pos.x + outer.width - workRight) <= 8;
     anchor.bottom = Math.abs(pos.y + outer.height - workBottom) <= 8;
   }
-  const physical = await scaledPhysicalSize(
+  let physical = await scaledPhysicalSize(
     api,
     appWindow,
     targetWidth,
@@ -705,6 +819,14 @@ async function resizeStripWindow({ width, height }) {
   await appWindow.setSize(physical).catch((error) => {
     console.warn("Unable to resize the strip window.", error);
   });
+  physical = await reconcileFloatingSizeAfterShow(
+    api,
+    appWindow,
+    targetWidth,
+    targetHeight,
+    stripScale,
+    physical,
+  );
   // 测量收敛出的尺寸记作下次变形的首帧（否则首帧永远是常量估计）。
   rememberStripSize(targetWidth, targetHeight);
   if ((anchor.right || anchor.bottom) && pos && workArea) {
@@ -742,7 +864,7 @@ async function resizeCompactWindow({ height }) {
     const capCss = monitor.workArea.size.height / factor / uiScale - 48;
     targetHeight = Math.min(targetHeight, Math.max(size.minHeight, Math.floor(capCss)));
   }
-  const physical = await scaledPhysicalSize(
+  let physical = await scaledPhysicalSize(
     api,
     appWindow,
     size.width,
@@ -753,6 +875,14 @@ async function resizeCompactWindow({ height }) {
   await appWindow.setSize(physical).catch((error) => {
     console.warn("Unable to resize the compact window.", error);
   });
+  physical = await reconcileFloatingSizeAfterShow(
+    api,
+    appWindow,
+    size.width,
+    targetHeight,
+    uiScale,
+    physical,
+  );
   // 高度收敛值记作下次变形的首帧。
   rememberCompactHeight(targetHeight);
   // 变高可能把窗口底边顶出屏幕；钳位用刚算出的 physical（setSize 异步生效，
@@ -782,7 +912,14 @@ async function reassertCompactSize(scaleFactor = null) {
   await appWindow.setSize(physical).catch((error) => {
     console.warn("Unable to reassert the compact window size.", error);
   });
-  await clampIntoWorkArea(api, appWindow, physical);
+  await reconcileFloatingSizeAfterShow(
+    api,
+    appWindow,
+    size.width,
+    compactContentHeight(size.height),
+    uiScale,
+    physical,
+  );
 }
 
 /// strip 不能只靠 DOM ResizeObserver：跨屏时 WebView 的 CSS 视口可能仍认为自己
@@ -807,7 +944,14 @@ async function reassertStripSize({ width, height, scaleFactor = null }) {
   await appWindow.setSize(physical).catch((error) => {
     console.warn("Unable to reassert the strip window size.", error);
   });
-  await clampIntoWorkArea(api, appWindow, physical);
+  await reconcileFloatingSizeAfterShow(
+    api,
+    appWindow,
+    targetWidth,
+    targetHeight,
+    stripScale,
+    physical,
+  );
 }
 
 /// macOS 菜单栏面板的高度跟随内容（宽度恒为 compact 设计宽）。

--- a/src/windowGeometry.js
+++ b/src/windowGeometry.js
@@ -29,6 +29,97 @@ function physicalWindowSize(width, height, contentScale = 1, monitorScale = 1) {
   };
 }
 
+/// WebView2 偶尔在混合 DPI 环境保留一层额外 zoom，导致原生窗口物理尺寸正确，
+/// 但 CSS 视口仍偏小。以当前“物理像素 / CSS 视口”的实测比例反算目标尺寸，
+/// 不再假设系统 DPI 与 setZoom 就是完整缩放链。
+function viewportCorrectedPhysicalSize({
+  currentPhysicalWidth,
+  currentPhysicalHeight,
+  viewportWidth,
+  viewportHeight,
+  expectedWidth,
+  expectedHeight,
+}) {
+  const values = [
+    currentPhysicalWidth,
+    currentPhysicalHeight,
+    viewportWidth,
+    viewportHeight,
+    expectedWidth,
+    expectedHeight,
+  ];
+  if (values.some((value) => !Number.isFinite(value) || value <= 0)) return null;
+
+  const widthRatio = expectedWidth / viewportWidth;
+  const heightRatio = expectedHeight / viewportHeight;
+  // 防止隐藏/切形态的瞬时 0 尺寸把窗口放大到不可恢复；正常 DPI/zoom
+  // 残差都落在 0.5–2 之间（应用自身允许的缩放范围也是 0.75–2）。
+  if (
+    widthRatio < 0.5 ||
+    widthRatio > 2 ||
+    heightRatio < 0.5 ||
+    heightRatio > 2
+  ) {
+    return null;
+  }
+  return {
+    width: Math.max(1, Math.round(currentPhysicalWidth * widthRatio)),
+    height: Math.max(1, Math.round(currentPhysicalHeight * heightRatio)),
+  };
+}
+
+function viewportCorrectedZoom({
+  contentScale,
+  viewportWidth,
+  viewportHeight,
+  expectedWidth,
+  expectedHeight,
+}) {
+  const values = [
+    contentScale,
+    viewportWidth,
+    viewportHeight,
+    expectedWidth,
+    expectedHeight,
+  ];
+  if (values.some((value) => !Number.isFinite(value) || value <= 0)) return null;
+
+  const widthRatio = viewportWidth / expectedWidth;
+  const heightRatio = viewportHeight / expectedHeight;
+  // 真实 zoom 应在两条轴上给出近似相同的比例；差异过大说明布局/尺寸仍在变化，
+  // 此时交给物理窗口兜底，不贸然改变内容缩放。
+  if (
+    widthRatio < 0.5 ||
+    widthRatio > 2 ||
+    heightRatio < 0.5 ||
+    heightRatio > 2 ||
+    Math.abs(widthRatio - heightRatio) > 0.08
+  ) {
+    return null;
+  }
+  return contentScale * ((widthRatio + heightRatio) / 2);
+}
+
+function horizontalStripTargetWidth({
+  cellCount,
+  cellWidth,
+  controlsWidth,
+  paddingLeft,
+  paddingRight,
+  gap,
+  roundingAllowance = 1,
+}) {
+  const cells = Math.max(1, Math.round(cellCount || 0));
+  return (
+    cells * cellWidth +
+    controlsWidth +
+    paddingLeft +
+    paddingRight +
+    cells * gap +
+    roundingAllowance
+  );
+}
+
 /// 记忆坐标是物理像素；用每台显示器自己的 DPI 推导候选窗口大小，再选与工作区
 /// 重叠最多的显示器。不能先读当前窗口 DPI——窗口随后可能恢复到另一台屏幕。
 function monitorForWindowPosition(
@@ -71,4 +162,10 @@ function monitorForWindowPosition(
   return best;
 }
 
-export { monitorForWindowPosition, physicalWindowSize };
+export {
+  horizontalStripTargetWidth,
+  monitorForWindowPosition,
+  physicalWindowSize,
+  viewportCorrectedPhysicalSize,
+  viewportCorrectedZoom,
+};

--- a/src/windowGeometry.test.js
+++ b/src/windowGeometry.test.js
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  horizontalStripTargetWidth,
   monitorForWindowPosition,
   physicalWindowSize,
+  viewportCorrectedPhysicalSize,
+  viewportCorrectedZoom,
 } from "./windowGeometry.js";
 
 function monitor(x, width, scaleFactor, workHeight = 1080) {
@@ -65,4 +68,70 @@ test("fully off-screen remembered positions do not select a monitor", () => {
     1,
   );
   assert.equal(selected, null);
+});
+
+test("horizontal strip width includes every outer flex gap", () => {
+  assert.equal(
+    horizontalStripTargetWidth({
+      cellCount: 2,
+      cellWidth: 68,
+      controlsWidth: 146,
+      paddingLeft: 6,
+      paddingRight: 5,
+      gap: 4,
+    }),
+    302,
+  );
+  assert.equal(
+    horizontalStripTargetWidth({
+      cellCount: 0,
+      cellWidth: 68,
+      controlsWidth: 146,
+      paddingLeft: 6,
+      paddingRight: 5,
+      gap: 4,
+    }),
+    230,
+  );
+});
+
+test("runtime viewport corrects a hidden WebView zoom layer", () => {
+  assert.deepEqual(
+    viewportCorrectedPhysicalSize({
+      currentPhysicalWidth: 560,
+      currentPhysicalHeight: 560,
+      viewportWidth: 256,
+      viewportHeight: 256,
+      expectedWidth: 320,
+      expectedHeight: 320,
+    }),
+    { width: 700, height: 700 },
+  );
+});
+
+test("runtime viewport correction rejects transient invalid measurements", () => {
+  assert.equal(
+    viewportCorrectedPhysicalSize({
+      currentPhysicalWidth: 560,
+      currentPhysicalHeight: 560,
+      viewportWidth: 0,
+      viewportHeight: 0,
+      expectedWidth: 320,
+      expectedHeight: 320,
+    }),
+    null,
+  );
+});
+
+test("runtime viewport can cancel a hidden WebView zoom layer", () => {
+  assert.equal(
+    viewportCorrectedZoom({
+      contentScale: 1,
+      viewportWidth: 256,
+      viewportHeight: 256,
+      expectedWidth: 320,
+      expectedHeight: 320,
+    }),
+    0.8,
+  );
 });


### PR DESCRIPTION
## What changed

- treat the rendered CSS viewport as the final sizing authority for Windows compact and strip forms
- compensate residual WebView2 zoom drift before falling back to a bounded physical-size correction
- serialize self-healing corrections so stale monitor/DPI work cannot overwrite the newest correction
- include horizontal strip flex gaps in the measured target width
- add regression coverage for the reported 256px viewport inside a 320px compact design

## Root cause

On the affected mixed-DPI dual-monitor setup, the native HWND reached the expected physical size while WebView2 retained an additional zoom layer. Reissuing the same native size therefore could not restore the full CSS viewport. The vertical strip shared the same failure; the horizontal strip happened to self-measure wide enough to remain visible.

## Impact

Affected scope: Windows shell plus shared strip geometry helpers. macOS shell behavior is unchanged.

The reporting user verified the R2 Windows installer resolves both compact-card and vertical-strip clipping.

## Validation

- `npm test` — 11 passed
- `npm run build`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` — 150 passed, 5 ignored
- native Windows release bundle built and verified by the affected mixed-DPI user