### PR TITLE
feat: merge Qoder CLI credits

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,6 +72,7 @@ Quota rows are replaced wholesale, never merged, so a window a plan no longer ha
 
 - **Codex**: `primary` and `secondary` are slots, not window semantics — a plan may carry a weekly window in the `primary` slot and have no `secondary` at all. Windows are classified by `windowDurationMins` (≤ 1440 minutes is a session window, otherwise weekly); the slot name is only a fallback when the duration is absent. A successful `app-server` read replaces the whole Codex row set.
 - **Claude**: the statusLine hook file is the zero-credential source. Windows handles the hook inside `metrik.exe --statusline` before desktop initialization; macOS and Linux use the generated Python hook. The opt-in OAuth source (off by default) reads the token Claude Code already stores and queries the official usage endpoint; the token is never persisted, uploaded, or logged. A successful read from either source replaces the whole Claude row set; a failed OAuth read falls back to the hook file rather than to a guess.
+- **Qoder**: Qoder, QoderWork, and Qoder CLI share one account-level Credits quota. The existing dashboard-cookie source reads that one quota only; it does not decrypt CLI credentials. Qoder CLI local telemetry with zero token counters is ignored rather than counted.
 - A window whose reset time has passed without fresh data renders as `--`, not as its last known percentage.
 
 ## Storage

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -30,6 +30,10 @@ change.
   only `Kimi`. Their credential sources stay separate internally, while
   duplicate official windows keep the fresher reliable sample. The monthly OMNI
   cycle remains visible; gift and booster balances remain hidden.
+- Qoder, QoderWork, and Qoder CLI are one visible `Qoder` quota identity.
+  Their account-level Credits are shared, so they must never create separate
+  agent counters or be summed. Qoder CLI's local telemetry is not a token
+  source when it reports zero counters.
 - Do not expose credentials or raw provider responses through UI, logs, storage,
   sync, fixtures, or diagnostics.
 

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -4,8 +4,8 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 /// 所有已启用 adapter 的 ID，前端 series 与汇总按此顺序输出。
-/// qoder 是配额-only：本地不落可解析的 token 用量（QoderWork agents.db
-/// 字段恒 0），只有官网 Credits 配额来源，没有对应的日志 adapter。
+/// qoder 是配额-only：Qoder、QoderWork 与 Qoder CLI 共用同一账户级 Credits
+/// 配额来源。Qoder CLI 的本地遥测 token 字段实测为 0，不能作为用量账本来源。
 /// kimiwork 只保留为内部配额来源，窗口合并到 kimi，不作为独立可见 Agent。
 pub const AGENT_IDS: [&str; 8] = [
     "codex",

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -1327,6 +1327,14 @@ fn source_views(report: ScanReport, sync_status: Option<SyncView>) -> Vec<Source
             quality: "exact".into(),
             quality_label: "精确解析".into(),
         },
+        SourceView {
+            id: "qoder-quota".into(),
+            kind: "official".into(),
+            label: "Qoder 官方 Credits".into(),
+            detail: "账户级 Credits 覆盖 Qoder、QoderWork 与 Qoder CLI；通过用户提供的官网 Cookie 读取，不读取或解密客户端登录凭据，也不把本地遥测的零 token 当作用量。".into(),
+            quality: "official".into(),
+            quality_label: "官方".into(),
+        },
     ];
 
     if let Some(sync_status) = sync_status.filter(|status| status.enabled) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,7 +158,7 @@ const AGENT_META = {
     iconClass: "agent-icon--workbuddy",
   },
   qoder: {
-    // 配额-only：Qoder/QoderWork 本地不落 token 用量，只有官网 Credits。
+    // 配额-only：Qoder/QoderWork/Qoder CLI 共用官网账户级 Credits。
     label: "Qoder",
     // 深青蓝：与 codex 的宝蓝、opencode 的青绿保持距离。
     accent: "#3a7ca5",
@@ -2247,7 +2247,7 @@ function QoderQuotaCard({ onSnapshotRefresh }) {
     <div className="settings-card">
       <h2>Qoder 官方额度</h2>
       <p className="settings-muted">
-        Qoder/QoderWork 本地不落 token 用量，只能读官网 Credits 额度，需要你提供一次
+        Qoder、QoderWork 与 Qoder CLI 共用账户级 Credits；本地客户端不提供可可靠解析的 token 用量，只能读官网 Credits 额度，需要你提供一次
         登录 cookie。cookie 仅明文保存在本机（不入账本、不进同步导出），可随时清除。
       </p>
       <details className="settings-guide">

--- a/src/usageClient.js
+++ b/src/usageClient.js
@@ -195,7 +195,7 @@ function demoSnapshot(period = "today") {
       { id: "kimi-local", kind: "local", label: "Kimi 本地 Token", detail: "只计单轮增量记录（会话累计记录会重复计数）；未安装 Kimi 时保持为 0。", quality: "exact", qualityLabel: "精确解析" },
       { id: "antigravity-live", kind: "local", label: "Antigravity 用量", detail: "来自本机 language server 实时 RPC；IDE 未运行时为 0，不估算。尚未实机验收。", quality: "exact", qualityLabel: "精确解析" },
       { id: "workbuddy-local", kind: "local", label: "WorkBuddy 本地 Token", detail: "读取 CodeBuddy/WorkBuddy 会话转录的 usage 字段并以消息标识去重；未安装时保持为 0。", quality: "exact", qualityLabel: "精确解析" },
-      { id: "qoder-quota", kind: "official", label: "Qoder 官方 Credits", detail: "设置 QODER_COOKIE 环境变量后读取官网额度；本地不落 token 用量，无本地统计。", quality: "official", qualityLabel: "官方" },
+      { id: "qoder-quota", kind: "official", label: "Qoder 官方 Credits", detail: "覆盖 Qoder、QoderWork 与 Qoder CLI 的账户级额度；设置 QODER_COOKIE 环境变量后读取官网额度，不把本地零 token 遥测当作用量。", quality: "official", qualityLabel: "官方" },
       { id: "kimi-quota", kind: "official", label: "Kimi 官方配额", detail: "合并 Kimi Code 与 kimi-desktop 的官方窗口；重复的 5h/7d 只显示一份，并保留月度订阅周期。", quality: "official", qualityLabel: "官方" },
     ],
     indexing: { pending: 0 },


### PR DESCRIPTION
## What changed
- Presents Qoder CLI as part of the single Qoder account-level Credits source.
- Adds the official Qoder source to the desktop source drawer.
- Keeps Qoder, QoderWork, and Qoder CLI out of separate agent/token counters.

## Why
Qoder CLI shares account-level Credits with Qoder and QoderWork, while its local telemetry reports zero token values and cannot be counted reliably.

## Validation
- cargo fmt --check
- cargo test
- npm test -- --run
- npm run build