### PR TITLE
Refine macOS panel aesthetic and fix USD symbol typography

### DIFF
--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -82,6 +82,17 @@ change.
 
 - Compact mode is a native menu-bar panel that follows current system
   appearance and material. It is not a floating Windows-style strip.
+- The panel material is system vibrancy from the HUD family, kept in the
+  active state because the non-activating panel never becomes key. The
+  glass-density slider adjusts a scrim above vibrancy, so blur stays native
+  while density sweeps continuously from airy to near-solid in both light
+  and dark appearance.
+- The panel has a fixed design size (width 320, height follows content). The
+  widget-scale setting is a Windows-only concept and is hidden on macOS; the
+  panel is part of the system UI and does not scale.
+- Appearance changes made in the separate expanded window (glass density)
+  propagate live to the panel webview via the Tauri event bus — WKWebView
+  storage events do not cross windows.
 - Content overlays must remain readable on both light and dark desktops.
 - The menu bar uses Metrik's own minimal grammar: one monochrome provider icon
   plus official remaining percentage for every selected agent, `--` for

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1093,9 +1093,11 @@ fn open_expanded_window(app: tauri::AppHandle, nav: Option<String>) -> Result<()
 
 /// macOS 菜单栏面板在紧凑卡片与胶囊条之间切换尺寸；后端负责在改尺寸后
 /// 重新锚定菜单栏图标。其它平台不调用此命令。
+/// 高度按高分屏可用高留足余量（前端已按 screen.availHeight 钳过），
+/// 这里只挡明显异常的值。
 #[tauri::command]
 fn resize_macos_panel(app: tauri::AppHandle, width: f64, height: f64) -> Result<(), String> {
-    if !(48.0..=640.0).contains(&width) || !(40.0..=640.0).contains(&height) {
+    if !(48.0..=640.0).contains(&width) || !(40.0..=2400.0).contains(&height) {
         return Err("macOS 面板尺寸超出允许范围".into());
     }
     #[cfg(target_os = "macos")]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,6 +56,7 @@ import {
   UI_SCALE_RANGE,
   applyStartupUiScale,
   applyWindowMode,
+  broadcastMacAppearance,
   checkForUpdate,
   closeWindow,
   getAutostart,
@@ -63,6 +64,7 @@ import {
   isDesktop,
   isMacPlatform,
   minimizeWindow,
+  onMacAppearance,
   onScaleFactorChanged,
   onTrayShowExpanded,
   openExpandedWindow,
@@ -667,7 +669,10 @@ function BreakdownSection({ snapshot, selectedAgent }) {
         <article className="breakdown-card">
           <h2>成本估算</h2>
           <p className="cost-total">
-            <strong>{formatUsd(scopedUsd)}</strong>
+            <strong>
+              <span className="cost-currency">$</span>
+              {formatUsd(scopedUsd).slice(1)}
+            </strong>
             <span>本周期 · API 等价</span>
           </p>
           <ul className="comp-legend">
@@ -1309,7 +1314,7 @@ function CompactWidget({
         );
         const macTarget = Math.min(target, cap);
         if (Math.abs(macTarget - shell.clientHeight) >= 2) {
-          runWindowAction(() => resizeMacosPanel({ width: rect.width || 320, height: macTarget }));
+          runWindowAction(() => resizeMacosPanel({ height: macTarget }));
         }
         return;
       }
@@ -2103,18 +2108,20 @@ function AppearanceCard({ theme, onThemeChange, glassAlpha, onGlassAlpha, uiScal
         ariaLabel="玻璃浓度百分比"
         onChange={onGlassAlpha}
       />
-      <SliderRow
-        label="小组件缩放"
-        hint={IS_MAC
-          ? "等比缩放菜单栏面板，下次打开时生效。"
-          : "等比缩放桌面小插件；滑杆改动下次进入时生效。"}
-        min={UI_SCALE_RANGE.min * 100}
-        max={UI_SCALE_RANGE.max * 100}
-        step={5}
-        percent={Math.round(uiScale * 100)}
-        ariaLabel="小组件缩放百分比"
-        onChange={onUiScale}
-      />
+      {/* mac 的菜单栏面板是系统 UI 的一部分，尺寸固定不提供缩放；
+          缩放只针对 Windows 的桌面小插件与胶囊条。 */}
+      {!IS_MAC && (
+        <SliderRow
+          label="小组件缩放"
+          hint="等比缩放桌面小插件；滑杆改动下次进入时生效。"
+          min={UI_SCALE_RANGE.min * 100}
+          max={UI_SCALE_RANGE.max * 100}
+          step={5}
+          percent={Math.round(uiScale * 100)}
+          ariaLabel="小组件缩放百分比"
+          onChange={onUiScale}
+        />
+      )}
       {!IS_MAC && (
         <SliderRow
           label="胶囊条缩放"
@@ -3286,6 +3293,7 @@ export function App() {
   const handleGlassAlpha = useCallback((next) => {
     setGlassAlpha(next);
     localStorage.setItem("metrik:glassAlpha", String(next));
+    if (IS_MAC) runWindowAction(() => broadcastMacAppearance({ glassAlpha: next }));
   }, []);
   // 卡片/胶囊的整体缩放系数（连续值）：窗口尺寸与 WebView 原生 zoom 同乘一个系数，
   // 等比放大不会变形；expanded 有独立系数。生效在 windowClient 的形态切换里，
@@ -3488,6 +3496,22 @@ export function App() {
       media?.removeEventListener?.("change", apply);
     };
   }, [transparent, viewMode]);
+
+  // mac 的设置页开在独立的完整视图窗口里，面板是另一个 webview 实例，
+  // 拖滑杆时面板自己的 React 状态不会变。WKWebView 的 storage 事件不跨
+  // 窗口触发（每窗口独立 process pool），所以经 Tauri 事件总线把玻璃浓度
+  // 实时推进面板（改 CSS 变量当场可见）。广播也会回到发送方，处理是幂等
+  // 的。其它平台单窗口无此问题。
+  useEffect(() => {
+    if (!IS_MAC || !isDesktop()) return undefined;
+    const unlistenPromise = onMacAppearance((payload) => {
+      const alpha = Number(payload.glassAlpha);
+      if (Number.isFinite(alpha) && alpha >= 0.6 && alpha <= 0.96) setGlassAlpha(alpha);
+    });
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, []);
 
   // 边缘挂靠：拖到屏幕上缘自动收起，鼠标碰边弹出。
   useEffect(() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -247,9 +247,18 @@ button:focus-visible {
 .widget-shell--mac:not(.widget-shell--glass-css) {
   /* 与 setEffects 传给窗口的 radius 对齐，避免四角露出方形材质。 */
   border-radius: 14px;
+  /* 浓度滑杆（0.60–0.96 写进 --glass-alpha）映射到 vibrancy 之上的罩层：
+     模糊由系统 hudWindow 材质提供，罩层只管浓度。两段线性拉开动态范围：
+     低半段（60→82%）0.05→0.42 清透递进，默认 0.82 → 0.42 与旧固定罩同档；
+     高半段（82→96%）0.42→0.90 加速冲向近实心——深色外观下 vibrancy 本身
+     就是深底，斜率不够的话拉满也看不出差别。 */
+  --mac-scrim: calc(
+    clamp(0.05, calc((var(--glass-alpha, 0.82) - 0.6) * 1.68 + 0.05), 0.42)
+    + clamp(0, calc((var(--glass-alpha, 0.82) - 0.82) * 3.43), 0.48)
+  );
   background:
     radial-gradient(130% 100% at 14% 0%, rgba(178, 200, 255, 0.07), transparent 52%),
-    linear-gradient(168deg, rgba(30, 34, 46, 0.22), rgba(12, 15, 22, 0.3));
+    linear-gradient(168deg, rgb(30 34 46 / calc(var(--mac-scrim) * 0.88)), rgb(12 15 22 / var(--mac-scrim)));
   border: none;
   /* 窗口阴影由 NSPanel 自己投，CSS 不再叠外阴影。 */
   box-shadow:
@@ -1052,9 +1061,10 @@ html:has(.strip-shell) #root {
    Metrik 的 WebView 内容也必须随之切换前景色，不能在浅色材质上继续用白字。 */
 @media (prefers-color-scheme: light) {
   .widget-shell--mac:not(.widget-shell--glass-css) {
+    /* 浅色外观：同一浓度值驱动白罩——低档几乎纯 vibrancy，高档霜白近实。 */
     background:
-      radial-gradient(130% 100% at 14% 0%, rgba(255, 255, 255, 0.48), transparent 52%),
-      linear-gradient(168deg, rgba(252, 252, 252, 0.4), rgba(238, 241, 246, 0.3));
+      radial-gradient(130% 100% at 14% 0%, rgb(255 255 255 / calc(var(--mac-scrim) * 1.15)), transparent 52%),
+      linear-gradient(168deg, rgb(252 252 252 / var(--mac-scrim)), rgb(238 241 246 / calc(var(--mac-scrim) * 0.8)));
     box-shadow:
       inset 0 0 0 1px rgba(31, 33, 36, 0.1),
       inset 0 1px rgba(255, 255, 255, 0.72);
@@ -1786,8 +1796,16 @@ html:has(.strip-shell) #root {
   font-weight: 400;
   font-variant-numeric: lining-nums tabular-nums;
   letter-spacing: -0.03em;
-  /* 1.0 会把 $ 上下探出的竖线裁掉（Newsreader 的 $ 高于数字）。 */
   line-height: 1.15;
+}
+
+/* Newsreader 的 $ 是带贯穿竖线的老式字形，34px 下像多画了一竖；
+   货币符号改用界面无衬线并降一号，数字保持衬线大字。 */
+.cost-total strong .cost-currency {
+  font-family: "Geist Variable", "Segoe UI Variable", sans-serif;
+  font-size: 21px;
+  font-weight: 500;
+  margin-right: 2px;
 }
 
 .cost-total span { color: #74767a; font-size: 11px; }

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -551,6 +551,22 @@ async function onTrayShowExpanded(handler) {
   return listen("tray://show-expanded", () => handler());
 }
 
+/// mac 外观改动（玻璃浓度）的跨窗口广播：设置页开在独立的完整视图窗口，
+/// 面板是另一个 webview 实例。WKWebView 的 storage 事件不跨窗口触发
+/// （每个窗口是独立 process pool），所以走 Tauri 事件总线；emit 也会回到
+/// 发送方自己，监听方要能幂等处理。其它平台单窗口，不用广播。
+async function broadcastMacAppearance(payload) {
+  if (!isDesktop() || !isMacPlatform()) return;
+  const { emit } = await import("@tauri-apps/api/event");
+  await emit("metrik://mac-appearance", payload).catch(() => {});
+}
+
+async function onMacAppearance(handler) {
+  if (!isDesktop() || !isMacPlatform()) return () => {};
+  const { listen } = await import("@tauri-apps/api/event");
+  return listen("metrik://mac-appearance", (event) => handler(event.payload || {}));
+}
+
 /// 拖动结束后持久化窗口位置（compact 与 strip 各记各的；expanded 不记）。
 async function startPositionMemory(getMode) {
   if (isMacPlatform()) return () => {};
@@ -632,11 +648,8 @@ async function applyWindowMode(mode, options = {}) {
   // macOS 的完整视图是独立窗口；菜单栏 NSPanel 只保留 compact 卡片。
   if (isMacPlatform()) {
     if (!isDesktop()) return;
-    const size = WINDOW_SIZES.compact;
-    const width = size.width;
     // 首帧直接用上次内容测量的高度（同 Windows 的尺寸缓存），避免两段式跳变。
-    const height = compactContentHeight(size.height);
-    await invoke("resize_macos_panel", { width, height });
+    await resizeMacosPanel({ height: compactContentHeight(WINDOW_SIZES.compact.height) });
     return;
   }
 
@@ -964,12 +977,18 @@ async function reassertStripSize({ width, height, scaleFactor = null }) {
   );
 }
 
-/// macOS 菜单栏面板的高度跟随内容（宽度恒为 compact 设计宽）。
+/// macOS 菜单栏面板的高度跟随内容（宽度恒为 compact 设计宽，不做缩放——
+/// 面板是系统 UI 的一部分，尺寸固定；缩放系数只属于 Windows 小插件）。
 /// 面板顶部锚定菜单栏图标，长高向下延伸——macos.rs 的 resize_panel 会
-/// 在尺寸变化后重算锚点，不会漂移。
-async function resizeMacosPanel({ width, height }) {
+/// 在尺寸变化后重算锚点，不会漂移。高度按屏幕可用高钳一次，
+/// 面板不能长出屏幕底。
+async function resizeMacosPanel({ width = WINDOW_SIZES.compact.width, height }) {
   if (!isDesktop() || !isMacPlatform()) return;
-  await invoke("resize_macos_panel", { width, height }).catch(() => {});
+  const maxHeight = Math.max(40, Math.floor((window.screen?.availHeight || 900) - 80));
+  await invoke("resize_macos_panel", {
+    width: Math.round(width),
+    height: Math.min(Math.round(height), maxHeight),
+  }).catch(() => {});
 }
 
 /// 显示器 DPI 变化时回调；调用方据此重算悬浮形态的物理尺寸。
@@ -1026,11 +1045,13 @@ async function setWindowGlass(enabled, radius = 12) {
     await makeWebviewTransparent();
   }
   try {
-    // macOS 的 vibrancy 是单选的：menu 是原生菜单同款材质。面板不再锁死
-    // dark，而是像 CodexBar 的 NSMenu 一样跟随应用当前的系统外观。
+    // macOS 的 vibrancy 是单选的：hudWindow 是系统 HUD 浮层一族的材质，
+    // 比 menu 更薄更清透，跟随系统外观。面板是 nonactivating（永远不会成为
+    // key window），state 必须锁 active，否则材质一直是失焦的发灰态。
+    // 浓度不在这里调——CSS 按滑杆在 vibrancy 之上叠深浅可调的罩层。
     await appWindow.setEffects(
       isMacPlatform()
-        ? { effects: ["menu"], state: "active", radius }
+        ? { effects: ["hudWindow"], state: "active", radius }
         : { effects: ["blur"] },
     );
     return "native";
@@ -1281,6 +1302,7 @@ export {
   WINDOW_SIZES,
   applyStartupUiScale,
   applyWindowMode,
+  broadcastMacAppearance,
   checkForUpdate,
   closeWindow,
   getAutostart,
@@ -1289,6 +1311,7 @@ export {
   isMacPlatform,
   minimizeWindow,
   normalizeUiScale,
+  onMacAppearance,
   onScaleFactorChanged,
   onTrayShowExpanded,
   openExpandedWindow,


### PR DESCRIPTION
## Summary
- macOS menu-bar panel: switch to `hudWindow` vibrancy locked to the active state; the glass-density slider now drives a scrim above system vibrancy (two-segment curve, airy → near-solid) and propagates live from the settings window to the panel via the Tauri event bus (WKWebView storage events do not cross windows).
- The panel keeps a fixed design size — the widget-scale slider is a Windows-only concept and is hidden on macOS.
- Cost card: render the `$` in the UI sans stack one step smaller; Newsreader's `$` has a full-height stroke that reads as a stray vertical bar at 34px. Fixes the symbol on both Windows and macOS.
- Update `docs/PRODUCT-CONSTRAINTS.md` accordingly.

## Verification
- `npm test` 11/11 pass; `vite build` clean.
- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` clean.
- Verified on macOS (dev build): hudWindow material, live density updates from the settings window, fixed panel size, and the reworked `$` rendering.
- Windows still needs a native smoke check for the cost-card `$` (shared code path, Segoe UI Variable fallback in the new font stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)