### PR TITLE
Release v0.12.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,13 @@ cargo test live_snapshot_smoke_test -- --ignored --nocapture  # 读真实本机�
 - 安装包未做代码签名，首次运行需要在系统提示里手动放行。Release 页附 SHA256 可校验文件完整性。
 - Windows 上没装 WebView2 的话，安装器需要联网获取运行时。
 - 只提供 Windows 和 macOS 安装包，Linux 需自行构建。
-- Kimi 与 Antigravity 的解析未经作者实机核对（本机没装这两个），数字有偏差欢迎提 issue。Antigravity 另外要求 IDE 正在运行才有数据。
+- Antigravity 需要 IDE 正在运行才有数据。
 - 首次索引大日志会占一段 CPU 和磁盘。期间界面照常可用、进度可见，未覆盖完整历史的数字会标注出来。
-
-架构与去重逻辑见 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)，长期产品约束见 [docs/PRODUCT-CONSTRAINTS.md](docs/PRODUCT-CONSTRAINTS.md)，Windows 验收清单见 [ACCEPTANCE.md](ACCEPTANCE.md)。
 
 ## License
 
 [AGPL-3.0-or-later](LICENSE)，Copyright © 2026 keros68。
 
-自用、修改、fork 都没有限制。要求只有一条：**分发修改版，或者拿它对外提供网络服务，就得同样以 AGPL-3.0 开源**，包括你改过的部分。
+本项目允许自由使用、修改和 fork。分发修改版，或基于修改版对外提供网络服务时，需按 AGPL-3.0 开放对应源码。
 
 v0.10.0 及更早的版本按 MIT 发布，那些版本仍然适用 MIT。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.12.8",
+      "version": "0.12.9",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.12.8"
+version = "0.12.9"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bump version 0.12.8 → 0.12.9 and carry the user's README wording updates.

This release includes (from #58):
- macOS menu-bar panel: `hudWindow` vibrancy locked to the active state, glass-density slider driving a scrim above system vibrancy with live cross-window propagation, fixed panel size (widget scale is Windows-only and hidden on macOS).
- Cost card: `$` rendered in the UI sans stack, fixing the stray-vertical-bar look of Newsreader's dollar glyph on both Windows and macOS.

After merge, pushing the `v0.12.9` tag will trigger the release workflow (draft release for maintainer confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)