### PR TITLE
feat: add remove button for synced devices

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -622,6 +622,26 @@ async fn configure_sync(
     .map_err(|error| format!("sync configuration task failed: {error}"))?
 }
 
+#[tauri::command]
+async fn remove_sync_device(
+    device_id: String,
+    state: State<'_, AppState>,
+) -> Result<domain::SyncView, String> {
+    let database_path = state.database_path.clone();
+    let scan_gate = Arc::clone(&state.scan_gate);
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let _gate = scan_gate
+            .lock()
+            .map_err(|_| "usage scan lock poisoned".to_owned())?;
+        let mut connection =
+            storage::open_database(&database_path).map_err(|error| error.to_string())?;
+        sync::remove_device(&mut connection, &device_id).map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("sync device removal task failed: {error}"))?
+}
+
 /// Windows 的 SWCA Acrylic：与 Win11 的 DWM Acrylic 不同，它接受自定义
 /// tint 颜色，磨砂更通透、可控（CodexBar 式亮玻璃在 Windows 上的对应物）。
 #[cfg(windows)]
@@ -1307,6 +1327,7 @@ pub fn run() {
             rebuild_local_ledger,
             sync_settings,
             configure_sync,
+            remove_sync_device,
             claude_hook_status,
             set_claude_hook,
             claude_oauth_status,

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -144,6 +144,31 @@ pub fn configure(connection: &mut Connection, directory: Option<String>) -> Resu
     sync_view(connection)
 }
 
+/// 删除一台远端设备：清空它的同步事件与设备记录，并移除共享文件夹里
+/// 它的导出文件。只删本地行不删文件的话，下次 `run_sync` 会因为
+/// `sync_device.exported_at_ms` 已不存在而重新导入同一份文件，删除形同无效。
+/// 本机设备（自身）不接受删除——它不在"已发现的设备"列表里，这里只做防御性校验。
+pub fn remove_device(connection: &mut Connection, device_id: &str) -> Result<SyncView> {
+    let (own_device_id, _) = device_identity(connection)?;
+    if device_id == own_device_id {
+        bail!("无法删除本机设备");
+    }
+
+    if let Some(dir) = sync_directory(connection)? {
+        let _ = std::fs::remove_file(dir.join(export_file_name(device_id)));
+    }
+
+    let transaction = connection.transaction()?;
+    transaction.execute(
+        "DELETE FROM remote_usage_event WHERE device_id = ?1",
+        [device_id],
+    )?;
+    transaction.execute("DELETE FROM sync_device WHERE device_id = ?1", [device_id])?;
+    transaction.commit()?;
+
+    sync_view(connection)
+}
+
 pub fn sync_view(connection: &Connection) -> Result<SyncView> {
     let (device_id, device_label) = device_identity(connection)?;
     let directory = sync_directory(connection)?;
@@ -561,6 +586,55 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM usage_event", [], |row| row.get(0))
             .unwrap();
         assert_eq!(mine, 1);
+    }
+
+    #[test]
+    fn remove_device_clears_rows_and_export_file() {
+        let shared = TestDirectory::new("remove");
+        let now = Utc::now().timestamp_millis();
+
+        let mut device_a = open_test_db();
+        set_setting(
+            &device_a,
+            SETTING_SYNC_DIR,
+            &shared.path().to_string_lossy(),
+        )
+        .unwrap();
+        insert_local_event(&device_a, "event-a", now - 1_000, 111);
+        let (device_a_id, _) = device_identity(&device_a).unwrap();
+        run_sync(&mut device_a, now);
+        let export_path = shared.path().join(export_file_name(&device_a_id));
+        assert!(export_path.exists());
+
+        let mut device_b = open_test_db();
+        set_setting(
+            &device_b,
+            SETTING_SYNC_DIR,
+            &shared.path().to_string_lossy(),
+        )
+        .unwrap();
+        run_sync(&mut device_b, now);
+        assert_eq!(sync_view(&device_b).unwrap().devices.len(), 1);
+
+        // B 删除 A：本地行清空，共享文件夹里的 A 导出文件一并移除，
+        // 否则下次同步会原样重新导入。
+        let view = remove_device(&mut device_b, &device_a_id).unwrap();
+        assert!(view.devices.is_empty());
+        let remote: i64 = device_b
+            .query_row("SELECT COUNT(*) FROM remote_usage_event", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(remote, 0);
+        assert!(!export_path.exists());
+    }
+
+    #[test]
+    fn remove_device_rejects_self() {
+        let mut local = open_test_db();
+        let (own_id, _) = device_identity(&local).unwrap();
+        let error = remove_device(&mut local, &own_id).unwrap_err().to_string();
+        assert!(error.contains("本机设备"));
     }
 
     #[test]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import {
   Minus,
   PushPinSimple,
   ShieldCheck,
+  Trash,
   X,
 } from "@phosphor-icons/react";
 import antigravityAppIcon from "./assets/antigravity-app-icon.png";
@@ -50,6 +51,7 @@ import {
   getUsageSessions,
   getUsageSnapshot,
   rebuildLocalLedger,
+  removeSyncDevice,
   setClaudeHook,
 } from "./usageClient";
 import {
@@ -2356,6 +2358,7 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
   const [directoryInput, setDirectoryInput] = useState("");
   const [busy, setBusy] = useState(false);
   const [feedback, setFeedback] = useState(null);
+  const [removingDeviceId, setRemovingDeviceId] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -2389,6 +2392,22 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
       setFeedback({ tone: "error", message: `未能更新同步设置：${error}` });
     } finally {
       setBusy(false);
+    }
+  };
+
+  const removeDevice = async (deviceId) => {
+    setBusy(true);
+    setFeedback(null);
+    try {
+      const next = await removeSyncDevice(deviceId);
+      setSettings(next);
+      setFeedback({ tone: "success", message: "设备已删除，已清除它的同步事件与导出文件。" });
+      onSnapshotRefresh();
+    } catch (error) {
+      setFeedback({ tone: "error", message: `未能删除设备：${error}` });
+    } finally {
+      setBusy(false);
+      setRemovingDeviceId(null);
     }
   };
 
@@ -2524,9 +2543,48 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
                     <ul className="settings-device-list">
                       {settings.devices.map((device) => (
                         <li key={device.id}>
-                          <strong>{device.label}</strong>
-                          <span>{device.id}</span>
-                          <small>{device.events} 条事件 · 导出于 {formatSyncTime(device.exportedAtMs)}</small>
+                          <div className="settings-device-head">
+                            <div className="settings-device-info">
+                              <strong>{device.label}</strong>
+                              <span>{device.id}</span>
+                              <small>{device.events} 条事件 · 导出于 {formatSyncTime(device.exportedAtMs)}</small>
+                            </div>
+                            {removingDeviceId !== device.id && (
+                              <button
+                                type="button"
+                                className="ledger-button ledger-button--secondary settings-device-remove"
+                                disabled={busy || settings?.demo}
+                                onClick={() => setRemovingDeviceId(device.id)}
+                              >
+                                <Trash size={15} weight="light" aria-hidden="true" />
+                                删除
+                              </button>
+                            )}
+                          </div>
+                          {removingDeviceId === device.id && (
+                            <div className="ledger-confirmation" role="group" aria-labelledby={`device-confirm-title-${device.id}`}>
+                              <strong id={`device-confirm-title-${device.id}`}>删除该设备？</strong>
+                              <p>将移除它的同步事件与共享文件夹中的导出文件。若该设备仍在线，会在下次同步后重新出现。</p>
+                              <div className="ledger-confirm-actions">
+                                <button
+                                  type="button"
+                                  className="ledger-button ledger-button--secondary"
+                                  disabled={busy}
+                                  onClick={() => setRemovingDeviceId(null)}
+                                >
+                                  取消
+                                </button>
+                                <button
+                                  type="button"
+                                  className="ledger-button ledger-button--primary"
+                                  disabled={busy}
+                                  onClick={() => removeDevice(device.id)}
+                                >
+                                  {busy ? "正在删除…" : "确认删除"}
+                                </button>
+                              </div>
+                            </div>
+                          )}
                         </li>
                       ))}
                     </ul>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2576,6 +2576,29 @@ html:has(.strip-shell) #root {
   box-shadow: inset 0 0 0 1px rgba(31, 33, 36, 0.07);
 }
 
+.settings-device-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.settings-device-info {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.settings-device-remove {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 0 12px;
+  font-size: 12px;
+}
+
 .glass-slider-row {
   display: flex;
   align-items: center;

--- a/src/usageClient.js
+++ b/src/usageClient.js
@@ -435,6 +435,13 @@ async function configureSync(directory) {
   return invoke("configure_sync", { directory });
 }
 
+async function removeSyncDevice(deviceId) {
+  if (!isTauriRuntime()) {
+    throw new Error("浏览器演示模式不能删除设备");
+  }
+  return invoke("remove_sync_device", { deviceId });
+}
+
 async function getClaudeHookStatus() {
   if (!isTauriRuntime()) {
     return { demo: true, installed: false, conflict: false, lastDataAtMs: null };
@@ -490,6 +497,7 @@ export {
   rebuildLocalLedger,
   getSyncSettings,
   configureSync,
+  removeSyncDevice,
   getClaudeHookStatus,
   setClaudeHook,
   getClaudeOauthStatus,


### PR DESCRIPTION
## Scope
`shared` — the sync layer is platform-neutral (Rust `sync.rs` + Tauri command + one JSX card in `src/App.jsx`). A single change covers both Windows and macOS; no platform-specific shell work.

## What
Each discovered device in the "同步与更新" → "已发现的设备" list now has a delete button with inline confirmation (reuses the existing `ledger-confirmation` pattern).

- **Backend** `src-tauri/src/sync.rs`: new `remove_device(connection, device_id)` deletes `remote_usage_event` + `sync_device` rows for the device and removes its export file `metrik-usage-{id}.json` from the shared folder. Refuses to delete the local device.
- **Backend** `src-tauri/src/lib.rs`: new `remove_sync_device` Tauri command (mirrors `configure_sync` lock-step), registered in `generate_handler`.
- **Frontend** `src/usageClient.js`: `removeSyncDevice(deviceId)`.
- **Frontend** `src/App.jsx`: Trash delete button + inline confirm per device row.
- **Styles** `src/styles.css`: `.settings-device-head / -info / -remove` layout (inherits existing dark-theme `.ledger-button` rules).

## Why delete the export file too
Only deleting local rows is a no-op: the next `run_sync` would re-import the same file because `sync_device.exported_at_ms` no longer exists to skip it. Removing the file means an offline device stays removed; a still-online device reappears after its next export (correct — it is still syncing). This mirrors the existing `configure(None)` behavior for the local export file.

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ 152 passed (incl. new `remove_device_clears_rows_and_export_file`, `remove_device_rejects_self`)
- `npm test` ✅ 11 passed
- `npm run build` ✅