### PR TITLE
Release v0.12.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.12.9",
+      "version": "0.12.10",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.12.9"
+version = "0.12.10"
 description = "Local-first AI agent usage monitor"
 authors = ["Metrik contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bump version to 0.12.10. Ships the sync device delete button (#60) merged on top of v0.12.9.

All five version files agree at 0.12.10 (package.json, package-lock.json top + packages root, src-tauri/tauri.conf.json, src-tauri/Cargo.toml + Cargo.lock).