### PR TITLE
chore(ci): upgrade GitHub Actions to v7 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # 需要全部 tag 才能判断版本号是否已被占用；PR 检出真实的 head 提交而不是
       # 合并提交，否则 base 上的 tag 永远算祖先，撞车就检测不出来。
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -77,9 +77,9 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,13 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # 不开 npm 缓存：它的 post 步骤会在 macOS 上失败，把已经构建成功、产物也传完
       # 的 job 标红（0.3.0、0.4.0 各误报一次）。发布不频繁，不值得为这点缓存收益
-      # 换一个会骗人的红叉。
-      - uses: actions/setup-node@v4
+      # 换一个会骗人的红叉。setup-node v5+ 会在 package.json 含 packageManager 字段时
+      # 自动开缓存——本仓库没有该字段，所以升级后仍是零缓存，与原意图一致。
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 


### PR DESCRIPTION
## Why
The v0.12.10 release build emitted this warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`.

Both `@v4` actions use `runs.using: node20`. Bump to `@v7`, which uses `runs.using: node24`.

## Changes
- `actions/checkout@v4` → `@v7` (3 uses across ci.yml + release.yml)
- `actions/setup-node@v4` → `@v7` (2 uses)

## No-cache behavior preserved
`release.yml` intentionally disables npm caching because its post-step fails on macOS and turns an otherwise-green job red (happened in 0.3.0 and 0.4.0). setup-node v5+ added automatic package-manager caching, but it only triggers when `package.json` has a `packageManager` field — this repo does not. So upgrade keeps zero caching, matching the original intent. Added a comment documenting this so the intent is not lost.

## Verification
CI on this PR is the verification: it must pass on both Windows and macOS with no Node.js 20 deprecation warning. No code change, so no local build/test needed beyond confirming the YAML is well-formed.