### PR TITLE
feat(settings): 关于卡署名作者与仓库链接，补打包发布者元数据

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "metrik",
       "version": "0.13.0",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource/instrument-serif": "^5.2.8",
@@ -14,6 +15,7 @@
         "@phosphor-icons/react": "^2.1.10",
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",
+        "@tauri-apps/plugin-opener": "^2.5.4",
         "@tauri-apps/plugin-os": "^2.3.2",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
@@ -1356,6 +1358,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.4.tgz",
+      "integrity": "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-os": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-autostart": "^2.5.1",
+    "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-os": "^2.3.2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1896,6 +1896,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2211,7 @@ dependencies = [
  "tauri-build",
  "tauri-nspanel",
  "tauri-plugin-autostart",
+ "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
@@ -2586,6 +2606,17 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "open"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -3983,6 +4014,28 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "metrik"
 version = "0.13.0"
 description = "Local-first AI agent usage monitor"
-authors = ["Metrik contributors"]
+authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"
 license = "AGPL-3.0-or-later"
 
@@ -28,6 +28,7 @@ serde_json = "1"
 sha2 = "0.10"
 tauri = { version = "2", features = ["tray-icon", "image-png", "macos-private-api"] }
 tauri-plugin-autostart = "2.5.1"
+tauri-plugin-opener = "2"
 tauri-plugin-os = "2.3.2"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-updater = "2.10.1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -27,6 +27,13 @@
     "autostart:allow-is-enabled",
     "os:allow-platform",
     "updater:default",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        { "url": "https://github.com/keros68/metrik*" },
+        { "url": "mailto:keros68@gmail.com" }
+      ]
+    },
     "process:allow-restart"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -918,6 +918,10 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init());
 
+    // 设置页“关于”里的仓库/邮箱链接用系统浏览器、邮件客户端打开。
+    #[cfg(desktop)]
+    let builder = builder.plugin(tauri_plugin_opener::init());
+
     builder
         .setup(|app| {
             // macOS 是一个菜单栏应用：面板 + 独立完整视图窗口 + template 图标，

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -58,6 +58,8 @@
       "icons/icon.ico"
     ],
     "category": "DeveloperTool",
-    "shortDescription": "Accurate, local-first AI agent usage monitoring"
+    "shortDescription": "Accurate, local-first AI agent usage monitoring",
+    "publisher": "keros68",
+    "copyright": "Copyright © 2026 keros68"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2171,6 +2171,41 @@ function UpdateBlock({ autoCheck, onAutoCheckChange, availableUpdate }) {
   );
 }
 
+const REPO_URL = "https://github.com/keros68/metrik";
+const AUTHOR_EMAIL = "keros68@gmail.com";
+
+// 桌面端交给系统浏览器/邮件客户端（opener 插件，capability 限定了这两个地址）；
+// 浏览器演示模式退化为普通链接。
+function AboutCard() {
+  const openExternal = async (event, url) => {
+    if (!isDesktop()) return;
+    event.preventDefault();
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url).catch((error) => console.warn("open external link failed:", error));
+  };
+  return (
+    <div className="settings-card settings-about">
+      <h2>关于</h2>
+      <p className="settings-muted">
+        Metrik {__APP_VERSION__} · 本地优先的 AI Agent 用量监控 · AGPL-3.0-or-later
+      </p>
+      <p className="settings-muted">
+        作者：keros68（
+        <a href={`mailto:${AUTHOR_EMAIL}`} onClick={(event) => openExternal(event, `mailto:${AUTHOR_EMAIL}`)}>
+          {AUTHOR_EMAIL}
+        </a>
+        ）
+      </p>
+      <p className="settings-muted">
+        项目仓库：
+        <a href={REPO_URL} onClick={(event) => openExternal(event, REPO_URL)}>
+          github.com/keros68/metrik
+        </a>
+      </p>
+    </div>
+  );
+}
+
 const THEME_OPTIONS = [
   { id: "auto", label: "自动" },
   { id: "light", label: "亮色" },
@@ -2796,6 +2831,7 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
               onAutoUpdateCheck={onAutoUpdateCheck}
               availableUpdate={availableUpdate}
             />
+            <AboutCard />
           </>
         )}
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3135,6 +3135,8 @@ html:has(.strip-shell--glass-ink-light) #root {
 
 .settings-error-text { color: #a1573d; }
 .settings-muted { margin: 0; color: #83858a; font-size: 13px; line-height: 1.6; }
+.settings-about a { color: inherit; text-decoration: underline; text-underline-offset: 2px; }
+.settings-about a:hover { color: #5a5c61; }
 
 .settings-device-list {
   display: grid;
@@ -4205,6 +4207,7 @@ html:has(.strip-shell--glass-ink-light) #root {
 :root[data-theme="dark"] .settings-status dt { color: var(--d-faint); }
 :root[data-theme="dark"] .settings-error-text { color: #e6906f; }
 :root[data-theme="dark"] .settings-muted { color: var(--d-faint); }
+:root[data-theme="dark"] .settings-about a:hover { color: var(--d-muted); }
 :root[data-theme="dark"] .settings-guide { color: var(--d-muted); }
 :root[data-theme="dark"] .settings-guide summary { color: #7fabef; }
 :root[data-theme="dark"] .settings-device-list li {


### PR DESCRIPTION
## 范围

shared（设置页 UI + 打包元数据），不改变任何 shell 的窗口行为。

## 改动

- 设置页「同步与更新」标签新增关于卡：版本、作者 keros68、邮箱 `keros68@gmail.com`、仓库 `github.com/keros68/metrik`、许可证 AGPL-3.0-or-later
- 外链经 `tauri-plugin-opener` 用系统浏览器/邮件客户端打开；capability 把 `opener:allow-open-url` 限定在仓库地址与作者邮箱两个目标
- `Cargo.toml` authors 换真实署名；`tauri.conf.json` bundle 补 `publisher` 与 `copyright`（进 Windows 安装包属性）

## 验证

- `npm test` 31 通过、`npm run build` 通过
- `cargo fmt --check`、`cargo clippy -- -D warnings` 干净
- 链接真机点击未验证，合并后顺手在桌面端点一下即可