### PR TITLE
docs(settings): OAuth 说明补充客户端用户用法与刷新节奏

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1973,8 +1973,10 @@ function ClaudeOauthBlock({ onSnapshotRefresh }) {
     <div className="settings-subsection">
       <h3>官方额度直连（OAuth）</h3>
       <p className="settings-muted">
-        备选来源：用本机 Claude Code 已保存的凭据直接查询官方额度（全产品合并值）。
+        备选来源：用本机 Claude Code 已保存的凭据直接查询官方额度（全产品合并值，约两分钟一刷新）。
         凭据只在内存中读取，不存储、不上传；接口失效时自动回落到状态栏钩子。
+        平时只用网页版或桌面客户端也能用：装一次 Claude Code 并运行 claude 登录，之后无需再碰 CLI，
+        网页与客户端的消耗同样计入这里的账户级额度。
       </p>
       <p className="settings-muted">
         ⚠️ 条款风险须知：Anthropic 2026 年 2 月更新的消费者条款禁止在第三方工具中使用 Claude 订阅的


### PR DESCRIPTION
## 范围

shared（设置页文案），无行为变化。

## 改动

- 「官方额度直连（OAuth）」说明补充：只用网页版/桌面客户端的用户，装一次 Claude Code 运行 `claude` 登录即可开启直连，网页与客户端消耗同样计入账户级额度；写明约两分钟一刷新。

## 验证

- `npm test` 31 通过、`npm run build` 通过