### PR TITLE
docs(settings): 关于卡片去掉推销语，只留事实

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2188,9 +2188,7 @@ function AboutCard() {
   return (
     <div className="settings-card settings-about">
       <h2>关于</h2>
-      <p className="settings-muted">
-        Metrik {__APP_VERSION__} · 本地优先的 AI Agent 用量监控 · AGPL-3.0-or-later
-      </p>
+      <p className="settings-muted">Metrik {__APP_VERSION__}</p>
       <p className="settings-muted">
         作者：keros68（
         <a href={`mailto:${AUTHOR_EMAIL}`} onClick={(event) => openExternal(event, `mailto:${AUTHOR_EMAIL}`)}>
@@ -2204,6 +2202,7 @@ function AboutCard() {
           github.com/keros68/metrik
         </a>
       </p>
+      <p className="settings-muted">许可证：AGPL-3.0-or-later</p>
     </div>
   );
 }


### PR DESCRIPTION
原来第一行：

```
Metrik 0.13.1 · 本地优先的 AI Agent 用量监控 · AGPL-3.0-or-later
```

中间那句是推销词，而这里是设置页的「关于」卡片——用户已经装了、正在用，不需要再被介绍一遍这软件干什么。这个位置只该有版本、作者、仓库、许可证。

它同时还是产品的**第三种说法**（README 一种、仓库简介一种、这里又一种），而且 `A · B · C` 三段式与下面两行的「标签：值」不一致。

改成四行：名称与版本、作者、仓库、许可证。

`npm run build` 与 `npm test`（31 项）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)