### PR TITLE
fix(strip): 横向胶囊条在双屏上持续闪烁

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -198,6 +198,9 @@ const STRIP_BAR_HEIGHT = 40;
 // 再宽图标和百分比周围就空得发肥。
 const STRIP_VERTICAL_WIDTH = 42;
 const STRIP_VCELL_HEIGHT = 54;
+// 横条宽度的收缩迟滞。一格 58px，所以 6px 远低于「真的少了一个 Agent」，
+// 又高于 DPI/zoom 取整带来的亚像素噪声。
+const STRIP_WIDTH_SHRINK_SLACK = 6;
 const STRIP_VCHROME_HEIGHT = IS_MAC ? 84 : 160;
 
 function stripWindowSize(orientation, count) {
@@ -1146,7 +1149,12 @@ function StripBar({
         const targetHeight = measureStripVerticalContent(shell);
         if (!targetHeight) return;
         // 交叉轴是设计常量：竖条恒为 52 宽（方向切换后窗口可能还停在横条宽度）。
-        if (Math.abs(targetHeight - shell.clientHeight) < 1 && shell.clientWidth === STRIP_VERTICAL_WIDTH) return;
+        if (
+          Math.abs(targetHeight - shell.clientHeight) < 1
+          && Math.abs(shell.clientWidth - STRIP_VERTICAL_WIDTH) <= 1
+        ) {
+          return;
+        }
         runLatestWindowCorrection(() =>
           resizeStripWindow({ width: STRIP_VERTICAL_WIDTH, height: Math.ceil(targetHeight) }),
         );
@@ -1155,7 +1163,17 @@ function StripBar({
       const targetWidth = measureStripHorizontalTarget(shell);
       if (!targetWidth) return;
       // 交叉轴是设计常量：横条恒为 40 高。
-      if (Math.abs(targetWidth - shell.clientWidth) < 1 && shell.clientHeight === STRIP_BAR_HEIGHT) return;
+      // 宽度方向做不对称迟滞：变宽立即跟进（否则格子被压到内容以下，图标和
+      // 百分比会叠在一起），变窄要超过一格的余量才动。测量噪声只会让目标略微
+      // 变小，对称的 1px 阈值会让它和调窗形成震荡（双屏用户实拍到持续闪烁）。
+      const widthDelta = targetWidth - shell.clientWidth;
+      if (
+        widthDelta < 1
+        && widthDelta > -STRIP_WIDTH_SHRINK_SLACK
+        && shell.clientHeight === STRIP_BAR_HEIGHT
+      ) {
+        return;
+      }
       runLatestWindowCorrection(() =>
         resizeStripWindow({ width: Math.ceil(targetWidth), height: STRIP_BAR_HEIGHT }),
       );

--- a/src/windowGeometry.js
+++ b/src/windowGeometry.js
@@ -97,7 +97,13 @@ function viewportCorrectedZoom({
   ) {
     return null;
   }
-  return contentScale * ((widthRatio + heightRatio) / 2);
+  // 只取长轴的比例，短轴仅用于上面的一致性校验。取平均会把短轴的取整残差
+  // 放大成很大的 zoom 变更：横向胶囊条高 40px，视口差 1 物理像素就是 2.5%，
+  // 平均之后 zoom 被改 1.25%；zoom 一变布局重排，测出来的目标宽度跟着变，
+  // 于是「调窗 → 重排 → 再调窗」闭环，表现为胶囊条持续闪烁。长轴上同样的
+  // 1px 只有 0.25%，落在噪声里。竖条不闪是因为它的宽度是常量，环路断开。
+  const ratio = expectedWidth >= expectedHeight ? widthRatio : heightRatio;
+  return contentScale * ratio;
 }
 
 function horizontalStripTargetWidth({

--- a/src/windowGeometry.test.js
+++ b/src/windowGeometry.test.js
@@ -135,3 +135,57 @@ test("runtime viewport can cancel a hidden WebView zoom layer", () => {
     0.8,
   );
 });
+
+test("短轴上的 1px 取整残差不该改变 zoom 修正", () => {
+  // 横条 400x40：视口高多出 1 物理像素。取两轴平均会得到 1.0125，
+  // 也就是凭空把内容放大 1.25%；放大后布局重排、测出的目标宽度变化，
+  // 就与调窗形成震荡（双屏用户实拍到持续闪烁）。只取长轴则不受影响。
+  assert.equal(
+    viewportCorrectedZoom({
+      contentScale: 1,
+      viewportWidth: 400,
+      viewportHeight: 41,
+      expectedWidth: 400,
+      expectedHeight: 40,
+    }),
+    1,
+  );
+});
+
+test("竖条取高度轴，横条取宽度轴", () => {
+  // 竖条 42x211：长轴是高度，视口高少 10% 时 zoom 应跟着降 10%。
+  assert.equal(
+    viewportCorrectedZoom({
+      contentScale: 1,
+      viewportWidth: 42,
+      viewportHeight: 190,
+      expectedWidth: 42,
+      expectedHeight: 200,
+    }),
+    0.95,
+  );
+  // 横条 400x40：长轴是宽度。
+  assert.equal(
+    viewportCorrectedZoom({
+      contentScale: 1,
+      viewportWidth: 380,
+      viewportHeight: 40,
+      expectedWidth: 400,
+      expectedHeight: 40,
+    }),
+    0.95,
+  );
+});
+
+test("两轴分歧过大时仍然拒绝修正，交给物理尺寸兜底", () => {
+  assert.equal(
+    viewportCorrectedZoom({
+      contentScale: 1,
+      viewportWidth: 400,
+      viewportHeight: 48,
+      expectedWidth: 400,
+      expectedHeight: 40,
+    }),
+    null,
+  );
+});


### PR DESCRIPTION
用户实拍：卡片切成横条后开始闪烁，竖条没有。抽帧看到的不是位置抖动，而是**格子被压到内容以下**（图标和百分比叠在一起）与恢复正常来回跳，也就是窗口宽度在震荡。

## 根因

两种形态的自愈轴正好相反：

| | 被测量的轴 | 交叉轴 |
|---|---|---|
| 竖条 | 高度（长轴 ~211px） | 宽度 = **常量 42** |
| 横条 | **宽度**（测量值） | 高度 = 常量 40 |

竖条的宽度写死，抖动传不回请求值，环路断开；横条的宽度来自 `controls.getBoundingClientRect()`，环路闭合。

闭环的放大器是 `viewportCorrectedZoom`——它取两轴比例的**平均**：

```
横条 期望 400×40：视口高偏 1px → zoom 修正 1.0125（+1.25%）
竖条 期望 42×211：视口高偏 1px → zoom 修正 1.0024（+0.24%）
```

横条短轴只有 40px，1 物理像素就是 2.5% 的比例误差。zoom 一变布局重排，测出的目标宽度跟着变，`ResizeObserver` 再次触发调窗，新的取整残差又喂回来。

双屏把它放大到肉眼可见：不同 DPI 下物理↔CSS 的取整残差本来就更大。

## 修改

1. `viewportCorrectedZoom` **只取长轴比例**，短轴仅用于原有的一致性校验（`|widthRatio - heightRatio| > 0.08` 那道守卫保留）。
2. 横条宽度改为**不对称迟滞**：变宽立即跟进（否则内容被裁），变窄要超过 6px 才动。一格 58px，6px 远低于「真的少了一个 Agent」，又高于取整噪声。
3. 顺带：竖条的交叉轴判断由全等改为 ±1 容差。请求 42 CSS px 实际可能落在 43，全等永远不成立，每次 schedule 都会白调一次窗（不可见，但是无用功）。

## 验证

`npm test` 34 项（新增 3 项，钉住「短轴 1px 噪声不得改变 zoom」「竖条取高度轴、横条取宽度轴」「两轴分歧过大仍拒绝修正」）、`npm run build`、`cargo fmt --check`、`cargo clippy -- -D warnings` 全过。

⚠️ **双屏那条路无法本机验证**——我这台只有单显示器。需要报告问题的用户实机确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)