### PR TITLE
Release v0.13.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.13.2"
+version = "0.13.3"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
五个版本文件从 0.13.2 提到 0.13.3，无其他改动。

本版相对 v0.13.2 只有 #75 的两处修复：

- `fix(mac)`：玻璃浓度滑杆下半程（5%–60%）在 macOS 面板上是死区，`--mac-scrim` 的定义域改成与滑杆一致；默认 82% 与两个端点的观感逐位不变。
- `fix(widget)`：透明卡片 warn 档配额进度条的选择器写成了自身后代，永远不匹配，警示色丢失；Windows 与 macOS 同时受影响。

macOS 面板仍未做实机目视验收，Release 说明沿用既有口径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)