### PR TITLE
fix(mac): 浅色外观下面板仍有白字白条

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1108,9 +1108,15 @@ html:has(.strip-shell) #root {
 
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent-list {
     background: rgba(255, 255, 255, 0.34);
+    /* 滚动条拇指也是白的：面板高度封顶后 Agent 多了就要滚，白压白看不见。 */
+    scrollbar-color: rgba(127, 130, 136, 0.4) transparent;
     box-shadow:
       0 0 0 1px rgba(31, 33, 36, 0.08),
       inset 0 1px rgba(255, 255, 255, 0.52);
+  }
+
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent-list::-webkit-scrollbar-thumb {
+    background: rgba(127, 130, 136, 0.4);
   }
 
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-metric,
@@ -1129,8 +1135,30 @@ html:has(.strip-shell) #root {
     box-shadow: 0 1px rgba(31, 33, 36, 0.07);
   }
 
-  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-window em {
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-window em,
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent em {
     color: rgba(24, 26, 30, 0.92);
+  }
+
+  /* 告急色沿用浅色玻璃那两档：#e8b04a 压在白霜上只有约 1.9:1，读不出来。 */
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-window--warn em,
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent--warn em {
+    color: #8f681f;
+  }
+
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-window--critical em,
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-agent--critical em {
+    color: #a1402e;
+  }
+
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-window--warn .widget-quota-track i {
+    background: var(--warn);
+    filter: none;
+  }
+
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-quota-window--critical .widget-quota-track i {
+    background: var(--critical);
+    filter: none;
   }
 
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-metric > span,
@@ -1165,6 +1193,17 @@ html:has(.strip-shell) #root {
   .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-refresh:disabled:hover {
     color: rgba(31, 33, 36, 0.58);
     background: transparent;
+  }
+
+  /* 白底上的白字底片：按钮沿用面板浅色外观的半透白芯片，墨色翻成深色。 */
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-expand {
+    color: rgba(24, 26, 30, 0.94);
+    background: rgba(255, 255, 255, 0.62);
+    box-shadow: inset 0 0 0 1px rgba(31, 33, 36, 0.1);
+  }
+
+  .widget-shell--mac:not(.widget-shell--glass-css).widget-shell--transparent .widget-expand:hover {
+    background: rgba(255, 255, 255, 0.82);
   }
 
   .strip-shell--mac:not(.strip-shell--glass-css) {


### PR DESCRIPTION
## 范围

`macOS shell`（只动 `@media (prefers-color-scheme: light)` 里的 `.widget-shell--mac` 规则，Windows 与深色外观不受影响）。

## 问题

系统浅色外观下面板已经翻成白霜底 + 深色字，但覆盖规则漏了几处，白墨压白霜读不出来：

- `.widget-agent em`：Agent 行右侧的剩余百分比（实机截图里 Claude 那行的 `71%`）
- `.widget-expand`：底栏「完整视图」按钮
- `.widget-agent-list` 滚动条拇指：面板高度封顶后 Agent 多了就要滚，白拇指在白霜上看不见

另外告急/严重档的 `#e8b04a` / `#ec7a63` 压在白霜上约 1.9:1，同样读不出来。

## 改法

全部沿用 Windows 浅色玻璃档（`--glass-light`）已有的配色，不新造：百分比 `rgba(24, 26, 30, 0.92)`、warn `#8f681f`、critical `#a1402e`、进度条 `var(--warn)` / `var(--critical)` 且 `filter: none`、滚动条拇指 `rgba(127, 130, 136, 0.4)`。「完整视图」按钮改成面板浅色外观自己的半透白芯片 + 深色墨。

## 验证

- `npm test` 34/34、`npm run build` 通过
- 脚本比对深色态所有设白色前景/白底的 `.widget-shell--transparent` 规则与浅色块的对应覆盖，改完只剩 `.window-action--active`，而该状态在 mac 面板上不会出现（`macMinimal` 隐藏了固定/透明/最小化按钮）
- **未做**：mac 实机目视验收，需要在浅色外观下打开面板确认上述几处已转黑字

🤖 Generated with [Claude Code](https://claude.com/claude-code)