### PR TITLE
style(window): 卡片和胶囊圆角收小到 8 物理像素

### DIFF
--- a/docs/WINDOWS-GLASS-IMPLEMENTATION.md
+++ b/docs/WINDOWS-GLASS-IMPLEMENTATION.md
@@ -330,7 +330,7 @@ CSS px 会被卡片和胶囊各自的 WebView 原生 zoom 放大，所以同样�
 | 卡片（缩放 0.95） | 0.95 | 1.1875 | 9.5 物理像素 |
 | 竖胶囊（缩放 1.75） | 1.75 | 2.1875 | **17.5 物理像素**——即被否掉的"大圆头" |
 
-`App.jsx` 按 `devicePixelRatio` 把 `GLASS_RADIUS_PX`（10 物理像素）折算成
+`App.jsx` 按 `devicePixelRatio` 把 `GLASS_RADIUS_PX`（8 物理像素）折算成
 `--glass-radius`，`resize` 时重算。两种形态、任何缩放档都是同一个视觉半径。
 
 静态外框只在浏览器补（`html[data-runtime="browser"]`）；桌面端不画，避免与

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2231,9 +2231,9 @@ const THEME_OPTIONS = [
   { id: "dark", label: "暗色" },
 ];
 
-// 悬浮形态的窗口圆角，物理像素。取值对齐卡片此前的观感：8 CSS px 在当时的
-// dpr 1.1875（系统 125% × 卡片缩放 95%）下正好画出 9.5 物理像素。
-const GLASS_RADIUS_PX = 10;
+// 悬浮形态的窗口圆角，物理像素。10 收到 8：贴着壁纸看，10 的弧偏圆，靠近
+// macOS 大部件而不是任务栏那一排小图标；8 更贴合胶囊的高度。
+const GLASS_RADIUS_PX = 8;
 
 const GLASS_TINT_OPTIONS = [
   { id: "dark", label: "深色" },


### PR DESCRIPTION
`GLASS_RADIUS_PX` 从 10 物理像素收到 8。

10 的弧偏圆，贴着壁纸看更像 macOS 大部件而不是任务栏那一排小图标。

这一个常量同时管卡片和竖胶囊，两种形态、任何缩放档共用同一个视觉半径，不需要分别调。折算到 125% 系统缩放 × 95% 卡片缩放（dpr 1.1875）：圆角从 8.42 CSS px 变成 6.74。

macOS 走 NSPanel 原生圆角，不受影响。

## 验证

- `npm test` 34 项通过
- 未做实机验收——圆角观感只能看，等构建产物出来再确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)
