### PR TITLE
Release v0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.13.6",
+      "version": "0.14.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.13.6"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.13.6"
+version = "0.14.0"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：`package.json`、`package-lock.json`、`src-tauri/tauri.conf.json`、`src-tauri/Cargo.toml`、`src-tauri/Cargo.lock` 五个文件从 `0.13.6` 升到 `0.14.0`，不含任何产品代码。

本次发布的产品改动已由 #83 合入并在 `main` 上通过双平台 CI（`acc8fa6`）。

## v0.14.0 内容

**按项目统计用量。** 账本新增事件发生时的工作目录，六个 Agent 中五个可归属（Codex / Claude / zcode / OpenCode / Kimi / WorkBuddy 取各自的 `cwd` 或 session 目录映射；Antigravity 的 RPC 数据不含目录，计入「读不到目录」）。

用量页改为项目主视图：占比环形 + 排名列表，点击项目进入该项目的会话明细。目录默认向上合并到 git 仓库根，也可手动登记项目根或隐藏目录——分组规则在查询层生效，账本永远保存原始目录，改规则不触发重扫。报告页新增项目走势（26 周条形 + 近 7 天环比）。

**升级提示**：`PARSER_VERSION` 由 4 升到 5，首次启动会重扫保留期内的日志以补上历史项目归属，补齐期间界面会标注「补齐中」。

**隐私**：项目目录只存本机，多设备同步导出不含该列。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
