### PR TITLE
fix(usage): 项目行操作可逆，补齐进度并入数据统计

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -524,6 +524,7 @@ function QuotaBarRow({ label, view, windowKey, accent }) {
 /// 状态由灯和 state 这一行承担，不把"数据不完整"顶成入口的名字。
 /// "部分覆盖" 这种自造词读者看不懂，直接说清楚哪里不全。
 function sourceStatusCopy(snapshot, loading, partial) {
+  const indexingPending = snapshot.indexing?.pending || 0;
   if (snapshot.pending) {
     return {
       title: "正在读取",
@@ -538,6 +539,15 @@ function sourceStatusCopy(snapshot, loading, partial) {
       hint: "点此排查",
       state: "读取失败",
       detail: "本机日志读取失败。界面不会用演示数字顶替，点此查看数据来源。",
+    };
+  }
+  if (indexingPending > 0) {
+    return {
+      title: "补齐历史",
+      hint: `还剩 ${indexingPending}`,
+      // 侧栏那行不能换行，只放数字；完整说明走 title 与统计说明抽屉。
+      state: `补齐中 ${indexingPending}`,
+      detail: `正在补齐历史索引，还剩 ${indexingPending} 个日志文件。历史周期的数字尚不完整，会随补齐自动更新。`,
     };
   }
   if (partial) {
@@ -566,6 +576,7 @@ function sourceStatusCopy(snapshot, loading, partial) {
 
 function Sidebar({ activeNav, onNavChange, snapshot, loading }) {
   const partial = snapshotIsPartial(snapshot);
+  const indexing = (snapshot.indexing?.pending || 0) > 0;
   const sourceStatus = sourceStatusCopy(snapshot, loading, partial);
   return (
     <aside className="sidebar" aria-label="主导航">
@@ -597,7 +608,7 @@ function Sidebar({ activeNav, onNavChange, snapshot, loading }) {
         onClick={() => onNavChange("sources")}
         title={sourceStatus.detail}
       >
-        <span className={`status-dot ${loading ? "status-dot--loading" : ""} ${snapshot.loadError ? "status-dot--error" : ""} ${partial ? "status-dot--warning" : ""}`} />
+        <span className={`status-dot ${loading || indexing ? "status-dot--loading" : ""} ${snapshot.loadError ? "status-dot--error" : ""} ${partial && !indexing ? "status-dot--warning" : ""}`} />
         <span>数据统计</span>
         <small>{sourceStatus.state}</small>
       </button>
@@ -1756,6 +1767,16 @@ function SourceDrawer({ snapshot, onClose, onRebuildLedger, rebuildState }) {
             <X size={21} weight="light" />
           </button>
         </header>
+
+        {(snapshot.indexing?.pending || 0) > 0 && (
+          <div className="indexing-note" role="status">
+            <ClockCounterClockwise size={20} weight="light" aria-hidden="true" />
+            <p>
+              正在补齐历史索引，还剩 <strong>{snapshot.indexing.pending}</strong> 个日志文件。
+              历史周期的数字尚不完整，会随补齐自动更新。
+            </p>
+          </div>
+        )}
 
         <div className="source-list">
           {snapshot.sources.map((source) => (
@@ -3113,7 +3134,7 @@ function UsageSection({ projectsState, sessionsState, period, onRulesChanged }) 
   const [detail, setDetail] = useState(null);
   const [showAllProjects, setShowAllProjects] = useState(false);
   const [copiedId, setCopiedId] = useState(null);
-  const [exportNote, setExportNote] = useState(null);
+  const [note, setNote] = useState(null);
   const [rulesOpen, setRulesOpen] = useState(false);
   const [rules, setRules] = useState(null);
   const [rulesBusy, setRulesBusy] = useState(false);
@@ -3141,7 +3162,7 @@ function UsageSection({ projectsState, sessionsState, period, onRulesChanged }) 
 
   const openDetail = (next) => {
     setModelFilter("all");
-    setExportNote(null);
+    setNote(null);
     setDetail(next);
   };
 
@@ -3152,7 +3173,7 @@ function UsageSection({ projectsState, sessionsState, period, onRulesChanged }) 
       setRules(saved);
       onRulesChanged();
     } catch (error) {
-      setExportNote(`规则保存失败：${error}`);
+      setNote({ text: `规则保存失败：${error}` });
     } finally {
       setRulesBusy(false);
     }
@@ -3166,10 +3187,6 @@ function UsageSection({ projectsState, sessionsState, period, onRulesChanged }) 
     const current = await currentRules();
     await applyRules({ ...current, roots: [...current.roots, path] });
   };
-  const hideProject = async (path) => {
-    const current = await currentRules();
-    await applyRules({ ...current, hidden: [...current.hidden, path] });
-  };
   const removeRoot = async (path) => {
     const current = await currentRules();
     await applyRules({ ...current, roots: current.roots.filter((item) => item !== path) });
@@ -3178,13 +3195,26 @@ function UsageSection({ projectsState, sessionsState, period, onRulesChanged }) 
     const current = await currentRules();
     await applyRules({ ...current, hidden: current.hidden.filter((item) => item !== path) });
   };
+  // 登记与取消登记同一颗按钮：图钉状态可逆，按钮也不会中途从 DOM 消失。
+  const togglePin = (project) => (
+    project.pinned ? removeRoot(project.path) : pinProject(project.path)
+  );
+  // 隐藏会让这一行消失，就地留一个撤销入口；规则面板仍是长期的恢复位置。
+  const hideProject = async (project) => {
+    const current = await currentRules();
+    await applyRules({ ...current, hidden: [...current.hidden, project.path] });
+    setNote({
+      text: `已隐藏 ${project.label}`,
+      undo: () => removeHidden(project.path),
+    });
+  };
 
   const noteExport = async (task) => {
     try {
       const savedPath = await task();
-      setExportNote(savedPath ? `已导出到 ${savedPath}` : "已开始下载");
+      setNote({ text: savedPath ? `已导出到 ${savedPath}` : "已开始下载" });
     } catch (error) {
-      setExportNote(`导出失败：${error}`);
+      setNote({ text: `导出失败：${error}` });
     }
   };
   const copySessionId = (sessionId) => {
@@ -3331,7 +3361,20 @@ ${session.sessionId}`}
           </button>
         </div>
 
-        {exportNote && <p className="settings-muted" role="status">{exportNote}</p>}
+        {note && (
+        <p className="usage-note" role="status">
+          {note.text}
+          {note.undo && (
+            <button
+              type="button"
+              disabled={rulesBusy}
+              onClick={() => { setNote(null); note.undo(); }}
+            >
+              撤销
+            </button>
+          )}
+        </p>
+      )}
         {groups.length === 0 && <p className="settings-muted">本周期内没有可显示的会话。</p>}
         {groups.length > 0 && <div className="report-card session-board">{renderSessionRows(groups)}</div>}
       </main>
@@ -3383,7 +3426,20 @@ ${session.sessionId}`}
         </button>
       </div>
 
-      {exportNote && <p className="settings-muted" role="status">{exportNote}</p>}
+      {note && (
+        <p className="usage-note" role="status">
+          {note.text}
+          {note.undo && (
+            <button
+              type="button"
+              disabled={rulesBusy}
+              onClick={() => { setNote(null); note.undo(); }}
+            >
+              撤销
+            </button>
+          )}
+        </p>
+      )}
 
       {rulesOpen && (
         <ProjectRulesCard
@@ -3451,7 +3507,10 @@ ${session.sessionId}`}
           <article
             className="project-row"
             key={project.path}
-            onClick={() => openDetail({ type: "project", path: project.path })}
+            onClick={(event) => {
+              if (event.target.closest?.(".project-actions")) return;
+              openDetail({ type: "project", path: project.path });
+            }}
             role="button"
             tabIndex={0}
             onKeyDown={(event) => {
@@ -3462,10 +3521,7 @@ ${session.sessionId}`}
             }}
           >
             <div className="session-copy">
-              <strong title={project.path}>
-                {project.label}
-                {project.pinned && <PushPinSimple size={11} weight="fill" aria-label="手动登记的项目根" />}
-              </strong>
+              <strong title={project.path}>{project.label}</strong>
               <small>
                 {project.agents.map((id) => AGENT_META[id]?.label || id).join(" · ")}
                 {project.model ? ` · ${modelDisplayName(project.model)}` : ""}
@@ -3481,24 +3537,33 @@ ${session.sessionId}`}
                 />
               </span>
             </div>
-            <div className="project-actions">
-              {!project.pinned && (
-                <button
-                  type="button"
-                  disabled={rulesBusy}
-                  title={`登记为项目根：${project.path} 下的子目录都归并到这一行`}
-                  aria-label={`把 ${project.label} 登记为项目根`}
-                  onClick={(event) => { event.stopPropagation(); pinProject(project.path); }}
-                >
-                  <PushPinSimple size={13} weight="regular" aria-hidden="true" />
-                </button>
-              )}
+            {/* 操作区整体阻断冒泡：按钮若在点击途中卸载，mouseup 会落到行上误触发进入详情。 */}
+            <div
+              className={`project-actions ${project.pinned ? "project-actions--pinned" : ""}`}
+              onClick={(event) => event.stopPropagation()}
+              onMouseDown={(event) => event.stopPropagation()}
+            >
+              <button
+                type="button"
+                className={project.pinned ? "is-active" : ""}
+                disabled={rulesBusy}
+                aria-pressed={project.pinned}
+                title={project.pinned
+                  ? `取消登记：${project.path} 下的子目录恢复各自成行`
+                  : `登记为项目根：${project.path} 下的子目录都归并到这一行`}
+                aria-label={project.pinned
+                  ? `取消登记项目根 ${project.label}`
+                  : `把 ${project.label} 登记为项目根`}
+                onClick={() => togglePin(project)}
+              >
+                <PushPinSimple size={13} weight={project.pinned ? "fill" : "regular"} aria-hidden="true" />
+              </button>
               <button
                 type="button"
                 disabled={rulesBusy}
                 title={`隐藏 ${project.path}：其用量不再作为项目展示，可在分组规则里恢复`}
                 aria-label={`隐藏项目 ${project.label}`}
-                onClick={(event) => { event.stopPropagation(); hideProject(project.path); }}
+                onClick={() => hideProject(project)}
               >
                 <EyeSlash size={13} weight="regular" aria-hidden="true" />
               </button>
@@ -4878,13 +4943,6 @@ export function App() {
           <ArrowsClockwise size={15} weight="light" aria-hidden="true" />
         </button>
         <Sidebar activeNav={activeNav} onNavChange={handleNavChange} snapshot={snapshot} loading={appBusy} />
-
-        {indexingPending > 0 ? (
-          <div className="indexing-banner" role="status">
-            <ClockCounterClockwise size={18} weight="light" aria-hidden="true" />
-            正在补齐历史索引，还剩 <strong>{indexingPending}</strong> 个日志文件。历史周期的数字尚不完整，会随补齐自动更新。
-          </div>
-        ) : null}
 
         {activeNav === "overview" ? (
           <>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3819,6 +3819,7 @@ const REPORT_VIEWS = [
   { id: "heatmap", label: "热力图" },
   { id: "trend", label: "周趋势" },
   { id: "share", label: "构成" },
+  { id: "projects", label: "项目" },
 ];
 
 // 周趋势/构成的统计时间段档位；热力图固定 26 周日历不参与。
@@ -3948,7 +3949,7 @@ function ReportsSection({ report }) {
               </button>
             ))}
           </div>
-          {view !== "heatmap" && (
+          {view !== "heatmap" && view !== "projects" && (
             <div className="report-view-toggle" role="group" aria-label="统计时间段">
               {REPORT_RANGE_WEEKS.map((num) => (
                 <button
@@ -3966,7 +3967,40 @@ function ReportsSection({ report }) {
         </div>
         {/* 固定高度：三种视图内容高度不同，卡片会随切换忽大忽小。 */}
         <div className="report-view-body">
-        {view === "trend" ? (
+        {view === "projects" ? (
+          (data.projects || []).length > 0 ? (
+            <ul className="project-trend-list">
+              {data.projects.map((project, index) => (
+                <li key={project.path}>
+                  <span className="project-trend-name" title={project.path}>
+                    {project.label}
+                    <small>{project.activeDays} 天</small>
+                  </span>
+                  <Sparkline
+                    points={project.weekly}
+                    color={index < PROJECT_COLOR_COUNT ? `var(--viz-${index + 1})` : "var(--viz-other)"}
+                  />
+                  <em>{compactTokens(project.tokens)}</em>
+                  {project.recentDeltaPercent != null ? (
+                    <small
+                      className={project.recentDeltaPercent >= 0 ? "trend-up" : "trend-down"}
+                      title="近 7 天相对再前 7 天"
+                    >
+                      {project.recentDeltaPercent >= 0
+                        ? <ArrowUp size={10} weight="bold" aria-hidden="true" />
+                        : <ArrowDown size={10} weight="bold" aria-hidden="true" />}
+                      {Math.abs(Math.round(project.recentDeltaPercent))}%
+                    </small>
+                  ) : (
+                    <small className="trend-flat">—</small>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="settings-muted">这段时间的用量还没有可归属的项目。</p>
+          )
+        ) : view === "trend" ? (
           <ReportTrendChart weeks={trendWeeks} />
         ) : view === "share" ? (
           <ReportShareDonut agents={rangeAgents} totalTokens={rangeTotal} weeksCount={trendWeeks.length} />
@@ -4049,41 +4083,6 @@ function ReportsSection({ report }) {
         </section>
       </div>
 
-      {(data.projects || []).length > 0 && (
-        <section className="report-card report-projects" aria-label="项目走势">
-          <h2>项目走势</h2>
-          <ul className="project-trend-list">
-            {data.projects.map((project, index) => (
-              <li key={project.path}>
-                <div className="project-trend-name">
-                  <span title={project.path}>{project.label}</span>
-                  <small>{project.activeDays} 天活跃</small>
-                </div>
-                <Sparkline
-                  points={project.weekly}
-                  color={index < PROJECT_COLOR_COUNT ? `var(--viz-${index + 1})` : "var(--viz-other)"}
-                />
-                <div className="project-trend-figures">
-                  <em>{compactTokens(project.tokens)}</em>
-                  {project.recentDeltaPercent != null ? (
-                    <small
-                      className={project.recentDeltaPercent >= 0 ? "trend-up" : "trend-down"}
-                      title="近 7 天相对再前 7 天"
-                    >
-                      {project.recentDeltaPercent >= 0
-                        ? <ArrowUp size={10} weight="bold" aria-hidden="true" />
-                        : <ArrowDown size={10} weight="bold" aria-hidden="true" />}
-                      {Math.abs(Math.round(project.recentDeltaPercent))}%
-                    </small>
-                  ) : (
-                    <small className="trend-flat">—</small>
-                  )}
-                </div>
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
     </main>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import {
   Database,
   EyeSlash,
   FileText,
+  FolderSimple,
   FunnelSimple,
   GearSix,
   HardDrives,
@@ -2951,7 +2952,7 @@ function projectLabel(path) {
   return parts[parts.length - 1] || path;
 }
 
-// 分组规则面板：登记项目根、隐藏目录，列出已有规则并可移除。
+// 项目归类设置：登记项目根、隐藏目录，列出已有规则并可移除。
 function ProjectRulesCard({ rules, busy, onAddRoot, onRemoveRoot, onRemoveHidden, onClose }) {
   const [draft, setDraft] = useState("");
   const submit = () => {
@@ -2961,16 +2962,16 @@ function ProjectRulesCard({ rules, busy, onAddRoot, onRemoveRoot, onRemoveHidden
     setDraft("");
   };
   return (
-    <section className="rules-card" aria-label="项目分组规则">
+    <section className="rules-card" aria-label="项目归类设置">
       <header className="rules-card-head">
-        <h2>分组规则</h2>
-        <button type="button" className="rules-close" onClick={onClose} aria-label="收起规则面板">
+        <h2>项目归类</h2>
+        <button type="button" className="rules-close" onClick={onClose} aria-label="收起项目归类设置">
           <X size={14} weight="bold" aria-hidden="true" />
         </button>
       </header>
       <p>
-        账本始终记录事件发生时的原始目录，规则只改变展示时的归并，移除规则即恢复。
-        未命中规则的目录自动向上合并到 git 仓库根；家目录、下载与系统临时目录默认不列为项目。
+        决定哪些目录算作一个项目。默认按 git 仓库根归并，家目录、下载与系统临时目录不列为项目。
+        账本始终记录事件发生时的原始目录，这里只改变展示时的归类，移除后即恢复。
       </p>
       <div className="rules-add">
         <input
@@ -3022,7 +3023,7 @@ function ProjectRulesCard({ rules, busy, onAddRoot, onRemoveRoot, onRemoveHidden
             </div>
           )}
           {rules.roots.length === 0 && rules.hidden.length === 0 && (
-            <p className="settings-muted">还没有手动规则。在项目行上点「归并」或「隐藏」，或在上方登记目录。</p>
+            <p className="settings-muted">还没有手动归类。在项目行上点图钉或眼睛，或在上方登记目录。</p>
           )}
         </>
       )}
@@ -3413,8 +3414,8 @@ ${session.sessionId}`}
           aria-expanded={rulesOpen}
           onClick={() => setRulesOpen((open) => !open)}
         >
-          <FunnelSimple size={13} weight="bold" aria-hidden="true" />
-          分组规则
+          <FolderSimple size={13} weight="bold" aria-hidden="true" />
+          项目归类
         </button>
         <button
           type="button"
@@ -3561,7 +3562,7 @@ ${session.sessionId}`}
               <button
                 type="button"
                 disabled={rulesBusy}
-                title={`隐藏 ${project.path}：其用量不再作为项目展示，可在分组规则里恢复`}
+                title={`隐藏 ${project.path}：其用量不再作为项目展示，可在项目归类里恢复`}
                 aria-label={`隐藏项目 ${project.label}`}
                 onClick={() => hideProject(project)}
               >

--- a/src/styles.css
+++ b/src/styles.css
@@ -3459,7 +3459,15 @@ html:has(.strip-shell--glass-ink-light) #root {
 }
 
 .project-row:hover .project-actions,
-.project-row:focus-within .project-actions { opacity: 1; }
+.project-row:focus-within .project-actions,
+.project-actions--pinned { opacity: 1; }
+
+/* 未悬停时，已登记的行只亮图钉，隐藏按钮仍然收着。 */
+.project-actions--pinned button:not(.is-active) { opacity: 0; }
+.project-row:hover .project-actions--pinned button,
+.project-row:focus-within .project-actions--pinned button { opacity: 1; }
+
+.project-actions button.is-active { color: #26282b; }
 
 .project-actions button {
   display: inline-flex;
@@ -3482,6 +3490,31 @@ html:has(.strip-shell--glass-ink-light) #root {
 }
 
 .project-actions button:disabled { opacity: 0.4; cursor: default; }
+
+/* 操作反馈行：与说明文字同级，撤销是行内按钮。 */
+.usage-note {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 12px 0 0;
+  color: #74767a;
+  font-size: 12.5px;
+}
+
+.usage-note button {
+  padding: 3px 10px;
+  color: #26282b;
+  font: inherit;
+  font-size: 12px;
+  background: rgba(31, 33, 36, 0.06);
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 160ms var(--motion);
+}
+
+.usage-note button:hover { background: rgba(31, 33, 36, 0.11); }
+.usage-note button:disabled { opacity: 0.45; cursor: default; }
 
 /* 相对占比条：只表达同一列表内的相对量级，不标数值。 */
 .project-bar {
@@ -3966,30 +3999,28 @@ html:has(.strip-shell--glass-ink-light) #root {
 /* 三种视图的自然高度差很大（热力图矮、折线高），固定容器高度，
    切换时卡片不再忽大忽小。内容垂直居中填满。 */
 /* 历史索引补齐中的显式标注。浮在内容之上而不是占一格，免得挤坏三列栅格。 */
-.indexing-banner {
-  position: absolute;
-  left: 148px;
-  bottom: 18px;
-  z-index: 4;
+/* 补齐进度：并入「统计说明」抽屉，与隐私说明同一种块级说明的样式。 */
+.indexing-note {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  max-width: calc(100vw - 449px - 176px);
-  padding: 9px 15px;
-  border: 1px solid rgba(31, 33, 36, 0.08);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 8px 24px rgba(31, 33, 36, 0.09);
-  backdrop-filter: blur(12px);
-  color: rgba(31, 33, 36, 0.62);
-  font-size: 12.5px;
-  letter-spacing: 0.01em;
-  animation: settle-in 480ms var(--motion) both;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(36, 107, 219, 0.07);
+  color: #3f6193;
 }
 
-.indexing-banner strong {
-  color: rgba(31, 33, 36, 0.9);
-  font-weight: 560;
+.indexing-note svg { flex: none; margin-top: 1px; }
+
+.indexing-note p {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.indexing-note strong {
+  font-weight: 580;
   font-variant-numeric: tabular-nums;
 }
 
@@ -4504,6 +4535,10 @@ html:has(.strip-shell--glass-ink-light) #root {
 
 /* --- 概览主区 --- */
 :root[data-theme="dark"] .section-kicker { color: var(--d-strong); }
+:root[data-theme="dark"] .indexing-note {
+  background: rgba(111, 155, 240, 0.13);
+  color: #a8c2f2;
+}
 :root[data-theme="dark"] .metric-line h1 { color: var(--d-strong); }
 :root[data-theme="dark"] .metric-line > span { color: var(--d-ink-2); }
 :root[data-theme="dark"] .comparison { color: var(--d-muted); }
@@ -4742,6 +4777,13 @@ html:has(.strip-shell--glass-ink-light) #root {
   color: var(--d-strong);
   background: rgba(255, 255, 255, 0.1);
 }
+:root[data-theme="dark"] .project-actions button.is-active { color: var(--d-strong); }
+:root[data-theme="dark"] .usage-note { color: var(--d-muted); }
+:root[data-theme="dark"] .usage-note button {
+  color: var(--d-ink-2);
+  background: rgba(255, 255, 255, 0.09);
+}
+:root[data-theme="dark"] .usage-note button:hover { background: rgba(255, 255, 255, 0.14); }
 :root[data-theme="dark"] .project-expand {
   color: var(--d-ink-3);
   background: rgba(255, 255, 255, 0.06);

--- a/src/styles.css
+++ b/src/styles.css
@@ -3869,11 +3869,11 @@ html:has(.strip-shell--glass-ink-light) #root {
 
 .report-grid .report-card { margin-top: 24px; }
 
-/* 项目走势：名称 + 26 周迷你折线 + 总量与近 7 天环比。 */
-.report-projects { margin-top: 24px; }
-
+/* 项目走势：作为报告卡片的一个视图，单行排布——视图体高度固定 272px，
+   最多 8 个项目必须放得下，双行会溢出。活跃天数跟在名称后面。 */
 .project-trend-list {
   display: grid;
+  align-content: center;
   gap: 2px;
   margin: 0;
   padding: 0;
@@ -3882,58 +3882,57 @@ html:has(.strip-shell--glass-ink-light) #root {
 
 .project-trend-list li {
   display: grid;
-  grid-template-columns: minmax(120px, 200px) minmax(0, 1fr) 96px;
+  grid-template-columns: minmax(110px, 190px) minmax(0, 1fr) 62px 52px;
   align-items: center;
-  gap: 18px;
-  padding: 9px 8px;
-  border-radius: 10px;
+  gap: 16px;
+  padding: 5px 8px;
+  border-radius: 8px;
 }
 
 .project-trend-list li:hover { background: rgba(31, 33, 36, 0.03); }
 
-.project-trend-name { display: grid; gap: 2px; min-width: 0; }
-
-.project-trend-name span {
+.project-trend-name {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
   overflow: hidden;
   color: #26282b;
-  font-size: 13.5px;
+  font-size: 13px;
   font-weight: 540;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .project-trend-name small {
-  color: #83858a;
-  font-size: 11px;
+  flex: none;
+  color: #a0a2a7;
+  font-size: 10.5px;
+  font-weight: 400;
   font-variant-numeric: tabular-nums;
 }
 
 .project-sparkline {
   width: 100%;
-  height: 26px;
+  height: 20px;
   color: #55575b;
 }
 
 .project-sparkline rect { fill: currentColor; opacity: 0.4; }
 .project-sparkline rect:last-child { opacity: 1; }
 
-.project-trend-figures {
-  display: grid;
-  gap: 2px;
-  justify-items: end;
-}
-
-.project-trend-figures em {
+.project-trend-list li > em {
   color: #2b2d31;
-  font-size: 13px;
+  font-size: 12.5px;
   font-style: normal;
   font-weight: 580;
   font-variant-numeric: tabular-nums;
+  text-align: right;
 }
 
-.project-trend-figures small {
+.project-trend-list li > small {
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 2px;
   font-size: 11px;
   font-variant-numeric: tabular-nums;
@@ -4835,10 +4834,10 @@ html:has(.strip-shell--glass-ink-light) #root {
 }
 :root[data-theme="dark"] .project-overview-figures small button:hover { color: var(--d-strong); }
 :root[data-theme="dark"] .project-trend-list li:hover { background: rgba(255, 255, 255, 0.04); }
-:root[data-theme="dark"] .project-trend-name span { color: var(--d-strong); }
+:root[data-theme="dark"] .project-trend-name { color: var(--d-strong); }
 :root[data-theme="dark"] .project-trend-name small { color: var(--d-muted); }
 :root[data-theme="dark"] .project-sparkline { color: var(--d-ink-3); }
-:root[data-theme="dark"] .project-trend-figures em { color: var(--d-strong); }
+:root[data-theme="dark"] .project-trend-list li > em { color: var(--d-strong); }
 :root[data-theme="dark"] .trend-up { color: var(--d-ink-2); }
 :root[data-theme="dark"] .trend-down { color: var(--d-muted); }
 :root[data-theme="dark"] .trend-flat { color: rgba(255, 255, 255, 0.3); }


### PR DESCRIPTION
v0.14.0 实机使用中发现的三个交互缺陷，外加补齐进度浮层的位置问题。

## 修复

**1. 固定后无法取消固定**

图钉按钮原本写成 `{!project.pinned && (...)}`，登记成功后整颗按钮不再渲染，行上没有任何取消入口——只能去分组规则面板里删。改成常驻的切换按钮：未登记时是空心图钉，已登记时填充高亮并常显（未悬停时隐藏按钮仍然收着），点一下即取消登记。

**2. 隐藏后没有就近的恢复入口**

隐藏会让该行立刻消失，此前唯一的恢复位置是分组规则面板，而用户刚点完并不知道要去那里。现在隐藏成功后原地留一条「已隐藏 X · 撤销」，点撤销即恢复。规则面板仍是长期的恢复位置。

**3. 点固定会误跳进项目详情**

根因是第 1 条：按钮在点击途中卸载（pinned 变 true → 按钮不再渲染），mousedown 落在按钮、mouseup 落到了行上，浏览器把 click 派发给二者的共同祖先，也就是带导航的行。原有的 `stopPropagation` 挡不住这种情况，因为事件压根不是从按钮派发的。

三道修复：按钮不再卸载（第 1 条）、操作区在容器层拦 `click` 与 `mousedown`、行的点击回调再加一道 `event.target.closest(".project-actions")` 来源判断。

## 另外

补齐历史索引的浮层固定在窗口左下，会压住页面底部内容（设置页尤其明显）。删掉浮层，改为「数据统计」的一种状态：侧栏状态灯转呼吸态、状态行显示「补齐中 N」，完整说明放进点开后的统计说明抽屉。补齐本来就是数据完整度的一种，并进已有的状态位比再加一个浮层合适。

## 验证

`npm test` 34 项、`npm run build` 通过。交互逻辑为实机反馈驱动的定向修复，浏览器扩展当时未连接，未能补截图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
