### PR TITLE
Release v0.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.0"
+version = "0.14.1"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：五个版本文件从 `0.14.0` 升到 `0.14.1`，不含任何产品代码。

产品改动已由 #85 合入并在 `main` 上通过双平台 CI（`5b682fb`）。

## v0.14.1 内容

v0.14.0 实机使用中发现的三个交互缺陷，以及两处界面调整。

- 固定项目后无法取消固定：图钉按钮原本在已登记时整个不渲染，行上没有取消入口。
- 隐藏项目后没有就近的恢复入口，只能去规则面板里找。
- 点固定按钮会误跳进项目详情：按钮在点击途中卸载，mouseup 落到行上，click 被派发给带导航的行。
- 补齐历史索引的浮层压住页面底部内容，改为「数据统计」的一种状态。
- 项目走势并入报告页图表卡片的视图切换，页面不再需要向下滚一屏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
