### PR TITLE
fix(reports): 填满图表卡片的固定视图体，修复三处宽窄窗口下的布局缺陷

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4007,12 +4007,12 @@ function ReportsSection({ report }) {
           <ReportShareDonut agents={rangeAgents} totalTokens={rangeTotal} weeksCount={trendWeeks.length} />
         ) : (
           <>
-        <div className="heatmap-months" aria-hidden="true">
+        <div className="heatmap-months" style={{ "--heatmap-weeks": weeks.length }} aria-hidden="true">
           {monthLabels.map((month) => (
             <span key={month.index} style={{ gridColumnStart: month.index + 1 }}>{month.label}</span>
           ))}
         </div>
-        <div className="heatmap" role="img" aria-label="近 26 周每日 token 用量热力图，颜色越深用量越大">
+        <div className="heatmap" style={{ "--heatmap-weeks": weeks.length }} role="img" aria-label="近 26 周每日 token 用量热力图，颜色越深用量越大">
           {weeks.map((week, weekIndex) => (
             <div className="heatmap-week" key={weekIndex}>
               {week.map((cell, dayIndex) => (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3694,12 +3694,29 @@ function smoothPath(points) {
 }
 
 function ReportTrendChart({ weeks }) {
+  // viewBox 宽度跟随容器实测宽度，缩放系数恒为 1：图表始终占满整行，
+  // 刻度字号也不再随窗口忽大忽小。固定 620 时，宽窗口下按高度约束缩放，
+  // 只画得出 720px，左右各空几百像素。
+  const hostRef = useRef(null);
+  const [width, setWidth] = useState(620);
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    if (!host) return undefined;
+    const apply = (value) => setWidth(Math.max(420, Math.round(value)));
+    apply(host.clientWidth);
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0]?.contentRect;
+      if (rect) apply(rect.width);
+    });
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, []);
+
   const agents = AGENT_ORDER.filter((id) => weeks.some((week) => (week.byAgent[id] || 0) > 0));
   if (!agents.length) {
-    return <p className="settings-muted">所选时间段内没有已索引的用量。</p>;
+    return <p className="settings-muted" ref={hostRef}>所选时间段内没有已索引的用量。</p>;
   }
   const max = Math.max(1, ...weeks.flatMap((week) => agents.map((id) => week.byAgent[id] || 0)));
-  const width = 620;
   const height = 210;
   const pad = { top: 12, right: 8, bottom: 22, left: 8 };
   const x = (index) => pad.left + (index / Math.max(1, weeks.length - 1)) * (width - pad.left - pad.right);
@@ -3711,7 +3728,7 @@ function ReportTrendChart({ weeks }) {
   const gridValues = [max / 2, max];
 
   return (
-    <div>
+    <div ref={hostRef}>
       <svg
         className="report-trend"
         viewBox={`0 0 ${width} ${height}`}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3885,7 +3885,8 @@ html:has(.strip-shell--glass-ink-light) #root {
   grid-template-columns: minmax(110px, 190px) minmax(0, 1fr) 62px 52px;
   align-items: center;
   gap: 16px;
-  padding: 5px 8px;
+  /* 6px 内边距让后端上限的 8 行正好用满 272px 的视图体。 */
+  padding: 6px 8px;
   border-radius: 8px;
 }
 
@@ -3944,20 +3945,32 @@ html:has(.strip-shell--glass-ink-light) #root {
 .trend-flat { color: #a7a9ae; }
 
 /* 热力图：蓝色序列（浅→深）编码日用量；空白天用中性灰。 */
+/* 格子尺寸随卡片宽度伸缩：固定 13px 时 7 行只占 109px，在 272px 的视图体里
+   留下一大块空白。上限 780px 是为了超宽窗口下格子不至于变成大色块；窄到
+   每列 11px 以下就横向滚动，保证仍然认得出深浅。 */
 .heatmap {
   display: flex;
-  gap: 3px;
+  gap: 4px;
+  max-width: 780px;
   overflow-x: auto;
   padding-bottom: 4px;
 }
 
 .heatmap-week {
   display: grid;
-  flex: 0 0 auto;
-  gap: 3px;
+  flex: 1 1 0;
+  min-width: 11px;
+  gap: 4px;
 }
 
-.heatmap i,
+.heatmap i {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 3px;
+}
+
+/* 图例格子不参与伸缩，保持固定小尺寸。 */
 .heatmap-scale i {
   display: block;
   width: 13px;
@@ -3974,8 +3987,9 @@ html:has(.strip-shell--glass-ink-light) #root {
 
 .heatmap-months {
   display: grid;
-  grid-auto-columns: 16px;
-  grid-auto-flow: column;
+  grid-template-columns: repeat(var(--heatmap-weeks, 27), minmax(0, 1fr));
+  gap: 4px;
+  max-width: 780px;
   margin-bottom: 6px;
   color: #83858a;
   font-size: 10px;
@@ -4095,18 +4109,17 @@ html:has(.strip-shell--glass-ink-light) #root {
 .report-donut {
   display: grid;
   align-items: center;
-  grid-template-columns: 200px minmax(0, 1fr);
-  gap: 28px;
-  max-width: 560px;
+  /* 始终两列。窄窗口下改成上下堆叠会让高度变成「环形 + 图例」之和，
+     在固定高度的视图体里必然溢出（Agent 越多越严重），所以让环形随列宽
+     收缩，高度取两者较大值。 */
+  grid-template-columns: minmax(96px, 240px) minmax(0, 1fr);
+  gap: min(30px, 4%);
+  max-width: 600px;
 }
 
-.report-donut svg { width: 200px; height: 200px; }
+.report-donut svg { width: 100%; height: auto; aspect-ratio: 1; }
 .donut-total { fill: #17181a; font-family: "Newsreader", Georgia, serif; font-size: 26px; }
 .donut-caption { fill: #83858a; font-size: 10px; }
-
-@media (max-width: 720px) {
-  .report-donut { grid-template-columns: 1fr; justify-items: center; }
-}
 
 .empty-section {
   grid-column: 2 / 4;

--- a/src/styles.css
+++ b/src/styles.css
@@ -3875,6 +3875,9 @@ html:has(.strip-shell--glass-ink-light) #root {
   display: grid;
   align-content: center;
   gap: 2px;
+  /* 与热力图、环形一样给个宽度上限：sparkline 用 preserveAspectRatio="none"
+     横向铺满，列再宽下去 26 根柱子会被拉成扁块，读不出柱状。 */
+  max-width: 820px;
   margin: 0;
   padding: 0;
   list-style: none;


### PR DESCRIPTION
报告页四个视图共用一个 272px 的固定视图体（固定高度是为了切换时卡片不忽大忽小），但实测填充率差得很远，另有三处既有缺陷在宽/窄窗口下才暴露。

## 填充

| 视图 | 改前空白 | 改后空白 |
| --- | --- | --- |
| 热力图 | 113px | 22px |
| 周趋势 | 3px | 29px |
| 构成 | 72px | 32px |
| 项目（8 行） | 18px | 2px |

- 热力图格子改为随卡片宽度伸缩（原先固定 13px），宽窗口下 25px，既填满空间也更好读。月份标签沿用同一套弹性列，实测对齐偏差 0.0px；窄到每列 11px 以下才横向滚动。
- 环形图 200 → 240px，与放大后的热力图量级一致。
- 项目行内边距 5 → 6px，后端上限的 8 行正好用满。项目数由 `REPORT_PROJECT_LIMIT = 8` 封顶，涨不出容器。

## 一并修掉的既有缺陷

三处都不是本分支引入的，是按多档窗口宽度实测时发现的：

1. **窄窗口下「构成」溢出卡片。** 720px 以下的媒体查询把环形与图例改成上下堆叠，高度变成两者之和，在固定高度的视图体里必然溢出——实测 560px 宽时内容 379px，图例穿出卡片压住下一张，Agent 越多越严重。改为始终两列、环形随列宽收缩，高度取两者较大值。
2. **「周趋势」在宽窗口缩在中间。** viewBox 固定 620×210，按高度约束缩放后只画得出 720px，1680px 容器里左右各空 480px。改为用 `ResizeObserver` 测容器宽度写进 viewBox，缩放系数恒为 1，图表占满整行，刻度字号也不再随窗口忽大忽小。做法与概览图（`UsagePlot` 的 ResizeObserver）一致；测量钩子放在提前 return 之前，空数据分支同样挂 ref。
3. **项目 sparkline 在宽窗口被拉成扁块。** 它用 `preserveAspectRatio="none"` 横向铺满，列宽过大时 26 根柱子每根 31px，读不出柱状。给列表加 820px 上限，与热力图 780、环形 600 的既有上限同类。

## 验证

- 浏览器实测 1680px 窗口：四个视图空白 22 / 29 / 32px（项目视演示数据 4 行；8 行为 2px），**均无横向溢出**，明暗两档都已核对
- 用真实样式表在无头 Chromium 上按 1000 / 700 / 560 三档宽度、图例撑到 8 个 Agent 复测
- `npm test` 34 项、`npm run build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
