### PR TITLE
Release v0.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.1"
+version = "0.14.2"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：五个版本文件从 `0.14.1` 升到 `0.14.2`，不含任何产品代码。

产品改动已由 #87 合入并在 `main` 上通过双平台 CI（`558dcb3`）。

## v0.14.2 内容

报告页图表卡片的布局修正。四个视图共用一个固定高度的视图体，实测填充率差得很远：热力图只用了 159px、下方空 113px。

- 热力图格子改为随卡片宽度伸缩，宽窗口下从 13px 放大到 25px，更好读也填满了空间。
- 环形图放大到 240px；项目行内边距微调，后端上限的 8 行正好用满。
- 修复窄窗口下「构成」视图溢出卡片：媒体查询把环形与图例改成上下堆叠，高度变成两者之和，图例会穿出卡片压住下方内容。
- 修复「周趋势」在宽窗口缩在中间：图表宽度改为跟随容器，不再左右各空几百像素。
- 修复项目走势的 sparkline 在宽窗口被拉成扁块。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
