### PR TITLE
Release v0.14.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.2"
+version = "0.14.3"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：五个版本文件从 `0.14.2` 升到 `0.14.3`，不含任何产品代码。

产品改动已由 #89 合入并在 `main` 上通过双平台 CI。

## v0.14.3 内容

完整视图侧栏的 Agent 现在跟随设置里「显示的 Agent」的选择与顺序。

- Agent 列表保留「设置里勾选的 ∪ 本周期有用量的」。装了七个 Agent 的机器上不再有半屏 "0 tokens 0.0%" 的空行，而有真实用量的 Agent 不会因为没勾选就被藏掉。
- 配额卡改按设置里的顺序排列，与小组件、胶囊条、macOS 菜单栏共用一份顺序。
- 图表折线、Token 构成、成本估算不受影响，顶部总量仍等于全部 Agent 之和。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
