### PR TITLE
Release v0.14.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.3"
+version = "0.14.4"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：五个版本文件从 `0.14.3` 升到 `0.14.4`，不含任何产品代码。

产品改动已由 #91 合入并在 `main` 上通过双平台 CI。

## v0.14.4 内容

- 修复侧栏配额卡没按设置里的勾选走。v0.14.3 把用量列表的并集规则照搬到了配额卡上，没勾的 Agent 只要有官方额度来源就照样显示。现在严格按勾选，顺序也跟勾选顺序；用量列表规则不变。
- WorkBuddy 换用新版应用图标（品牌已从紫色圆形改为绿色圆角方形）。
- 项目页「项目归类」改为「添加项目」。
- 环形图中心文字下移 4px 对准环心，项目占比与报告页 Agent 占比同步。
- 项目页「已隐藏 N」改为「未计入项目 N」——这个数含内置排除，删光自己的隐藏规则也不会归零。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
