### PR TITLE
fix(quota): 直连查询失败不再被静默吞掉

### DIFF
--- a/src-tauri/src/claude_oauth.rs
+++ b/src-tauri/src/claude_oauth.rs
@@ -35,7 +35,45 @@ const ENV_CONFIG_DIR: &str = "CLAUDE_CONFIG_DIR";
 /// app_setting 里的开关键；"1" 表示用户已显式开启。
 pub const SETTING_KEY: &str = "claude_oauth_quota_enabled";
 
+/// 最近一次直连查询失败的原因。失败被静默吞掉时用户只会看到"没有额度"，
+/// 却拿不到任何可行动的信息（凭据过期？缺 scope？限流？），所以如实留档。
+/// 存的是本模块自己生成的错误文案，不含 token、请求头或响应体。
+const LAST_ERROR_SETTING_KEY: &str = "claude_oauth_last_error";
+
 pub const SOURCE_LABEL: &str = "官方额度（OAuth）";
+
+/// 直连的最近一次失败，供设置页与配额卡如实说明为什么没有数字。
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeOauthFailure {
+    pub at_ms: i64,
+    pub message: String,
+}
+
+pub fn record_failure(connection: &rusqlite::Connection, message: &str) -> Result<()> {
+    let failure = ClaudeOauthFailure {
+        at_ms: chrono::Utc::now().timestamp_millis(),
+        message: message.to_owned(),
+    };
+    let raw =
+        serde_json::to_string(&failure).context("failed to serialize claude oauth failure")?;
+    crate::storage::set_app_setting(connection, LAST_ERROR_SETTING_KEY, &raw)
+}
+
+pub fn clear_failure(connection: &rusqlite::Connection) -> Result<()> {
+    crate::storage::set_app_setting(connection, LAST_ERROR_SETTING_KEY, "")
+}
+
+pub fn last_failure(connection: &rusqlite::Connection) -> Result<Option<ClaudeOauthFailure>> {
+    let Some(raw) = crate::storage::get_app_setting(connection, LAST_ERROR_SETTING_KEY)? else {
+        return Ok(None);
+    };
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    // 记录损坏时当作没有记录，不因为一条诊断把设置页打不开。
+    Ok(serde_json::from_str(&raw).ok())
+}
 
 #[derive(Deserialize)]
 struct CredentialsFileShape {
@@ -59,6 +97,15 @@ pub struct ClaudeOauthStatus {
     pub credentials_present: bool,
     /// token 带 `user:profile` scope（用量端点必需）。
     pub scope_ok: bool,
+    /// 最近一次直连查询失败；开关本身正常时，问题只会出现在这里。
+    pub last_failure: Option<ClaudeOauthFailure>,
+}
+
+impl ClaudeOauthStatus {
+    pub fn with_failure(mut self, failure: Option<ClaudeOauthFailure>) -> Self {
+        self.last_failure = failure;
+        self
+    }
 }
 
 #[derive(Deserialize)]
@@ -200,6 +247,7 @@ impl ClaudeOauth {
             enabled,
             credentials_present: credentials.is_some(),
             scope_ok,
+            last_failure: None,
         }
     }
 
@@ -378,6 +426,49 @@ fn parse_iso8601_ms(value: &str) -> Option<i64> {
 mod tests {
     use super::*;
     use std::fs;
+
+    fn memory_ledger() -> rusqlite::Connection {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(include_str!("../migrations/001_init.sql"))
+            .unwrap();
+        connection
+    }
+
+    #[test]
+    fn failure_is_recorded_until_a_later_success_clears_it() {
+        let connection = memory_ledger();
+        assert!(last_failure(&connection).unwrap().is_none());
+
+        record_failure(
+            &connection,
+            "Claude 凭据已失效（401），请重新运行 claude login",
+        )
+        .unwrap();
+        let recorded = last_failure(&connection).unwrap().unwrap();
+        assert_eq!(
+            recorded.message,
+            "Claude 凭据已失效（401），请重新运行 claude login"
+        );
+        assert!(recorded.at_ms > 0);
+
+        // 后一次失败覆盖前一次：展示的必须是当前的问题。
+        record_failure(&connection, "Claude 用量接口限流（429），稍后自动重试").unwrap();
+        assert_eq!(
+            last_failure(&connection).unwrap().unwrap().message,
+            "Claude 用量接口限流（429），稍后自动重试"
+        );
+
+        clear_failure(&connection).unwrap();
+        assert!(last_failure(&connection).unwrap().is_none());
+    }
+
+    #[test]
+    fn corrupt_failure_record_reads_as_no_failure() {
+        let connection = memory_ledger();
+        crate::storage::set_app_setting(&connection, LAST_ERROR_SETTING_KEY, "not json").unwrap();
+        assert!(last_failure(&connection).unwrap().is_none());
+    }
 
     #[test]
     fn status_reports_credentials_and_scope() {

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -261,6 +261,9 @@ pub struct SeriesPoint {
 pub struct AgentQuotaView {
     pub agent: String,
     pub windows: Vec<AgentQuotaWindow>,
+    /// 没有窗口时的原因（目前只有 Claude 直连查询失败会填）。让"没有数字"
+    /// 这件事可自查，而不是笼统地叫用户去开另一个来源。
+    pub note: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -188,8 +188,17 @@ pub fn build_snapshot(
         storage::get_app_setting(&connection, claude_oauth::SETTING_KEY)?.as_deref() == Some("1");
     let mut claude_samples = Vec::new();
     if oauth_enabled {
-        if let Ok(samples) = cached_claude_oauth_quota(claude_quota_cache, force) {
-            claude_samples = samples;
+        // 失败原因必须留档。丢掉 Err 会让"开了直连却没有额度"完全无法自查：
+        // 界面回落到钩子文案，叫用户去开一个他根本不用的 statusLine。
+        // 缓存命中失败时返回的是 Ok(空)，既不清也不覆盖上一条记录。
+        match cached_claude_oauth_quota(claude_quota_cache, force) {
+            Ok(samples) => {
+                if !samples.is_empty() {
+                    claude_oauth::clear_failure(&connection)?;
+                }
+                claude_samples = samples;
+            }
+            Err(error) => claude_oauth::record_failure(&connection, &error.to_string())?,
         }
     }
     if claude_samples.is_empty() {
@@ -1186,9 +1195,18 @@ fn query_snapshot_at(
         agent_quotas: AGENT_IDS
             .iter()
             .map(|agent| {
+                let windows = load_visible_agent_quota_windows(connection, agent)?;
+                // 只在确实没有可用窗口时才带原因；有数字了就没什么好解释的。
+                let note =
+                    if *agent == "claude" && !windows.iter().any(|window| window.view.available) {
+                        claude_oauth::last_failure(connection)?.map(|failure| failure.message)
+                    } else {
+                        None
+                    };
                 Ok(AgentQuotaView {
                     agent: (*agent).to_owned(),
-                    windows: load_visible_agent_quota_windows(connection, agent)?,
+                    windows,
+                    note,
                 })
             })
             .collect::<Result<Vec<_>>>()?,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -514,7 +514,10 @@ async fn claude_oauth_status(
             .map_err(|error| error.to_string())?
             .as_deref()
             == Some("1");
-        Ok(claude_oauth::ClaudeOauth::detected().status(enabled))
+        let failure = claude_oauth::last_failure(&connection).map_err(|error| error.to_string())?;
+        Ok(claude_oauth::ClaudeOauth::detected()
+            .status(enabled)
+            .with_failure(failure))
     })
     .await
     .map_err(|error| format!("claude oauth status task failed: {error}"))?
@@ -549,6 +552,8 @@ async fn set_claude_oauth(
                 )
                 .map_err(|error| error.to_string())?;
         }
+        // 上一轮的失败原因对新开关无效，留着会指向已经不存在的问题。
+        claude_oauth::clear_failure(&connection).map_err(|error| error.to_string())?;
         // 清缓存让下一次快照立即按新开关取数。
         if let Ok(mut guard) = claude_quota_cache.lock() {
             *guard = None;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -372,6 +372,15 @@ function quotaHasData(entry) {
   return Boolean(entry?.windows?.some((window) => window.view.available));
 }
 
+/// 没有额度数字时该说什么。后端在 note 里带上直连失败的真实原因（凭据过期、
+/// 缺 scope、限流……）；有原因就别再叫用户去开状态栏钩子——他多半已经开了
+/// 直连，而且不用 Claude Code 的人开了钩子也不会有数据。
+function quotaEmptyCopy(entry, agentId, short = false) {
+  if (entry?.note) return short ? "直连查询失败" : "直连查询失败 · 见设置";
+  if (agentId !== "claude") return short ? "官方配额不可用" : "暂无可靠来源";
+  return short ? "设置中开启配额钩子" : "在设置中开启配额钩子后显示";
+}
+
 function shortWindowLabel(key) {
   if (key === "five_hour" || key === "primary") return "5h";
   if (key === "seven_day" || key === "secondary") return "7d";
@@ -861,12 +870,8 @@ function Inspector({ snapshot, selectedAgent, onSelectAgent, onOpenSources, widg
             <section className="quota-group" key={agentId}>
               <header>
                 <strong>{AGENT_META[agentId].label}</strong>
-                <small>
-                  {hasData
-                    ? quotaProvenance(provenanceView)
-                    : agentId === "claude"
-                      ? "在设置中开启配额钩子后显示"
-                      : "暂无可靠来源"}
+                <small title={hasData ? undefined : entry.note || undefined}>
+                  {hasData ? quotaProvenance(provenanceView) : quotaEmptyCopy(entry, agentId)}
                 </small>
               </header>
               {hasData &&
@@ -1639,9 +1644,7 @@ function CompactWidget({
                   ? "窗口已重置，等待刷新"
                   : quotaView.available
                     ? `${formatReset(quotaView.resetsInMinutes)}后重置`
-                    : quotaAgent === "claude"
-                      ? "设置中开启配额钩子"
-                      : "官方配额不可用"}
+                    : quotaEmptyCopy(quotaEntry, quotaAgent, true)}
             </small>
           </button>
         </section>
@@ -2076,6 +2079,15 @@ function ClaudeOauthBlock({ onSnapshotRefresh }) {
                       : "未开启 · 凭据可用"}
               </dd>
             </div>
+            {/* 开关一切正常、却始终没有额度数字时，唯一能解释原因的就是这一行。 */}
+            {status.lastFailure && (
+              <div>
+                <dt>最近失败</dt>
+                <dd>
+                  {status.lastFailure.message} · {formatSyncTime(status.lastFailure.atMs)}
+                </dd>
+              </div>
+            )}
           </dl>
         </>
       )}


### PR DESCRIPTION
用户反馈：开了「官方额度直连（OAuth）」之后，Claude 配额卡始终显示「在设置中开启配额钩子后显示」。他们平时不用 Claude Code，装 statusLine 钩子也不会有数据，于是彻底走不出去，也拿不到任何解释。

## 根因

`engine.rs` 里这一句把失败原因整个丢掉：

```rust
if let Ok(samples) = cached_claude_oauth_quota(claude_quota_cache, force) {
    claude_samples = samples;
}
if claude_samples.is_empty() {
    claude_samples = ClaudeHook::detected().quota_samples();   // 回落到状态栏钩子
}
```

`claude_oauth.rs` 本来对每种失败都写好了可行动的中文原因——凭据不存在、缺 `user:profile` 权限、401 已失效、429 限流、HTTP 码、网络错误、响应不是预期 JSON、没有可用窗口——一句都传不出来。回落之后界面显示写死的钩子文案，对这批用户是一条走不通的建议。

## 改动

**失败如实留档**（`app_setting`）。存的是本模块自己生成的错误文案，不含 token、请求头或响应体——`fetch_quota_samples` 里本来就有「错误信息里绝不能带请求头」的约束，这里沿用。

清除时机三条：拿到窗口才清；缓存命中失败时返回的是 `Ok(空)`，既不清除也不覆盖上一条（否则 300s 的失败 TTL 内原因会时有时无）；开关切换时清掉，避免指向已经不存在的问题。

**`AgentQuotaView` 增加可选 `note`**，只在 Claude 确实没有可用窗口时才带——有数字了就没什么好解释的。

**三处文案**：配额卡显示「直连查询失败 · 见设置」，完整原因挂 tooltip；设置页直连区新增「最近失败」行，给出完整原因与相对时间；紧凑小组件焦点卡里同一句错误建议一并修掉。共用 `quotaEmptyCopy()`。

## 未覆盖的部分

**只让失败可自查，没有改动直连本身的成功路径。** 那条路径在开发机上无法验证：不开启就没有凭据可读，而开启涉及卡片里已声明的条款风险，应由用户自行决定。开发机 `app_setting` 中没有 `claude_oauth_quota_enabled`，直连从未在此启用过。

新增的两个测试覆盖失败记录的读写、后一次覆盖前一次、以及记录损坏时降级为「无记录」，**不是**真实接口调用。

如果那位用户的直连本该成功却失败了，本次改动只会让他看到原因，不会让它变好——但有了原因才知道下一步修什么。

## 验证

- `cargo fmt --check` 干净、`cargo clippy --all-targets -- -D warnings` 零告警
- `cargo test` 174 项通过（新增 2 项）
- `npm test` 34 项、`npm run build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
