### PR TITLE
Release v0.14.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.4"
+version = "0.14.5"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：五个版本文件从 `0.14.4` 升到 `0.14.5`，不含任何产品代码。

产品改动已由 #93 合入并在 `main` 上通过双平台 CI。

## v0.14.5 内容

修复「官方额度直连（OAuth）」查询失败时毫无提示的问题。失败原因原本被 `if let Ok(...)` 整个丢弃，界面回落成「在设置中开启配额钩子后显示」——对不使用 Claude Code 的用户是一条走不通的建议。

现在失败如实留档：配额卡显示「直连查询失败 · 见设置」并把完整原因挂在 tooltip，设置页直连区新增「最近失败」行给出原因与时间。记录内容不含凭据、请求头或响应体。

本次只解决「失败时能不能说清楚」，直连本身的成功路径未作改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
