### PR TITLE
chore: 忽略 .zcode/ 工作目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Thumbs.db
 .agents/
 .codex/
 .claude/
+.zcode/
 .maintainer/
 .worktrees/
 .codex-release-*/


### PR DESCRIPTION
zcode 会在仓库根写 `.zcode/plans/`，此前未被忽略，`git status` 里一直挂着 `?? .zcode/`，一次 `git add -A` 就会把它提进去。

与相邻的 `.codex/`、`.claude/`、`.maintainer/` 保持一致，忽略整个工具目录而不只是 `plans` 子目录——该目录以后放别的东西也一并挡住（zcode 的配置里存过明文 key）。

仓库中没有已跟踪的 `.zcode` 文件（`git ls-files .zcode` 为空），无需 `git rm --cached`。

验证：`git check-ignore -v .zcode/plans/plan-sess_*.md` 命中 `.gitignore:16`，`git status` 中的 `?? .zcode/` 消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
