### PR TITLE
refactor(quota): QuotaProvider 注册表 + 本机 Agent 检测

### DIFF
--- a/src-tauri/src/claude_oauth.rs
+++ b/src-tauri/src/claude_oauth.rs
@@ -17,17 +17,27 @@ use std::time::Duration;
 /// 1. 环境变量 `CLAUDE_CODE_OAUTH_TOKEN`（用户显式指定的裸 token）；
 /// 2. 凭据文件 `$CLAUDE_CONFIG_DIR|~/.claude` 下的 `.credentials.json`
 ///    （Linux、以及部分 Windows 安装）；
-/// 3. macOS 钥匙串条目 `Claude Code-credentials`（macOS 上 Claude Code 默认
-///    把 token 存进系统钥匙串而非明文文件）。读取经 `security` 命令，token
-///    同样只在内存里用一次，不落盘。
+/// 3. macOS 钥匙串（macOS 上 Claude Code 默认把 token 存进系统钥匙串而非
+///    明文文件）：先试旧 service 名 `Claude Code-credentials`，未命中再从
+///    `security dump-keychain` 的条目里找 v2.1.52+ 的
+///    `Claude Code-credentials-<hash>`。读取经 `security` 命令，token 同样
+///    只在内存里用一次，不落盘。
+///
+/// token 失效（401）时调一次官方 CLI `claude auth status --json` 让 Claude Code
+/// 自己刷新，然后重读凭据重试一次。刷新与落盘全由官方客户端完成——本模块
+/// 从不刷新、不写回、不解析该命令的输出。
 const CREDENTIALS_FILE: &str = ".credentials.json";
 const USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
 const BETA_HEADER: &str = "oauth-2025-04-20";
 const REQUIRED_SCOPE: &str = "user:profile";
 /// 用户显式指定 token 的环境变量（与 Claude Code 官方同名）。
 const ENV_TOKEN: &str = "CLAUDE_CODE_OAUTH_TOKEN";
+/// 覆盖 claude 可执行文件位置的环境变量（与 CODEX_BINARY 同一惯例）。
+const ENV_CLI: &str = "CLAUDE_BINARY";
 /// Claude Code 在 macOS 钥匙串里存凭据用的 generic-password service 名。
-#[cfg(target_os = "macos")]
+/// v2.1.52 起改成 `Claude Code-credentials-<hash>`，哈希不可推导，只能从
+/// 钥匙串条目里找；旧名仍在用，两者都要试。
+#[cfg(any(target_os = "macos", test))]
 const KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
 /// 覆盖 Claude 配置目录的环境变量（与 Claude Code 官方同名）。
 const ENV_CONFIG_DIR: &str = "CLAUDE_CONFIG_DIR";
@@ -87,6 +97,27 @@ struct OauthCredentials {
     access_token: Option<String>,
     #[serde(default)]
     scopes: Vec<String>,
+    /// 过期时刻。Claude Code 写的是毫秒，但字段名与单位在不同版本间变过，
+    /// 两种命名都收，秒/毫秒按量级判断。
+    #[serde(default, rename = "expiresAt", alias = "expires_at")]
+    expires_at: Option<i64>,
+}
+
+impl OauthCredentials {
+    /// token 是否已过期。读不到过期时刻就当作未过期——不能因为少一个字段
+    /// 就把一份可用的凭据判死。
+    fn is_expired(&self, now_ms: i64) -> bool {
+        let Some(raw) = self.expires_at else {
+            return false;
+        };
+        // 1e11 毫秒约合 1973 年，秒则约合公元 5138 年：两种单位不会混淆。
+        let at_ms = if raw.abs() < 100_000_000_000 {
+            raw.saturating_mul(1000)
+        } else {
+            raw
+        };
+        at_ms <= now_ms
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -213,6 +244,8 @@ impl ClaudeOauth {
                 return Some(OauthCredentials {
                     access_token: Some(token),
                     scopes: vec![REQUIRED_SCOPE.to_owned()],
+                    // 用户自己给的裸 token，没有过期信息可依据。
+                    expires_at: None,
                 });
             }
         }
@@ -259,14 +292,66 @@ impl ClaudeOauth {
         let Some(credentials) = self.read_credentials() else {
             bail!("本机没有 Claude Code 登录凭据（环境变量、~/.claude/.credentials.json、macOS 钥匙串均未命中）");
         };
+        // 已经过期就先刷新，省掉一次注定 401 的请求。
+        let credentials = if credentials.is_expired(chrono::Utc::now().timestamp_millis()) {
+            self.refresh_credentials().unwrap_or(credentials)
+        } else {
+            credentials
+        };
+        match self.request_usage(&credentials, timeout) {
+            Err(UsageError::Unauthorized) => {
+                // token 失效：让官方 CLI 自己刷新一次再重试。刷新与落盘全由
+                // Claude Code 完成，我们既不解析它的输出也不写回任何凭据。
+                let Some(refreshed) = self.refresh_credentials() else {
+                    bail!("Claude 凭据已失效（401），自动刷新未成功，请重新运行 claude login");
+                };
+                self.request_usage(&refreshed, timeout)
+                    .map_err(|error| match error {
+                        UsageError::Unauthorized => anyhow::anyhow!(
+                            "Claude 凭据已失效（401），刷新后仍被拒绝，请重新运行 claude login"
+                        ),
+                        UsageError::Other(error) => error,
+                    })
+            }
+            Err(UsageError::Other(error)) => Err(error),
+            Ok(samples) => Ok(samples),
+        }
+    }
+
+    /// 让官方 CLI 刷新 token（`claude auth status --json`），然后重读凭据。
+    /// 只取"刷新"这个副作用：输出直接丢弃，退出码也不作判据——判据是重读
+    /// 出来的凭据本身。
+    fn refresh_credentials(&self) -> Option<OauthCredentials> {
+        // 单测不碰系统来源，避免读到开发机的真实凭据或起真实进程。
+        if !self.consult_system {
+            return None;
+        }
+        let mut command = claude_cli_command()?;
+        command
+            .args(["auth", "status", "--json"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        let child = command.spawn().ok()?;
+        wait_with_deadline(child, Duration::from_secs(12));
+        self.read_credentials()
+    }
+
+    fn request_usage(
+        &self,
+        credentials: &OauthCredentials,
+        timeout: Duration,
+    ) -> std::result::Result<Vec<QuotaSample>, UsageError> {
         if !credentials
             .scopes
             .iter()
             .any(|scope| scope == REQUIRED_SCOPE)
         {
-            bail!("Claude 凭据缺少 user:profile 权限，无法查询用量。请重新运行 claude login");
+            return Err(UsageError::Other(anyhow::anyhow!(
+                "Claude 凭据缺少 user:profile 权限，无法查询用量。请重新运行 claude login"
+            )));
         }
-        let token = credentials.access_token.unwrap_or_default();
+        let token = credentials.access_token.clone().unwrap_or_default();
 
         let agent = ureq::AgentBuilder::new().timeout(timeout).build();
         let response = agent
@@ -278,29 +363,106 @@ impl ClaudeOauth {
             .call()
             .map_err(|error| match error {
                 // 错误信息里绝不能带请求头（token）。
-                ureq::Error::Status(401, _) => {
-                    anyhow::anyhow!("Claude 凭据已失效（401），请重新运行 claude login")
-                }
+                ureq::Error::Status(401, _) => UsageError::Unauthorized,
                 ureq::Error::Status(429, _) => {
-                    anyhow::anyhow!("Claude 用量接口限流（429），稍后自动重试")
+                    UsageError::Other(anyhow::anyhow!("Claude 用量接口限流（429），稍后自动重试"))
                 }
                 ureq::Error::Status(code, _) => {
-                    anyhow::anyhow!("Claude 用量接口返回 HTTP {code}")
+                    UsageError::Other(anyhow::anyhow!("Claude 用量接口返回 HTTP {code}"))
                 }
                 ureq::Error::Transport(transport) => {
-                    anyhow::anyhow!("Claude 用量接口网络错误: {transport}")
+                    UsageError::Other(anyhow::anyhow!("Claude 用量接口网络错误: {transport}"))
                 }
             })?;
 
-        let body = response.into_string().context("读取 Claude 用量响应失败")?;
-        let usage: UsageResponse =
-            serde_json::from_str(&body).context("Claude 用量响应不是预期的 JSON")?;
+        let parse = || -> Result<Vec<QuotaSample>> {
+            let body = response.into_string().context("读取 Claude 用量响应失败")?;
+            let usage: UsageResponse =
+                serde_json::from_str(&body).context("Claude 用量响应不是预期的 JSON")?;
+            let samples = samples_from_usage(usage, chrono::Utc::now().timestamp_millis());
+            if samples.is_empty() {
+                bail!("Claude 用量响应缺少可用的额度窗口");
+            }
+            Ok(samples)
+        };
+        parse().map_err(UsageError::Other)
+    }
+}
 
-        let samples = samples_from_usage(usage, chrono::Utc::now().timestamp_millis());
-        if samples.is_empty() {
-            bail!("Claude 用量响应缺少可用的额度窗口");
+/// 401 要与其它失败分开：只有它值得刷新后重试一次。
+enum UsageError {
+    Unauthorized,
+    Other(anyhow::Error),
+}
+
+/// 组装调用 claude CLI 的命令。与 `app_server.rs` 定位 codex 的写法同构：
+/// Windows 上 npm 装出来的是 `.cmd` 脚本，得经 cmd.exe 起。
+fn claude_cli_command() -> Option<std::process::Command> {
+    use std::process::Command;
+
+    let explicit = std::env::var_os(ENV_CLI).map(PathBuf::from);
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        let npm_script = std::env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .map(|root| root.join("npm").join("claude.cmd"))
+            .filter(|path| path.exists());
+        let script = explicit
+            .or(npm_script)
+            .unwrap_or_else(|| PathBuf::from("claude"));
+        let mut command = Command::new("cmd.exe");
+        command
+            .args(["/D", "/C"])
+            .arg(script)
+            // 不弹控制台窗口。
+            .creation_flags(0x0800_0000);
+        Some(command)
+    }
+
+    #[cfg(not(windows))]
+    {
+        if let Some(path) = explicit {
+            return Some(Command::new(path));
         }
-        Ok(samples)
+        let mut candidates = Vec::new();
+        if let Some(home) = dirs::home_dir() {
+            candidates.extend([
+                home.join(".local/bin/claude"),
+                home.join(".claude/local/claude"),
+                home.join(".npm-global/bin/claude"),
+            ]);
+        }
+        candidates.extend([
+            PathBuf::from("/opt/homebrew/bin/claude"),
+            PathBuf::from("/usr/local/bin/claude"),
+        ]);
+        let found = candidates.into_iter().find(|path| path.exists());
+        // 都没命中就交给 PATH。
+        Some(Command::new(
+            found.unwrap_or_else(|| PathBuf::from("claude")),
+        ))
+    }
+}
+
+/// 等一个子进程结束，超时就连同它一起结束。快照构建持有扫描锁，
+/// 一个吊死的 CLI 会把整次刷新拖住，所以必须有上限。
+fn wait_with_deadline(mut child: std::process::Child, limit: Duration) -> bool {
+    let started = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+        if started.elapsed() >= limit {
+            let _ = child.kill();
+            let _ = child.wait();
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
     }
 }
 
@@ -333,13 +495,29 @@ fn parse_credentials(raw: &str) -> Option<OauthCredentials> {
         })
 }
 
-/// 从 macOS 钥匙串取 Claude Code 存的凭据 JSON。`security -w` 只输出密码本体
-/// （即那段 JSON）；条目不存在或被拒时命令非零退出，返回 None，绝不猜测。
-/// 首次读取可能弹出系统钥匙串授权框，这是 macOS 的预期行为。
+/// 从 macOS 钥匙串取 Claude Code 存的凭据 JSON。先试沿用至今的旧 service 名；
+/// 未命中再从钥匙串条目里找 v2.1.52+ 的 `Claude Code-credentials-<hash>`。
+/// 只试旧名会让装了较新 Claude Code 的 Mac 用户明明登录过却被判为"未找到凭据"。
 #[cfg(target_os = "macos")]
 fn read_macos_keychain() -> Option<String> {
+    if let Some(raw) = keychain_password(KEYCHAIN_SERVICE) {
+        return Some(raw);
+    }
+    for service in discover_keychain_services() {
+        if let Some(raw) = keychain_password(&service) {
+            return Some(raw);
+        }
+    }
+    None
+}
+
+/// `security -w` 只输出密码本体（即那段 JSON）；条目不存在或被拒时命令非零
+/// 退出，返回 None，绝不猜测。首次读取可能弹出系统钥匙串授权框，这是 macOS
+/// 的预期行为。
+#[cfg(target_os = "macos")]
+fn keychain_password(service: &str) -> Option<String> {
     let output = std::process::Command::new("security")
-        .args(["find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"])
+        .args(["find-generic-password", "-s", service, "-w"])
         .output()
         .ok()?;
     if !output.status.success() {
@@ -348,6 +526,48 @@ fn read_macos_keychain() -> Option<String> {
     let raw = String::from_utf8(output.stdout).ok()?;
     let trimmed = raw.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_owned())
+}
+
+/// 列出钥匙串里所有 Claude Code 的 generic-password service 名。
+/// `dump-keychain` 不带 `-d` 只列元数据、不读密码本体，因此不会弹密码框。
+#[cfg(target_os = "macos")]
+fn discover_keychain_services() -> Vec<String> {
+    let Ok(output) = std::process::Command::new("security")
+        .arg("dump-keychain")
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    keychain_services_from_dump(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// 从 `dump-keychain` 的输出里挑出 Claude Code 的 service 名。条目行形如
+/// `    "svce"<blob>="Claude Code-credentials-<hash>"`。旧名已经单独试过，
+/// 这里排掉，避免白跑一次。
+///
+/// 解析与平台无关，故不加 `cfg(macos)` 门——否则在 Windows 上连测都测不了，
+/// 而这段正是最需要回归保护的部分。
+#[cfg(any(target_os = "macos", test))]
+fn keychain_services_from_dump(dump: &str) -> Vec<String> {
+    let mut found: Vec<String> = Vec::new();
+    for line in dump.lines() {
+        let Some(rest) = line.trim().strip_prefix("\"svce\"<blob>=\"") else {
+            continue;
+        };
+        let Some(service) = rest.strip_suffix('"') else {
+            continue;
+        };
+        if service.starts_with(KEYCHAIN_SERVICE)
+            && service != KEYCHAIN_SERVICE
+            && !found.iter().any(|seen| seen == service)
+        {
+            found.push(service.to_owned());
+        }
+    }
+    found
 }
 
 /// 把用量响应归一成额度样本：平铺窗口打底，limits[] 同键覆盖，
@@ -461,6 +681,60 @@ mod tests {
 
         clear_failure(&connection).unwrap();
         assert!(last_failure(&connection).unwrap().is_none());
+    }
+
+    /// Claude Code v2.1.52 起把凭据存进带哈希后缀的 service 名。开发机是
+    /// Windows，这段只能靠样本回归——真机行为需在 macOS 上另行核实。
+    #[test]
+    fn keychain_dump_yields_hashed_service_names_only() {
+        let dump = r#"
+keychain: "/Users/dev/Library/Keychains/login.keychain-db"
+class: "genp"
+attributes:
+    0x00000007 <blob>="Claude Code-credentials-a1b2c3"
+    "acct"<blob>="unknown"
+    "svce"<blob>="Claude Code-credentials"
+class: "genp"
+attributes:
+    "acct"<blob>="dev"
+    "svce"<blob>="Claude Code-credentials-a1b2c3"
+class: "genp"
+attributes:
+    "svce"<blob>="Claude Code-credentials-a1b2c3"
+class: "genp"
+attributes:
+    "svce"<blob>="com.apple.assistant"
+"#;
+        // 旧名单独试过所以排除；标签行（0x00000007）不算；重复项去掉。
+        assert_eq!(
+            keychain_services_from_dump(dump),
+            vec!["Claude Code-credentials-a1b2c3".to_owned()]
+        );
+    }
+
+    #[test]
+    fn keychain_dump_without_claude_entries_is_empty() {
+        assert!(keychain_services_from_dump("\"svce\"<blob>=\"com.apple.assistant\"").is_empty());
+        assert!(keychain_services_from_dump("").is_empty());
+    }
+
+    #[test]
+    fn expiry_accepts_both_seconds_and_milliseconds() {
+        let now_ms = 1_785_800_000_000_i64;
+        let credentials = |expires_at| OauthCredentials {
+            access_token: Some("t".into()),
+            scopes: vec![REQUIRED_SCOPE.to_owned()],
+            expires_at,
+        };
+
+        // 毫秒
+        assert!(credentials(Some(now_ms - 1)).is_expired(now_ms));
+        assert!(!credentials(Some(now_ms + 60_000)).is_expired(now_ms));
+        // 秒
+        assert!(credentials(Some(now_ms / 1000 - 1)).is_expired(now_ms));
+        assert!(!credentials(Some(now_ms / 1000 + 60)).is_expired(now_ms));
+        // 读不到过期时刻不判死，交给服务端裁决。
+        assert!(!credentials(None).is_expired(now_ms));
     }
 
     #[test]

--- a/src-tauri/src/detect.rs
+++ b/src-tauri/src/detect.rs
@@ -1,0 +1,170 @@
+//! 本机装了哪些 Agent。
+//!
+//! 只看安装痕迹，不看有没有用量：装了但最近没用过的也该算"检测到"，否则
+//! 设置里会把它挪进"未检测到"，用户会以为我们不支持。
+//!
+//! **检测只用于排序与分组，从不用于过滤。** 探针会误判——换了非默认配置
+//! 目录、便携安装、或者我们压根没有可靠探针（Antigravity 只有运行期的 RPC
+//! 端点，没有稳定的安装痕迹）。若误判能把一个 Agent 从列表里抹掉，用户就
+//! 再也勾不上它了，所以未检测到的一律仍可展开手动勾选。
+//!
+//! 路径取自各 adapter 的 `discover()`，不另猜一套：改了那边这里要跟着改，
+//! `probe_paths_match_adapter_roots` 会在偏离时失败。
+
+use crate::coding_quota;
+use std::path::PathBuf;
+
+/// 一个 Agent 的安装探针。三种形态对应三类来源，与各 adapter 的取数方式一致。
+pub enum Probe {
+    /// 任一路径存在即算装了。路径已按平台解析成绝对路径。
+    Paths(Vec<PathBuf>),
+    /// 由用户配置的凭据提供（Qoder 只有账户级 Credits，没有本地日志）。
+    Credential(fn() -> bool),
+    /// 没有便宜且可靠的安装痕迹。此类 Agent 只能靠"本周期有用量"反推，
+    /// 由调用方补上，这里如实返回"未知"而不是猜一个路径。
+    Unknown,
+}
+
+pub struct AgentProbe {
+    pub id: &'static str,
+    pub probe: Probe,
+}
+
+fn home() -> PathBuf {
+    dirs::home_dir().unwrap_or_default()
+}
+
+/// OpenCode 的数据根：与 `OpencodeAdapter::detected()` 同一套解析。
+fn opencode_data_dir() -> PathBuf {
+    std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .filter(|value| value.is_absolute())
+        .unwrap_or_else(|| home().join(".local").join("share"))
+        .join("opencode")
+}
+
+/// Kimi 的数据根：与 `KimiAdapter::detected()` 同一套解析。
+fn kimi_code_dir() -> PathBuf {
+    std::env::var_os("KIMI_CODE_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .unwrap_or_else(|| home().join(".kimi-code"))
+}
+
+pub fn table() -> Vec<AgentProbe> {
+    let home = home();
+    vec![
+        AgentProbe {
+            id: "codex",
+            probe: Probe::Paths(vec![home.join(".codex")]),
+        },
+        AgentProbe {
+            id: "claude",
+            probe: Probe::Paths(vec![home.join(".claude")]),
+        },
+        AgentProbe {
+            id: "zcode",
+            probe: Probe::Paths(vec![home.join(".zcode")]),
+        },
+        AgentProbe {
+            id: "opencode",
+            probe: Probe::Paths(vec![opencode_data_dir()]),
+        },
+        AgentProbe {
+            id: "kimi",
+            probe: Probe::Paths(vec![kimi_code_dir(), home.join(".kimi")]),
+        },
+        AgentProbe {
+            // Antigravity 只在 IDE 运行时才有 language server 端点，扫进程与
+            // 试端口都太贵，不适合每次开设置页都跑一遍。
+            id: "antigravity",
+            probe: Probe::Unknown,
+        },
+        AgentProbe {
+            id: "workbuddy",
+            probe: Probe::Paths(vec![home.join(".codebuddy"), home.join(".workbuddy")]),
+        },
+        AgentProbe {
+            id: "qoder",
+            probe: Probe::Credential(|| coding_quota::qoder_cookie_source().is_some()),
+        },
+    ]
+}
+
+/// 本机检测到的 Agent id。返回顺序即表的顺序。
+pub fn installed_agents() -> Vec<&'static str> {
+    table()
+        .into_iter()
+        .filter(|entry| match &entry.probe {
+            Probe::Paths(paths) => paths.iter().any(|path| path.exists()),
+            Probe::Credential(check) => check(),
+            Probe::Unknown => false,
+        })
+        .map(|entry| entry.id)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::AGENT_IDS;
+
+    #[test]
+    fn every_agent_has_exactly_one_probe() {
+        let ids: Vec<&str> = table().into_iter().map(|entry| entry.id).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ids.len(), "有 Agent 写了两个探针");
+
+        let mut expected: Vec<&str> = AGENT_IDS.to_vec();
+        expected.sort_unstable();
+        assert_eq!(
+            sorted, expected,
+            "探针表与 AGENT_IDS 不一致：新增 Agent 时两处要同步"
+        );
+    }
+
+    /// 探针路径必须与各 adapter 真正扫描的根一致。adapter 改了目录而这里没跟，
+    /// 会让用户看到"未检测到"却明明有数据。
+    #[test]
+    fn probe_paths_match_adapter_roots() {
+        let home = home();
+        let by_id = |wanted: &str| {
+            table()
+                .into_iter()
+                .find(|entry| entry.id == wanted)
+                .map(|entry| entry.probe)
+                .expect("表里应有该 Agent")
+        };
+        let paths = |probe: Probe| match probe {
+            Probe::Paths(paths) => paths,
+            _ => panic!("该 Agent 应当是路径探针"),
+        };
+
+        // 与 codex.rs / claude.rs / zcode.rs 里的根同源，取其父目录。
+        assert_eq!(paths(by_id("codex")), vec![home.join(".codex")]);
+        assert_eq!(paths(by_id("claude")), vec![home.join(".claude")]);
+        assert_eq!(paths(by_id("zcode")), vec![home.join(".zcode")]);
+        assert_eq!(
+            paths(by_id("workbuddy")),
+            vec![home.join(".codebuddy"), home.join(".workbuddy")]
+        );
+        // 这两个受环境变量覆盖，必须走与 adapter 相同的解析。
+        assert_eq!(paths(by_id("opencode")), vec![opencode_data_dir()]);
+        assert_eq!(
+            paths(by_id("kimi")),
+            vec![kimi_code_dir(), home.join(".kimi")]
+        );
+    }
+
+    #[test]
+    fn unknown_probe_never_claims_installed() {
+        let antigravity = table()
+            .into_iter()
+            .find(|entry| entry.id == "antigravity")
+            .expect("表里应有 antigravity");
+        assert!(matches!(antigravity.probe, Probe::Unknown));
+        assert!(!installed_agents().contains(&"antigravity"));
+    }
+}

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -299,6 +299,9 @@ pub struct AgentSummary {
     pub cache_write: i64,
     pub output: i64,
     pub share: f64,
+    /// 本机装了这个 Agent：安装痕迹命中，或本周期确有用量（后者兜住没有可靠
+    /// 安装探针的 Agent）。只用于设置里的排序分组，不用于过滤——见 `detect`。
+    pub detected: bool,
 }
 
 /// 周期内按模型聚合的 processed token 用量，按 tokens 降序排列。

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -2,18 +2,16 @@ use crate::adapters::{
     AgentAdapter, AntigravityAdapter, ClaudeAdapter, CodexAdapter, KimiAdapter, OpencodeAdapter,
     ScanDiagnostics, SourceCandidate, WorkbuddyAdapter, ZcodeAdapter,
 };
-use crate::app_server;
-use crate::claude_hook::ClaudeHook;
-use crate::claude_oauth::{self, ClaudeOauth};
-use crate::coding_quota;
+use crate::claude_oauth;
 use crate::domain::ProjectReportRow;
 use crate::domain::{
     AgentCost, AgentQuotaView, AgentReportRow, AgentSummary, CostSummary, DayUsage, IndexingView,
-    ModelSummary, ProjectSummary, QuotaSample, QuotaView, SeriesPoint, SessionSummary, SourceView,
-    SyncView, UsageProjects, UsageReport, UsageSessions, UsageSnapshot, AGENT_IDS,
+    ModelSummary, ProjectSummary, QuotaView, SeriesPoint, SessionSummary, SourceView, SyncView,
+    UsageProjects, UsageReport, UsageSessions, UsageSnapshot, AGENT_IDS,
 };
 use crate::pricing;
 use crate::projects::{self, ProjectResolver, Resolution};
+use crate::quota;
 use crate::storage;
 use crate::sync;
 use anyhow::{Context, Result};
@@ -22,7 +20,6 @@ use rusqlite::{params, Connection};
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
-use std::sync::Mutex;
 use std::time::{Duration as StdDuration, Instant};
 
 /// 报告窗口固定为 182 天（26 周），与 `usage_snapshot` 的扫描周期无关。
@@ -162,9 +159,7 @@ fn estimate_usd(model_components: &HashMap<String, TokenComponents>) -> Option<f
 pub fn build_snapshot(
     database_path: &Path,
     period: &str,
-    quota_cache: &Mutex<Option<(Instant, Vec<QuotaSample>)>>,
-    claude_quota_cache: &Mutex<Option<(Instant, Vec<QuotaSample>)>>,
-    http_quota_cache: &Mutex<HashMap<&'static str, (Instant, Vec<QuotaSample>)>>,
+    quota_cache: &quota::QuotaCache,
     force: bool,
 ) -> Result<UsageSnapshot> {
     let mut connection = storage::open_database(database_path)?;
@@ -172,72 +167,8 @@ pub fn build_snapshot(
     let retention_cutoff = now - Duration::days(RETENTION_DAYS).num_milliseconds();
     let report = ingest_sources(&mut connection, retention_cutoff)?;
 
-    // app-server 是 Codex 额度的权威来源：拉到就整体替换，套餐变更后消失的
-    // 窗口（如 prolite 没有 5 小时窗）不得留着旧日志快照冒充当前额度。
-    if let Ok(samples) = cached_live_quota(quota_cache, force) {
-        if !samples.is_empty() {
-            connection.execute("DELETE FROM quota_snapshot WHERE adapter_id = 'codex'", [])?;
-        }
-        for sample in &samples {
-            storage::upsert_quota(&connection, sample)?;
-        }
-    }
-    // Claude 官方额度：用户显式开启 OAuth 来源时优先（账户级合并额度，
-    // 不依赖终端状态栏）；拉取失败或未开启时回落到 statusLine 钩子文件。
-    let oauth_enabled =
-        storage::get_app_setting(&connection, claude_oauth::SETTING_KEY)?.as_deref() == Some("1");
-    let mut claude_samples = Vec::new();
-    if oauth_enabled {
-        // 失败原因必须留档。丢掉 Err 会让"开了直连却没有额度"完全无法自查：
-        // 界面回落到钩子文案，叫用户去开一个他根本不用的 statusLine。
-        // 缓存命中失败时返回的是 Ok(空)，既不清也不覆盖上一条记录。
-        match cached_claude_oauth_quota(claude_quota_cache, force) {
-            Ok(samples) => {
-                if !samples.is_empty() {
-                    claude_oauth::clear_failure(&connection)?;
-                }
-                claude_samples = samples;
-            }
-            Err(error) => claude_oauth::record_failure(&connection, &error.to_string())?,
-        }
-    }
-    if claude_samples.is_empty() {
-        claude_samples = ClaudeHook::detected().quota_samples();
-    }
-    if !claude_samples.is_empty() {
-        // 当前来源是 Claude 配额的唯一事实：整体替换，来源里消失的窗口
-        // （或旧版 primary/secondary 键）不得滞留在展示里。
-        connection.execute("DELETE FROM quota_snapshot WHERE adapter_id = 'claude'", [])?;
-    }
-    for sample in claude_samples {
-        storage::upsert_quota(&connection, &sample)?;
-    }
-
-    // GLM/Kimi 官方配额：与 codex/claude 同型，一次实时 GET，跨快照缓存限流。
-    // 取到才整体替换该 Agent 的窗口；无凭据/失败时保留旧行（会随时效变陈旧），
-    // 绝不写零值或估算冒充。
-    for (adapter_id, fetch) in [
-        (
-            "zcode",
-            coding_quota::fetch_zcode_quota as fn(StdDuration) -> Result<Vec<QuotaSample>>,
-        ),
-        ("kimi", coding_quota::fetch_kimi_quota),
-        ("kimiwork", coding_quota::fetch_kimiwork_quota),
-        ("qoder", coding_quota::fetch_qoder_quota),
-        ("workbuddy", coding_quota::fetch_workbuddy_quota),
-    ] {
-        if let Ok(samples) = cached_coding_quota(http_quota_cache, adapter_id, fetch, force) {
-            if !samples.is_empty() {
-                connection.execute(
-                    "DELETE FROM quota_snapshot WHERE adapter_id = ?1",
-                    [adapter_id],
-                )?;
-                for sample in &samples {
-                    storage::upsert_quota(&connection, sample)?;
-                }
-            }
-        }
-    }
+    // 各家官方额度的取数与落库统一在 quota 模块，见那里的落库语义说明。
+    quota::refresh_all(&connection, quota_cache, force)?;
 
     storage::prune_missing_sources(&mut connection)?;
     storage::prune_old_events(&connection, retention_cutoff)?;
@@ -775,96 +706,6 @@ fn global_event_bounds(connection: &Connection) -> Result<(Option<i64>, Option<i
             |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, Option<i64>>(1)?)),
         )
         .context("failed to calculate ledger event bounds")
-}
-
-fn cached_live_quota(
-    cache: &Mutex<Option<(Instant, Vec<QuotaSample>)>>,
-    force: bool,
-) -> Result<Vec<QuotaSample>> {
-    let mut guard = cache
-        .lock()
-        .map_err(|_| anyhow::anyhow!("quota cache lock poisoned"))?;
-    // force（手动刷新）跳过新鲜缓存的早退，立即尝试拉取；失败路径与常规一致：
-    // 依旧写入失败哨兵并保留库中旧行，绝不因强制刷新而删数据。
-    if !force {
-        if let Some((captured, value)) = guard.as_ref() {
-            let ttl = if value.is_empty() { 240 } else { 60 };
-            if captured.elapsed() < StdDuration::from_secs(ttl) {
-                return Ok(value.clone());
-            }
-        }
-    }
-    match app_server::read_codex_quota(StdDuration::from_secs(4)) {
-        Ok(value) => {
-            *guard = Some((Instant::now(), value.clone()));
-            Ok(value)
-        }
-        Err(error) => {
-            // An unavailable CLI should not make every periodic widget refresh
-            // pay the full process timeout. The empty sentinel uses a longer TTL.
-            *guard = Some((Instant::now(), Vec::new()));
-            Err(error)
-        }
-    }
-}
-
-/// Claude OAuth 官方额度的缓存拉取：成功 120s、失败 300s（限流友好）。
-fn cached_claude_oauth_quota(
-    cache: &Mutex<Option<(Instant, Vec<QuotaSample>)>>,
-    force: bool,
-) -> Result<Vec<QuotaSample>> {
-    let mut guard = cache
-        .lock()
-        .map_err(|_| anyhow::anyhow!("claude quota cache lock poisoned"))?;
-    if !force {
-        if let Some((captured, value)) = guard.as_ref() {
-            let ttl = if value.is_empty() { 300 } else { 120 };
-            if captured.elapsed() < StdDuration::from_secs(ttl) {
-                return Ok(value.clone());
-            }
-        }
-    }
-    match ClaudeOauth::detected().fetch_quota_samples(StdDuration::from_secs(6)) {
-        Ok(value) => {
-            *guard = Some((Instant::now(), value.clone()));
-            Ok(value)
-        }
-        Err(error) => {
-            *guard = Some((Instant::now(), Vec::new()));
-            Err(error)
-        }
-    }
-}
-
-/// GLM/Kimi 等走网络的官方配额缓存拉取：按 adapter 分桶，成功 120s、失败 300s。
-/// adapter 每次快照都重建，故缓存不能放 adapter 里，必须由 engine 层跨快照持有。
-fn cached_coding_quota(
-    cache: &Mutex<HashMap<&'static str, (Instant, Vec<QuotaSample>)>>,
-    adapter_id: &'static str,
-    fetch: fn(StdDuration) -> Result<Vec<QuotaSample>>,
-    force: bool,
-) -> Result<Vec<QuotaSample>> {
-    let mut guard = cache
-        .lock()
-        .map_err(|_| anyhow::anyhow!("coding quota cache lock poisoned"))?;
-    if !force {
-        if let Some((captured, value)) = guard.get(adapter_id) {
-            let ttl = if value.is_empty() { 300 } else { 120 };
-            if captured.elapsed() < StdDuration::from_secs(ttl) {
-                return Ok(value.clone());
-            }
-        }
-    }
-    match fetch(StdDuration::from_secs(6)) {
-        Ok(value) => {
-            guard.insert(adapter_id, (Instant::now(), value.clone()));
-            Ok(value)
-        }
-        Err(error) => {
-            guard.insert(adapter_id, (Instant::now(), Vec::new()));
-            Err(error)
-        }
-    }
 }
 
 /// 按固定的保留期视界摄取日志。需要解析的源按 mtime 倒序排队，在时间预算内尽量
@@ -1712,6 +1553,7 @@ fn bucket_label(period: &str, start: NaiveDate, index: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
     fn test_local_time(date: NaiveDate, hour: u32) -> chrono::DateTime<Local> {
         Local
@@ -3102,18 +2944,8 @@ mod tests {
             std::process::id(),
             Utc::now().timestamp_millis()
         ));
-        let quota_cache = Mutex::new(None);
-        let claude_quota_cache = Mutex::new(None);
-        let http_quota_cache = Mutex::new(HashMap::new());
-        let snapshot = build_snapshot(
-            &database,
-            "today",
-            &quota_cache,
-            &claude_quota_cache,
-            &http_quota_cache,
-            false,
-        )
-        .unwrap();
+        let quota_cache = Mutex::new(HashMap::new());
+        let snapshot = build_snapshot(&database, "today", &quota_cache, false).unwrap();
         println!(
             "live snapshot: total={}, codex={}, claude={}, quota_available={}, quota_remaining={:.1}, quota_source={}",
             snapshot.total_tokens,

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -3,6 +3,7 @@ use crate::adapters::{
     ScanDiagnostics, SourceCandidate, WorkbuddyAdapter, ZcodeAdapter,
 };
 use crate::claude_oauth;
+use crate::detect;
 use crate::domain::ProjectReportRow;
 use crate::domain::{
     AgentCost, AgentQuotaView, AgentReportRow, AgentSummary, CostSummary, DayUsage, IndexingView,
@@ -1014,6 +1015,9 @@ fn query_snapshot_at(
             .collect(),
     };
 
+    // 安装探针只碰文件系统与已配置的凭据，一次快照查一遍即可。
+    let installed = detect::installed_agents();
+
     let mut models: Vec<ModelSummary> = model_totals
         .into_iter()
         .map(|((agent, model), tokens)| ModelSummary {
@@ -1063,6 +1067,9 @@ fn query_snapshot_at(
                     cache_write: comps.cache_write,
                     output: comps.output,
                     share: share(totals[agent]),
+                    // 有用量必然装了；反过来不成立，所以安装痕迹是主判据、
+                    // 用量兜底（Antigravity 没有便宜可靠的安装探针）。
+                    detected: installed.contains(agent) || totals[agent] > 0,
                 }
             })
             .collect(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod app_server;
 mod claude_hook;
 mod claude_oauth;
 mod coding_quota;
+mod detect;
 mod domain;
 mod engine;
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,25 +9,25 @@ mod engine;
 mod macos;
 mod pricing;
 mod projects;
+mod quota;
 mod schema;
 mod storage;
 mod sync;
 
 use anyhow::{Context, Result};
-use domain::{QuotaSample, UsageProjects, UsageReport, UsageSessions, UsageSnapshot};
+use domain::{UsageProjects, UsageReport, UsageSessions, UsageSnapshot};
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{Manager, State};
 
-type SharedQuotaCache = Arc<Mutex<Option<(Instant, Vec<QuotaSample>)>>>;
-/// 走网络的官方配额（GLM/Kimi）按 adapter 分桶缓存，跨快照持有以限流。
-type SharedHttpQuotaCache = Arc<Mutex<HashMap<&'static str, (Instant, Vec<QuotaSample>)>>>;
+/// 各家官方配额按 adapter 分桶缓存，跨快照持有以限流。取数节奏由各 provider
+/// 自己声明，见 `quota` 模块。
+type SharedQuotaCache = Arc<quota::QuotaCache>;
 
 const DATABASE_FILE_NAME: &str = "metrik.sqlite3";
 const RECOVERY_DATABASE_FILE_NAME: &str = "metrik.recovery.sqlite3";
@@ -38,8 +38,6 @@ struct AppState {
     database_path: PathBuf,
     scan_gate: Arc<Mutex<()>>,
     quota_cache: SharedQuotaCache,
-    claude_quota_cache: SharedQuotaCache,
-    http_quota_cache: SharedHttpQuotaCache,
 }
 
 fn sqlite_sidecar_path(database_path: &Path, suffix: &str) -> PathBuf {
@@ -343,8 +341,6 @@ async fn usage_snapshot(
     let database_path = state.database_path.clone();
     let scan_gate = Arc::clone(&state.scan_gate);
     let quota_cache = Arc::clone(&state.quota_cache);
-    let claude_quota_cache = Arc::clone(&state.claude_quota_cache);
-    let http_quota_cache = Arc::clone(&state.http_quota_cache);
 
     tauri::async_runtime::spawn_blocking(move || {
         let _gate = scan_gate
@@ -354,8 +350,6 @@ async fn usage_snapshot(
             &database_path,
             &period,
             &quota_cache,
-            &claude_quota_cache,
-            &http_quota_cache,
             force.unwrap_or(false),
         )
         .map_err(|error| error.to_string())
@@ -478,23 +472,14 @@ async fn rebuild_local_ledger(
     let database_path = state.database_path.clone();
     let scan_gate = Arc::clone(&state.scan_gate);
     let quota_cache = Arc::clone(&state.quota_cache);
-    let claude_quota_cache = Arc::clone(&state.claude_quota_cache);
-    let http_quota_cache = Arc::clone(&state.http_quota_cache);
 
     tauri::async_runtime::spawn_blocking(move || {
         let _gate = scan_gate
             .lock()
             .map_err(|_| "usage scan lock poisoned".to_owned())?;
         storage::reset_derived_ledger(&database_path).map_err(|error| error.to_string())?;
-        engine::build_snapshot(
-            &database_path,
-            &period,
-            &quota_cache,
-            &claude_quota_cache,
-            &http_quota_cache,
-            false,
-        )
-        .map_err(|error| error.to_string())
+        engine::build_snapshot(&database_path, &period, &quota_cache, false)
+            .map_err(|error| error.to_string())
     })
     .await
     .map_err(|error| format!("local ledger rebuild task failed: {error}"))?
@@ -530,7 +515,7 @@ async fn set_claude_oauth(
 ) -> Result<claude_oauth::ClaudeOauthStatus, String> {
     let database_path = state.database_path.clone();
     let scan_gate = Arc::clone(&state.scan_gate);
-    let claude_quota_cache = Arc::clone(&state.claude_quota_cache);
+    let quota_cache = Arc::clone(&state.quota_cache);
     tauri::async_runtime::spawn_blocking(move || {
         let _gate = scan_gate
             .lock()
@@ -555,8 +540,8 @@ async fn set_claude_oauth(
         // 上一轮的失败原因对新开关无效，留着会指向已经不存在的问题。
         claude_oauth::clear_failure(&connection).map_err(|error| error.to_string())?;
         // 清缓存让下一次快照立即按新开关取数。
-        if let Ok(mut guard) = claude_quota_cache.lock() {
-            *guard = None;
+        if let Ok(mut guard) = quota_cache.lock() {
+            guard.remove("claude");
         }
         Ok(claude_oauth::ClaudeOauth::detected().status(enabled))
     })
@@ -1065,9 +1050,7 @@ pub fn run() {
             app.manage(AppState {
                 database_path,
                 scan_gate: Arc::new(Mutex::new(())),
-                quota_cache: Arc::new(Mutex::new(None)),
-                claude_quota_cache: Arc::new(Mutex::new(None)),
-                http_quota_cache: Arc::new(Mutex::new(HashMap::new())),
+                quota_cache: Arc::new(Mutex::new(HashMap::new())),
             });
             Ok(())
         })

--- a/src-tauri/src/quota.rs
+++ b/src-tauri/src/quota.rs
@@ -1,0 +1,400 @@
+//! 官方额度来源的统一取数层。
+//!
+//! 此前每家厂商都在 `engine::build_snapshot` 里单独硬接：Codex 走 app-server、
+//! Claude 走 OAuth 再回落 statusLine 钩子、GLM/Kimi/Qoder/WorkBuddy 走 HTTP。
+//! 三段代码形状相同却各写一遍，加一家厂商的成本是"再改一次 engine 的取数
+//! 流程"——这才是覆盖面上不去的结构性原因。
+//!
+//! 这里把共同形状抽出来：声明缓存节奏与超时（各家限流策略不同，故随 provider
+//! 声明而非写死），实现一个 `fetch`，在 `registry()` 里列一行。engine 只调
+//! `refresh_all`。
+//!
+//! 落库语义对所有来源一致，且不得放宽：**拿到窗口才整体替换该 adapter 的行**
+//! ——来源里消失的窗口（如套餐变更后没有 5 小时窗）不得滞留冒充当前额度；
+//! 拿不到就保留旧行（会随时效在展示层变陈旧），绝不写零值或估算。
+
+use crate::app_server;
+use crate::claude_hook::ClaudeHook;
+use crate::claude_oauth::{self, ClaudeOauth};
+use crate::coding_quota;
+use crate::domain::QuotaSample;
+use crate::storage;
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// 缓存节奏与单次取数超时。
+#[derive(Clone, Copy)]
+pub struct QuotaPolicy {
+    /// 拿到窗口后多久内不再重拉。
+    fresh_ttl: Duration,
+    /// 拉空或失败后多久内不再重试（限流友好）。
+    empty_ttl: Duration,
+    timeout: Duration,
+}
+
+impl QuotaPolicy {
+    const fn new(fresh_secs: u64, empty_secs: u64, timeout_secs: u64) -> Self {
+        Self {
+            fresh_ttl: Duration::from_secs(fresh_secs),
+            empty_ttl: Duration::from_secs(empty_secs),
+            timeout: Duration::from_secs(timeout_secs),
+        }
+    }
+}
+
+/// 一次取数的结果。`samples` 为空不算错误——多数来源在没有凭据时就是空。
+pub struct QuotaOutcome {
+    pub samples: Vec<QuotaSample>,
+    /// 失败原因；只有声明要留档的 provider 会被上层记下来。
+    pub failure: Option<String>,
+}
+
+/// 取数前从账本读出的开关快照。provider 不直接碰数据库——落库与设置读写
+/// 都留在这一层，provider 只负责"从外部拿到窗口"。
+pub struct ProviderEnv {
+    settings: HashMap<String, String>,
+}
+
+impl ProviderEnv {
+    pub fn load(connection: &Connection) -> Result<Self> {
+        let mut statement = connection
+            .prepare("SELECT key, value FROM app_setting")
+            .context("failed to prepare app_setting query")?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .context("failed to read app_setting")?;
+        let mut settings = HashMap::new();
+        for row in rows {
+            let (key, value) = row.context("failed to read an app_setting row")?;
+            settings.insert(key, value);
+        }
+        Ok(Self { settings })
+    }
+
+    fn flag(&self, key: &str) -> bool {
+        self.settings.get(key).map(String::as_str) == Some("1")
+    }
+}
+
+pub trait QuotaProvider: Send + Sync {
+    /// 写入 `quota_snapshot` 用的 adapter_id。
+    fn adapter_id(&self) -> &'static str;
+
+    fn policy(&self) -> QuotaPolicy;
+
+    /// 主来源的前置条件（开关、凭据、可执行文件）。false 时不发起拉取，
+    /// 直接走 `fallback`。
+    fn is_available(&self, _env: &ProviderEnv) -> bool {
+        true
+    }
+
+    fn fetch(&self, timeout: Duration) -> Result<Vec<QuotaSample>>;
+
+    /// 主来源拿不到时的本地兜底（目前只有 Claude 的 statusLine 钩子文件）。
+    /// 读本地文件，成本可忽略，故不进缓存。
+    fn fallback(&self) -> Vec<QuotaSample> {
+        Vec::new()
+    }
+
+    /// 失败原因是否留档给用户看。默认不留：多数来源在没配凭据时失败是常态，
+    /// 留档只会制造噪声。Claude 直连是例外——它是用户显式开启的，失败必须
+    /// 有交代。
+    fn record_failure(&self, _connection: &Connection, _message: &str) -> Result<()> {
+        Ok(())
+    }
+
+    fn clear_failure(&self, _connection: &Connection) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// adapter 每次快照都重建，故缓存不能放 provider 里，必须由调用方跨快照持有。
+pub type QuotaCache = Mutex<HashMap<&'static str, (Instant, Vec<QuotaSample>)>>;
+
+pub fn registry() -> Vec<Box<dyn QuotaProvider>> {
+    let mut providers: Vec<Box<dyn QuotaProvider>> =
+        vec![Box::new(CodexQuota), Box::new(ClaudeQuota)];
+    for (adapter_id, fetch) in [
+        (
+            "zcode",
+            coding_quota::fetch_zcode_quota as fn(Duration) -> Result<Vec<QuotaSample>>,
+        ),
+        ("kimi", coding_quota::fetch_kimi_quota),
+        ("kimiwork", coding_quota::fetch_kimiwork_quota),
+        ("qoder", coding_quota::fetch_qoder_quota),
+        ("workbuddy", coding_quota::fetch_workbuddy_quota),
+    ] {
+        providers.push(Box::new(HttpQuota { adapter_id, fetch }));
+    }
+    providers
+}
+
+/// 取数并落库。engine 只调这一个。
+pub fn refresh_all(connection: &Connection, cache: &QuotaCache, force: bool) -> Result<()> {
+    let env = ProviderEnv::load(connection)?;
+    for provider in registry() {
+        let provider = provider.as_ref();
+        let mut samples = Vec::new();
+        if provider.is_available(&env) {
+            let outcome = cached_fetch(cache, provider, force);
+            match &outcome.failure {
+                Some(message) => provider.record_failure(connection, message)?,
+                // 缓存命中失败时返回的是"空且无错误"：既不留档也不清除，
+                // 上一条记录继续有效。
+                None if !outcome.samples.is_empty() => provider.clear_failure(connection)?,
+                None => {}
+            }
+            samples = outcome.samples;
+        }
+        if samples.is_empty() {
+            samples = provider.fallback();
+        }
+        if samples.is_empty() {
+            continue;
+        }
+        connection
+            .execute(
+                "DELETE FROM quota_snapshot WHERE adapter_id = ?1",
+                [provider.adapter_id()],
+            )
+            .with_context(|| format!("failed to clear {} quota rows", provider.adapter_id()))?;
+        for sample in &samples {
+            storage::upsert_quota(connection, sample)?;
+        }
+    }
+    Ok(())
+}
+
+/// 按 provider 的节奏取数并跨快照缓存。`force`（手动刷新）跳过新鲜缓存立即
+/// 重拉；失败路径与常规一致——写入空哨兵、保留库中旧行，绝不因强制刷新而删数据。
+fn cached_fetch(cache: &QuotaCache, provider: &dyn QuotaProvider, force: bool) -> QuotaOutcome {
+    let policy = provider.policy();
+    let Ok(mut guard) = cache.lock() else {
+        // 锁中毒只可能来自别处的 panic，此时当作"这次没数据"：保留库中旧行，
+        // 也不拿一句内部错误去污染用户能看到的失败记录。
+        return QuotaOutcome {
+            samples: Vec::new(),
+            failure: None,
+        };
+    };
+    if !force {
+        if let Some((captured, cached)) = guard.get(provider.adapter_id()) {
+            let ttl = if cached.is_empty() {
+                policy.empty_ttl
+            } else {
+                policy.fresh_ttl
+            };
+            if captured.elapsed() < ttl {
+                return QuotaOutcome {
+                    samples: cached.clone(),
+                    failure: None,
+                };
+            }
+        }
+    }
+    match provider.fetch(policy.timeout) {
+        Ok(samples) => {
+            guard.insert(provider.adapter_id(), (Instant::now(), samples.clone()));
+            QuotaOutcome {
+                samples,
+                failure: None,
+            }
+        }
+        Err(error) => {
+            // 来源不可用时不该让每次周期性刷新都付一次完整超时，空哨兵用更长的 TTL。
+            guard.insert(provider.adapter_id(), (Instant::now(), Vec::new()));
+            QuotaOutcome {
+                samples: Vec::new(),
+                failure: Some(error.to_string()),
+            }
+        }
+    }
+}
+
+/// Codex：本机 ChatGPT / Codex app-server 是权威来源。它是本地进程，
+/// 比走网络的几家更快也更值得频繁重试，故 TTL 与超时都更短。
+struct CodexQuota;
+
+impl QuotaProvider for CodexQuota {
+    fn adapter_id(&self) -> &'static str {
+        "codex"
+    }
+
+    fn policy(&self) -> QuotaPolicy {
+        QuotaPolicy::new(60, 240, 4)
+    }
+
+    fn fetch(&self, timeout: Duration) -> Result<Vec<QuotaSample>> {
+        app_server::read_codex_quota(timeout)
+    }
+}
+
+/// Claude：用户显式开启 OAuth 直连时优先（账户级合并额度，含网页版消耗，
+/// 不依赖终端状态栏）；未开启或拉取失败时回落到 statusLine 钩子文件。
+struct ClaudeQuota;
+
+impl QuotaProvider for ClaudeQuota {
+    fn adapter_id(&self) -> &'static str {
+        "claude"
+    }
+
+    fn policy(&self) -> QuotaPolicy {
+        QuotaPolicy::new(120, 300, 6)
+    }
+
+    fn is_available(&self, env: &ProviderEnv) -> bool {
+        env.flag(claude_oauth::SETTING_KEY)
+    }
+
+    fn fetch(&self, timeout: Duration) -> Result<Vec<QuotaSample>> {
+        ClaudeOauth::detected().fetch_quota_samples(timeout)
+    }
+
+    fn fallback(&self) -> Vec<QuotaSample> {
+        ClaudeHook::detected().quota_samples()
+    }
+
+    fn record_failure(&self, connection: &Connection, message: &str) -> Result<()> {
+        claude_oauth::record_failure(connection, message)
+    }
+
+    fn clear_failure(&self, connection: &Connection) -> Result<()> {
+        claude_oauth::clear_failure(connection)
+    }
+}
+
+/// 走网络的官方配额（GLM / Kimi / Qoder / WorkBuddy）：一次实时 GET，
+/// 凭据由各自的 fetch 自行从本机配置读取，没有凭据时返回错误而不是零值。
+struct HttpQuota {
+    adapter_id: &'static str,
+    fetch: fn(Duration) -> Result<Vec<QuotaSample>>,
+}
+
+impl QuotaProvider for HttpQuota {
+    fn adapter_id(&self) -> &'static str {
+        self.adapter_id
+    }
+
+    fn policy(&self) -> QuotaPolicy {
+        QuotaPolicy::new(120, 300, 6)
+    }
+
+    fn fetch(&self, timeout: Duration) -> Result<Vec<QuotaSample>> {
+        (self.fetch)(timeout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn memory_ledger() -> Connection {
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(include_str!("../migrations/001_init.sql"))
+            .unwrap();
+        connection
+    }
+
+    #[test]
+    fn registry_covers_every_quota_adapter_exactly_once() {
+        let mut ids: Vec<&str> = registry()
+            .iter()
+            .map(|provider| provider.adapter_id())
+            .collect();
+        let before = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), before, "两个 provider 写了同一个 adapter_id");
+        assert_eq!(
+            ids,
+            vec![
+                "claude",
+                "codex",
+                "kimi",
+                "kimiwork",
+                "qoder",
+                "workbuddy",
+                "zcode"
+            ]
+        );
+    }
+
+    #[test]
+    fn env_reads_the_opt_in_flag_as_written() {
+        let connection = memory_ledger();
+        let env = ProviderEnv::load(&connection).unwrap();
+        assert!(!env.flag(claude_oauth::SETTING_KEY));
+
+        storage::set_app_setting(&connection, claude_oauth::SETTING_KEY, "1").unwrap();
+        assert!(ProviderEnv::load(&connection)
+            .unwrap()
+            .flag(claude_oauth::SETTING_KEY));
+
+        // 关闭写的是 "0"，不是删除键——不能把它也当成开启。
+        storage::set_app_setting(&connection, claude_oauth::SETTING_KEY, "0").unwrap();
+        assert!(!ProviderEnv::load(&connection)
+            .unwrap()
+            .flag(claude_oauth::SETTING_KEY));
+    }
+
+    /// Claude 直连是用户显式开启的来源，未开启时不该发起拉取——否则会把
+    /// 一条"没有凭据"的失败记录摆到用户面前。
+    #[test]
+    fn claude_primary_waits_for_the_opt_in_flag() {
+        let connection = memory_ledger();
+        let env = ProviderEnv::load(&connection).unwrap();
+        assert!(!ClaudeQuota.is_available(&env));
+
+        storage::set_app_setting(&connection, claude_oauth::SETTING_KEY, "1").unwrap();
+        let env = ProviderEnv::load(&connection).unwrap();
+        assert!(ClaudeQuota.is_available(&env));
+
+        // 其余来源没有开关，永远可用。
+        assert!(CodexQuota.is_available(&env));
+    }
+
+    #[test]
+    fn a_fresh_cache_entry_short_circuits_the_fetch() {
+        struct Counting {
+            calls: std::sync::atomic::AtomicUsize,
+        }
+        impl QuotaProvider for Counting {
+            fn adapter_id(&self) -> &'static str {
+                "codex"
+            }
+            fn policy(&self) -> QuotaPolicy {
+                QuotaPolicy::new(60, 240, 4)
+            }
+            fn fetch(&self, _timeout: Duration) -> Result<Vec<QuotaSample>> {
+                self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err(anyhow::anyhow!("来源不可用"))
+            }
+        }
+
+        let provider = Counting {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let cache: QuotaCache = Mutex::new(HashMap::new());
+
+        // 第一次真的去拉，失败原因如实带回。
+        let first = cached_fetch(&cache, &provider, false);
+        assert!(first.samples.is_empty());
+        assert_eq!(first.failure.as_deref(), Some("来源不可用"));
+
+        // 空哨兵在 TTL 内挡住重拉，且不再报错——上一条记录继续有效。
+        let second = cached_fetch(&cache, &provider, false);
+        assert!(second.failure.is_none());
+        assert_eq!(provider.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        // force 跳过缓存，立即重试。
+        let third = cached_fetch(&cache, &provider, true);
+        assert_eq!(third.failure.as_deref(), Some("来源不可用"));
+        assert_eq!(provider.calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2444,50 +2444,62 @@ function AppearanceCard({ theme, onThemeChange, glassAlpha, onGlassAlpha, glassT
   );
 }
 
-function AgentListColumn({ title, hint, agents, onToggle, onMove }) {
+function AgentListColumn({ title, hint, agents, detected, onToggle, onMove }) {
   // 已选的按显示顺序排前面，未选的按默认顺序垫后。
   const rows = agentIdsInDisplayOrder(agents);
+  // 勾选过的一律留在上面：检测只用于分组，不能把用户自己选的挪进折叠区。
+  // detected 为 null 表示这次拿不到检测结果（加载中、演示数据、旧后端），
+  // 此时不折叠——宁可多列几行，也不能因为不知道就把 Agent 藏起来。
+  const present = detected
+    ? rows.filter((agentId) => agents.includes(agentId) || detected.has(agentId))
+    : rows;
+  const missing = detected ? rows.filter((agentId) => !present.includes(agentId)) : [];
+  const row = (agentId) => {
+    const index = agents.indexOf(agentId);
+    const checked = index >= 0;
+    return (
+      <li key={agentId}>
+        <label>
+          <input
+            type="checkbox"
+            checked={checked}
+            disabled={checked && agents.length === 1}
+            onChange={() => onToggle(agentId)}
+          />
+          <AgentMark agentId={agentId} />
+          <span>{AGENT_META[agentId].label}</span>
+        </label>
+        {checked && (
+          <button
+            type="button"
+            className="settings-agent-move"
+            onClick={() => onMove(agentId)}
+            disabled={index === 0}
+            aria-label={`将 ${AGENT_META[agentId].label} 上移`}
+            title="上移"
+          >
+            ↑
+          </button>
+        )}
+      </li>
+    );
+  };
   return (
     <div className="settings-agent-column">
       <h3>{title}</h3>
       <p className="settings-muted">{hint}</p>
-      <ul className="settings-agent-toggle">
-        {rows.map((agentId) => {
-          const index = agents.indexOf(agentId);
-          const checked = index >= 0;
-          return (
-            <li key={agentId}>
-              <label>
-                <input
-                  type="checkbox"
-                  checked={checked}
-                  disabled={checked && agents.length === 1}
-                  onChange={() => onToggle(agentId)}
-                />
-                <AgentMark agentId={agentId} />
-                <span>{AGENT_META[agentId].label}</span>
-              </label>
-              {checked && (
-                <button
-                  type="button"
-                  className="settings-agent-move"
-                  onClick={() => onMove(agentId)}
-                  disabled={index === 0}
-                  aria-label={`将 ${AGENT_META[agentId].label} 上移`}
-                  title="上移"
-                >
-                  ↑
-                </button>
-              )}
-            </li>
-          );
-        })}
-      </ul>
+      <ul className="settings-agent-toggle">{present.map(row)}</ul>
+      {missing.length > 0 && (
+        <details className="settings-agent-missing">
+          <summary>本机未检测到（{missing.length}）</summary>
+          <ul className="settings-agent-toggle">{missing.map(row)}</ul>
+        </details>
+      )}
     </div>
   );
 }
 
-function AgentsDisplayCard({ widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent }) {
+function AgentsDisplayCard({ widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, detectedAgents }) {
   return (
     <div className="settings-card">
       <h2>显示的 Agent</h2>
@@ -2499,6 +2511,7 @@ function AgentsDisplayCard({ widgetAgents, onToggleWidgetAgent, onMoveWidgetAgen
           title={IS_MAC ? "菜单栏、小组件与侧栏" : "小组件与侧栏"}
           hint="完整视图侧栏还会自动补上本周期有用量的 Agent。"
           agents={widgetAgents}
+          detected={detectedAgents}
           onToggle={onToggleWidgetAgent}
           onMove={onMoveWidgetAgent}
         />
@@ -2507,6 +2520,7 @@ function AgentsDisplayCard({ widgetAgents, onToggleWidgetAgent, onMoveWidgetAgen
             title="胶囊条"
             hint={'无配额来源的以 "--" 占格。'}
             agents={stripAgents}
+            detected={detectedAgents}
             onToggle={onToggleStripAgent}
             onMove={onMoveStripAgent}
           />
@@ -2660,7 +2674,7 @@ const SETTINGS_TABS = [
   },
 ];
 
-function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, glassAlpha, onGlassAlpha, glassTint, onGlassTint, glassInk, onGlassInk, uiScale, onUiScale, stripScale, onStripScale, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
+function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, detectedAgents, glassAlpha, onGlassAlpha, glassTint, onGlassTint, glassInk, onGlassInk, uiScale, onUiScale, stripScale, onStripScale, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
   const [settings, setSettings] = useState(null);
   const [directoryInput, setDirectoryInput] = useState("");
   const [busy, setBusy] = useState(false);
@@ -2773,6 +2787,7 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
             stripAgents={stripAgents}
             onToggleStripAgent={onToggleStripAgent}
             onMoveStripAgent={onMoveStripAgent}
+            detectedAgents={detectedAgents}
           />
         )}
 
@@ -4590,6 +4605,16 @@ export function App() {
     return snapshot.agents.find((agent) => agent.id === selectedAgent)?.tokens || 0;
   }, [selectedAgent, snapshot]);
 
+  // 本机装了哪些 Agent，供设置里的分组用。拿不到检测结果时返回 null，
+  // 由列表决定不折叠——加载中、演示数据、旧后端都属于"不知道"，
+  // 而不知道时把 Agent 收进折叠区会让用户以为我们不支持它。
+  const detectedAgents = useMemo(() => {
+    if (snapshot.pending || snapshot.loadError) return null;
+    const known = snapshot.agents.filter((agent) => typeof agent.detected === "boolean");
+    if (!known.length) return null;
+    return new Set(known.filter((agent) => agent.detected).map((agent) => agent.id));
+  }, [snapshot]);
+
   // 配额卡只在小组件已勾选展示的 Agent 里轮换（用户明确不想看的不进循环）；
   // 勾选了但配额来源未启用的也保留——"官方配额不可用/设置中开启钩子"的
   // 提示本身是有效信息。widgetAgents 由设置保证非空。
@@ -5080,6 +5105,7 @@ export function App() {
             stripAgents={stripAgents}
             onToggleStripAgent={handleToggleStripAgent}
             onMoveStripAgent={handleMoveStripAgent}
+            detectedAgents={detectedAgents}
             glassAlpha={glassAlpha}
             onGlassAlpha={handleGlassAlpha}
             glassTint={glassTint}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3110,6 +3110,23 @@ html:has(.strip-shell--glass-ink-light) #root {
   line-height: 1.7;
 }
 
+/* 本机没检测到的 Agent：默认收起，但一定可展开手动勾选——检测会误判，
+   不能因此让某个 Agent 变得不可达。 */
+.settings-agent-missing {
+  margin-top: 12px;
+}
+
+.settings-agent-missing summary {
+  color: #55575b;
+  cursor: pointer;
+  font-size: 12.5px;
+  user-select: none;
+}
+
+.settings-agent-missing > ul {
+  margin-top: 10px;
+}
+
 .settings-card {
   padding: 22px 24px;
   background: rgba(251, 251, 250, 0.85);
@@ -4745,6 +4762,7 @@ html:has(.strip-shell--glass-ink-light) #root {
 :root[data-theme="dark"] .settings-about a:hover { color: var(--d-muted); }
 :root[data-theme="dark"] .settings-guide { color: var(--d-muted); }
 :root[data-theme="dark"] .settings-guide summary { color: #7fabef; }
+:root[data-theme="dark"] .settings-agent-missing summary { color: var(--d-muted); }
 :root[data-theme="dark"] .settings-device-list li {
   background: var(--d-raised);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);


### PR DESCRIPTION
三个提交，建议按顺序审。前两步是我们商量的「先重构、再检测、最后接厂商」里的第 1、2 步；**第 3 步（接 Cursor / Copilot）没做**，等这两步过了再说。

**不要合并发版**——第一个提交里有一处 macOS 行为在开发机上验不了，见下。

---

## 1. `fix(quota)`：Claude 凭据在新版 macOS 钥匙串里也找得到

上一轮定的三件事。第一条是真 bug：

- **macOS 钥匙串双名查找。** Claude Code v2.1.52 起把凭据存进带哈希后缀的 service 名（`Claude Code-credentials-<hash>`），旧名仍在用。此前只试旧名，**装了较新 Claude Code 的 Mac 用户明明登录过，设置页却显示「本机未找到 Claude Code 登录凭据」**。现在先试旧名，未命中再从 `security dump-keychain` 的条目里找——该命令不带 `-d` 只列元数据、不读密码本体，不会弹密码框。
- **401 后自动刷新重试一次。** 调官方 CLI `claude auth status --json`（本机 2.1.221 实测确认该命令与 `--json` 均存在）让 Claude Code 自己刷新，再重读凭据重试。刷新与落盘全由官方客户端完成，本模块不解析它的输出、不写回任何凭据。子进程有 12 秒上限并连同其一起结束——快照构建持有扫描锁，吊死的 CLI 会把整次刷新拖住。
- **解析凭据里的 `expiresAt`。** 已过期就先刷新，省掉一次注定 401 的请求。秒/毫秒按量级判断；字段缺失不判死，交给服务端裁决。

> ⚠️ **需要在 macOS 上实机核实。** 开发机是 Windows，`"svce"<blob>="..."` 的输出格式照 `security` 的通用格式写，解析有测试兜底，但格式假设本身没验过。401 重试路径也未真实触发过（需要一个过期 token）。验法：Mac 上开直连，看设置页是否显示「已开启 · 凭据可用」。

## 2. `refactor(quota)`：抽出 QuotaProvider 注册表

此前每家厂商都在 `build_snapshot` 里单独硬接，三段形状相同的代码各写一遍，还各带一个缓存函数与一个缓存字段。**加一家厂商的成本因此不是「写一个模块」，而是「再改一次 engine 的取数流程」**——这才是覆盖面上不去的结构性原因。

- `QuotaProvider` trait：`adapter_id` / `policy`（缓存节奏与超时）/ `is_available`（开关、凭据前置条件）/ `fetch` / `fallback` / 失败留档。加一家 = 一个实现 + `registry()` 里一行。
- 三个缓存函数并成一个 `cached_fetch`，三个缓存字段并成一个按 `adapter_id` 分桶的 map。各家节奏不同（Codex 是本地进程，60/240s、超时 4s；走网络的 120/300s、超时 6s），故随 provider 声明而非写死。
- `ProviderEnv` 一次读出开关快照，provider 不直接碰数据库。

**行为逐条对齐，无变化**：注册表顺序与原取数顺序一致；落库仍是「拿到窗口才整体替换该 adapter 的行，拿不到就保留旧行」；Claude 的开关判断、失败留档、缓存命中失败时既不留档也不清除、以及回落钩子的时机都照搬；TTL 与超时数值未动。

## 3. `feat(settings)`：按本机检测结果给 Agent 列表分组

声明式探针表，一个 Agent 一行，三种形态对应三类来源：目录存在、已配置的凭据（Qoder 只有账户级 Credits，没有本地日志）、以及如实标注的「无可靠探针」（Antigravity 只在 IDE 运行时才有 language server 端点，扫进程试端口太贵）。无探针的靠「本周期有用量」兜底。

路径取自各 adapter 的 `discover()`，不另猜一套；`probe_paths_match_adapter_roots` 会在两处偏离时失败，包括受 `XDG_DATA_HOME` / `KIMI_CODE_HOME` 覆盖的两个。

**检测只用于排序分组，从不用于过滤。** 探针会误判，若误判能把一个 Agent 从列表里抹掉，用户就再也勾不上它了。所以未检测到的收进可展开的一栏而不是隐藏；已勾选的一律留在上面；拿不到检测结果时（加载中、演示数据、旧后端）完全不折叠。

本机核对：

| Agent | 探针 | 与实际 |
| --- | --- | --- |
| Codex / Claude / GLM | 检测到 | ✓ 有用量 |
| Kimi | 检测到（`.kimi-code`） | ✓ 装了但本周期没用量——只看用量会漏掉的那类 |
| WorkBuddy | 检测到（`.workbuddy`） | ✓ 与 `D:\WorkBuddy` 一致 |
| OpenCode / Qoder | 未检测到 | ✓ |

## 验证

- `cargo fmt --check` 干净、`cargo clippy --all-targets -- -D warnings` 零告警
- `cargo test` 184 项通过（新增 7 项：quota 4、detect 3），原有测试一个没改
- `npm test` 34 项、`npm run build` 通过
- 探针表按本机真实目录逐条核对（见上表）

未做：接 Cursor / Copilot（第 3 步）。参考实现的许可证已核对——CodexBar 与 token-monitor 是 MIT、token-remain 是 Apache-2.0，均可借鉴；ai-token-monitor **无许可证**，只取事实不取代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
