### PR TITLE
Release v0.14.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.5",
+      "version": "0.14.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.5"
+version = "0.14.6"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：五个版本文件从 `0.14.5` 升到 `0.14.6`，不含任何产品代码。

产品改动已由 #96 合入并在 `main` 上通过双平台 CI。

## v0.14.6 内容

- 修复 macOS 上找不到 Claude 登录凭据：Claude Code v2.1.52 起改用带哈希后缀的钥匙串 service 名，此前只试旧名。改动是严格增量的——旧名命中即走原路径，只在旧名落空时多试一次。
- 401 后请官方 CLI 刷新一次再重试，刷新与落盘全由 Claude Code 完成。
- 设置里的「显示的 Agent」按本机检测结果分组。检测只用于排序分组，不用于过滤。
- 内部：各家官方额度改为统一的 `QuotaProvider` 注册表，行为逐条对齐无变化。

> macOS 钥匙串的真机行为尚未核实（开发机为 Windows）。因改动严格增量、无回归路径，先发布后在 macOS 上验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
