### PR TITLE
feat(usage): 口径自检——分量对不上来源自报总量就标出来

### DIFF
--- a/src-tauri/src/adapters/codex.rs
+++ b/src-tauri/src/adapters/codex.rs
@@ -56,6 +56,11 @@ struct RawTokenUsage {
     output_tokens: i64,
     #[serde(default)]
     reasoning_output_tokens: i64,
+    /// Codex 自报的总量，用作口径自检的判据（见
+    /// `TokenVector::disagrees_with_reported_total`）。本机 60011 条读数
+    /// 恒等于 input + output——reasoning 与缓存读都已含在里面，不另加。
+    #[serde(default)]
+    total_tokens: i64,
 }
 
 #[derive(Deserialize, Default)]
@@ -191,6 +196,10 @@ impl AgentAdapter for CodexAdapter {
                             output: total.output_tokens.max(0),
                             reasoning_output: total.reasoning_output_tokens.max(0),
                         };
+                        // 口径自检对累计快照做，不对增量做：来源报的也是累计值。
+                        if current.disagrees_with_reported_total(total.total_tokens) {
+                            diagnostics.total_mismatches += 1;
+                        }
                         let delta = current.positive_delta(previous.as_ref());
                         // Replayed counters still advance the baseline so the first
                         // live delta only counts the fork's own increment.
@@ -333,6 +342,56 @@ mod tests {
         assert_eq!(deltas, vec![100, 40, 50]);
         assert_eq!(deltas.iter().sum::<i64>(), 190);
         std::fs::remove_file(temp).ok();
+    }
+
+    /// 口径自检：来源自报总量与我们拆出的分量一致时不该报警，不一致时必须
+    /// 记下来并把该来源标为数据不完整。不一致意味着我们对字段语义的理解错了
+    /// （reasoning 是否含在 output、缓存是否含在输入……），这类错不会崩溃、
+    /// 只会显示一个看着合理的错数字。
+    #[test]
+    fn a_reported_total_that_contradicts_our_components_is_flagged() {
+        let write_log = |name: &str, line: &str| {
+            let temp = std::env::temp_dir()
+                .join(format!("metrik-codex-{name}-{}.jsonl", std::process::id()));
+            let mut file = File::create(&temp).unwrap();
+            writeln!(
+                file,
+                r#"{{"type":"session_meta","payload":{{"id":"session-a"}}}}"#
+            )
+            .unwrap();
+            writeln!(file, "{line}").unwrap();
+            drop(file);
+            let metadata = temp.metadata().unwrap();
+            let candidate = SourceCandidate {
+                source_id: "source".into(),
+                path: temp.clone(),
+                size: metadata.len(),
+                mtime_ns: 1,
+            };
+            let parsed = CodexAdapter::with_roots(vec![])
+                .parse(&candidate, i64::MIN)
+                .unwrap();
+            std::fs::remove_file(temp).ok();
+            parsed
+        };
+
+        // 真机口径：total = input + output，reasoning 与缓存读都已含在里面。
+        let agreeing = write_log(
+            "agree",
+            r#"{"timestamp":"2026-07-12T01:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":30,"output_tokens":20,"reasoning_output_tokens":8,"total_tokens":120}}}}"#,
+        );
+        assert_eq!(agreeing.diagnostics.total_mismatches, 0);
+        assert!(!agreeing.diagnostics.is_partial());
+        assert_eq!(agreeing.source.events[0].tokens.processed(), 120);
+
+        // 假设来源某天改成"reasoning 另计"：total 变 128 而我们仍按 120 拆。
+        // 数字看着依旧合理，只有和自报总量一比才露馅。
+        let disagreeing = write_log(
+            "disagree",
+            r#"{"timestamp":"2026-07-12T01:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":30,"output_tokens":20,"reasoning_output_tokens":8,"total_tokens":128}}}}"#,
+        );
+        assert_eq!(disagreeing.diagnostics.total_mismatches, 1);
+        assert!(disagreeing.diagnostics.is_partial());
     }
 
     #[test]

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -32,24 +32,34 @@ pub struct SourceCandidate {
 
 const SCAN_DIAGNOSTICS_PREFIX_V1: &str = "jsonl-scan-v1";
 const SCAN_DIAGNOSTICS_PREFIX_V2: &str = "jsonl-scan-v2";
+const SCAN_DIAGNOSTICS_PREFIX_V3: &str = "jsonl-scan-v3";
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ScanDiagnostics {
     pub malformed_lines: usize,
     pub unreadable_lines: usize,
     pub rejected_events: usize,
+    /// 口径自检失败的读数条数：我们算出的分量和来源自己报的总量对不上。
+    /// 见 `TokenVector::disagrees_with_reported_total`。
+    pub total_mismatches: usize,
 }
 
 impl ScanDiagnostics {
     pub fn is_partial(&self) -> bool {
-        self.malformed_lines > 0 || self.unreadable_lines > 0 || self.rejected_events > 0
+        self.malformed_lines > 0
+            || self.unreadable_lines > 0
+            || self.rejected_events > 0
+            || self.total_mismatches > 0
     }
 
     pub fn storage_marker(&self) -> Option<String> {
         self.is_partial().then(|| {
             format!(
-                "{SCAN_DIAGNOSTICS_PREFIX_V2}:{}:{}:{}",
-                self.malformed_lines, self.unreadable_lines, self.rejected_events
+                "{SCAN_DIAGNOSTICS_PREFIX_V3}:{}:{}:{}:{}",
+                self.malformed_lines,
+                self.unreadable_lines,
+                self.rejected_events,
+                self.total_mismatches
             )
         })
     }
@@ -59,9 +69,13 @@ impl ScanDiagnostics {
         let version = parts.next()?;
         let malformed_lines = parts.next()?.parse().ok()?;
         let unreadable_lines = parts.next()?.parse().ok()?;
-        let rejected_events = match version {
-            SCAN_DIAGNOSTICS_PREFIX_V1 => 0,
-            SCAN_DIAGNOSTICS_PREFIX_V2 => parts.next()?.parse().ok()?,
+        // 旧标记继续认：升级后不该因为标记格式变了就把既有来源判成"读过但未知"。
+        let (rejected_events, total_mismatches) = match version {
+            SCAN_DIAGNOSTICS_PREFIX_V1 => (0, 0),
+            SCAN_DIAGNOSTICS_PREFIX_V2 => (parts.next()?.parse().ok()?, 0),
+            SCAN_DIAGNOSTICS_PREFIX_V3 => {
+                (parts.next()?.parse().ok()?, parts.next()?.parse().ok()?)
+            }
             _ => return None,
         };
         parts.next().is_none().then_some(())?;
@@ -69,6 +83,7 @@ impl ScanDiagnostics {
             malformed_lines,
             unreadable_lines,
             rejected_events,
+            total_mismatches,
         })
     }
 }
@@ -174,6 +189,7 @@ mod tests {
             malformed_lines: 2,
             unreadable_lines: 1,
             rejected_events: 3,
+            total_mismatches: 4,
         };
         let marker = diagnostics.storage_marker().unwrap();
 
@@ -185,15 +201,49 @@ mod tests {
         assert_eq!(ScanDiagnostics::from_storage_marker("unrelated"), None);
     }
 
+    /// 升级不能让既有来源的诊断读不出来：旧标记一律仍要认，缺的字段补 0。
     #[test]
-    fn legacy_scan_diagnostics_marker_remains_readable() {
+    fn legacy_scan_diagnostics_markers_remain_readable() {
         assert_eq!(
             ScanDiagnostics::from_storage_marker("jsonl-scan-v1:2:1"),
             Some(ScanDiagnostics {
                 malformed_lines: 2,
                 unreadable_lines: 1,
                 rejected_events: 0,
+                total_mismatches: 0,
             })
+        );
+        assert_eq!(
+            ScanDiagnostics::from_storage_marker("jsonl-scan-v2:2:1:3"),
+            Some(ScanDiagnostics {
+                malformed_lines: 2,
+                unreadable_lines: 1,
+                rejected_events: 3,
+                total_mismatches: 0,
+            })
+        );
+        // 位数对不上的标记宁可不认，也不猜。
+        assert_eq!(
+            ScanDiagnostics::from_storage_marker("jsonl-scan-v2:2:1"),
+            None
+        );
+        assert_eq!(
+            ScanDiagnostics::from_storage_marker("jsonl-scan-v3:2:1:3"),
+            None
+        );
+    }
+
+    /// 口径自检独立于"行读坏了"：只有它非零也必须把来源标成数据不完整。
+    #[test]
+    fn a_total_mismatch_alone_marks_the_source_partial() {
+        let diagnostics = ScanDiagnostics {
+            total_mismatches: 1,
+            ..Default::default()
+        };
+        assert!(diagnostics.is_partial());
+        assert_eq!(
+            ScanDiagnostics::from_storage_marker(&diagnostics.storage_marker().unwrap()),
+            Some(diagnostics)
         );
     }
 }

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -32,6 +32,22 @@ impl TokenVector {
         self.input_uncached + self.cache_read + self.cache_write + self.output
     }
 
+    /// 口径自检：把我们拆出来的分量和来源**自己报的总量**比一次。
+    ///
+    /// 读日志算 token 最危险的错法不是崩溃，而是把字段语义理解反了——
+    /// reasoning 是否已含在 output 里、缓存读是否已含在输入里、拿到的是累计
+    /// 还是增量、百分比是已用还是剩余。这类错**不会报错，只会显示一个看着
+    /// 合理的错数字**，用户无从察觉。（真事：广泛使用的 tokscale 假设
+    /// output 不含 reasoning 而分开相加，本机 11 万条 Codex 读数证明它是错的。）
+    ///
+    /// 凡是来源自带总量的，就用它当判据。对不上即记一次诊断，该来源标为
+    /// 「数据不完整」并说明原因——把安静的错变成响亮的错。
+    ///
+    /// `reported_total <= 0` 视为"来源没报"，不参与判定：缺字段不是错。
+    pub fn disagrees_with_reported_total(&self, reported_total: i64) -> bool {
+        reported_total > 0 && self.processed() != reported_total
+    }
+
     pub fn positive_delta(&self, previous: Option<&Self>) -> Self {
         let Some(previous) = previous else {
             return self.clone();

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -56,6 +56,8 @@ struct AdapterDiagnostics {
     malformed_lines: usize,
     unreadable_lines: usize,
     rejected_events: usize,
+    /// 口径自检失败：分量和来源自报总量对不上，说明字段语义可能理解错了。
+    total_mismatches: usize,
 }
 
 #[derive(Clone)]
@@ -838,6 +840,7 @@ fn record_scan_diagnostics(
     aggregate.malformed_lines += diagnostics.malformed_lines;
     aggregate.unreadable_lines += diagnostics.unreadable_lines;
     aggregate.rejected_events += diagnostics.rejected_events;
+    aggregate.total_mismatches += diagnostics.total_mismatches;
 }
 
 fn query_snapshot(
@@ -1510,7 +1513,17 @@ fn coverage_detail(diagnostics: &AdapterDiagnostics, errors: usize) -> String {
         return String::new();
     }
 
-    let skipped = (diagnostics.partial_sources > 0).then(|| {
+    // 口径校验失败与"内容没读到"性质不同：前者说明读到的数字本身可能是错的，
+    // 后者只是少算。两句分开写，不能混成一句"可能不完整"糊过去。
+    let mismatched = (diagnostics.total_mismatches > 0).then(|| {
+        format!(
+            "⚠️ {} 条读数与来源自报的总量对不上，说明本版本对该来源的字段口径可能有误，显示的数字请勿采信，已记录待修正；",
+            diagnostics.total_mismatches
+        )
+    });
+    let skipped_lines =
+        diagnostics.malformed_lines + diagnostics.unreadable_lines + diagnostics.rejected_events;
+    let skipped = (diagnostics.partial_sources > 0 && skipped_lines > 0).then(|| {
         format!(
             "{} 个会话存在未计入的 JSONL 内容（格式异常 {} 行、文本读取失败 {} 行、身份冲突 {} 条）；",
             diagnostics.partial_sources,
@@ -1521,7 +1534,8 @@ fn coverage_detail(diagnostics: &AdapterDiagnostics, errors: usize) -> String {
     });
     let failed = (errors > 0).then(|| format!("另有 {errors} 个会话未能完成更新；"));
     format!(
-        "{}{}本周期总量仅覆盖成功解析的记录，可能不完整。",
+        "{}{}{}本周期总量仅覆盖成功解析的记录，可能不完整。",
+        mismatched.unwrap_or_default(),
         skipped.unwrap_or_default(),
         failed.unwrap_or_default()
     )
@@ -2962,6 +2976,17 @@ mod tests {
             snapshot.agent_quotas[0].windows.first().map(|w| w.view.remaining_percent).unwrap_or(0.0),
             snapshot.agent_quotas[0].windows.first().map(|w| w.view.source_label.clone()).unwrap_or_default()
         );
+        // 口径自检在真机数据上必须零误报，否则每个用户一打开就看到警告。
+        // 本机 60011 条 Codex 读数已验证 total == input + output。
+        for source in &snapshot.sources {
+            println!("  source {:<18} {}", source.id, source.quality_label);
+            assert!(
+                !source.detail.contains("与来源自报的总量对不上"),
+                "口径自检在真机数据上误报：{} / {}",
+                source.id,
+                source.detail
+            );
+        }
         assert!(!snapshot.is_demo);
         assert!((1..=24).contains(&snapshot.series.len()));
         let expected_last_label = format!("{:02}:00", snapshot.series.len() - 1);


### PR DESCRIPTION
批量接入更多 Agent 之前的安全阀。纯后端，无界面改动。

## 为什么

读日志算 token 最危险的错法不是崩溃，而是**把字段语义理解反了**：reasoning 是否已含在 output 里、缓存读是否已含在输入里、拿到的是累计还是增量、百分比是已用还是剩余。这类错不会报错，只会显示一个看着合理的错数字，用户无从察觉。

而我们打算靠竞品的格式知识去接新厂商——竞品能可靠告诉我们「日志在哪、字段叫什么」（事实），但「字段什么语义」它们也会错。

**真事**：广泛使用的 `tokscale`（Javis603/token-monitor 依赖）假设 output 不含 reasoning 而分开相加。本机 654 个 Codex 会话、**112386 条 reasoning > 0 的读数**证明它是错的：

| 判据 | 命中 |
| --- | --- |
| `total == input + output` | **112386** |
| `total == input + output + reasoning` | **0** |

按 tokscale 的口径会虚增约 1%，reasoning 占比越高错得越多。而且凡是依赖 tokscale 的项目会**一起错**，"多家开源实现对比" 在这种共享上游的情况下不构成验证。

## 做了什么

凡是来源自带总量的，就拿它当判据，把安静的错变成响亮的错。

- **`TokenVector::disagrees_with_reported_total`** — 来源没报总量（`<= 0`）时不参与判定，缺字段不算错。
- **`ScanDiagnostics.total_mismatches`** — 独立于「行读坏了」，只有它非零也把来源标为数据不完整。存储标记升到 `v3`，`v1`/`v2` 仍可读、缺的字段补 0（升级不该让既有来源的诊断读不出来）；位数对不上的标记宁可不认也不猜。
- **Codex adapter** 解析 `total_tokens` 并对**累计快照**自检——来源报的也是累计值，对增量做会错。
- **「数据统计」文案单独措辞**：口径失败说明数字本身可能是错的，与「内容没读到」性质不同，不混成一句「可能不完整」糊过去。

## 未做（刻意）

Codex 的 `cache_write_input_tokens` 仍不解析、`cache_write` 恒填 0。本机 60011 条读数里它全是 0，且**无法确认它是含在 `input_tokens` 内还是独立项**——正是本 PR 要防的那类猜测。若它将来变成非零且是独立项，自检会当场抓住（总量对不上）；若是内含项，总量仍对，只有构成拆解略偏，属可接受的次要误差。

## 验证

- **真机零误报**：`live_snapshot_smoke_test` 在本机真实日志上跑通，八个来源全部仍是「精确解析」。该断言已写进测试，以后回归会失败。
- 新增 3 项测试：口径一致/不一致的端到端行为、旧存储标记向后兼容、只有口径失败也算数据不完整。
- `cargo fmt --check` 干净、`cargo clippy --all-targets -- -D warnings` 零告警、`cargo test` 186 项通过。
- `npm test` 34 项、`npm run build` 通过（前端未改）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
