### PR TITLE
feat(usage): 自定义来源——用户指一下目录就能算进统计

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,6 +117,16 @@ The current test suite covers cumulative Codex deltas, fork replay, Claude progr
 
 An adapter is only trustworthy once its field *semantics* are confirmed against real data, not just its field names. Both classes of bug this codebase has hit — Codex fork replay counted as new usage, and a weekly quota window labeled as a five-hour one — came from assuming a plausible meaning for a field that the source defines differently. When a source cannot be observed on a real machine, prefer leaving the agent unimplemented over shipping a parser whose numbers look right.
 
+Reading another project's parser does not substitute for that confirmation. Competitors reliably tell you *where the logs are* and *what the fields are called* — those are facts. They are not reliable about what a field *means*: the widely used `tokscale` assumes `output_tokens` excludes reasoning tokens and adds them separately, which 112,386 readings across 654 local Codex sessions disprove (`total_tokens == input_tokens + output_tokens` in every one, never `+ reasoning`). Projects that share such a dependency are wrong together, so agreement between several of them is not verification.
+
+### Accounting self-check
+
+Where a source reports its own total, `TokenVector::disagrees_with_reported_total` compares it against the components we derived. A mismatch increments `ScanDiagnostics::total_mismatches`, which marks that source incomplete and states in the sources drawer that the displayed numbers may be wrong. This exists because a misread field does not crash — it produces a plausible wrong number that nobody notices. The check converts that silent failure into a visible one, which is what makes it defensible to add adapters based on formats we have not exercised ourselves.
+
+### User-declared sources
+
+Users can point Metrik at a directory of **Claude-compatible JSONL** and have it counted without waiting for a dedicated adapter; those events merge into the `custom` agent slot, and each declared source is listed by name in the sources drawer. The format is fixed on purpose: offering a field-mapping UI would push the very semantic judgement described above onto the user, where getting it wrong is silent. A directory in another format simply parses to no events and reports zero.
+
 ## Runtime boundary
 
 - Compact mode refreshes every five minutes while visible; expanded mode refreshes every minute. While `indexing.pending > 0` the UI polls every 400 ms instead, so each snapshot spends another `PARSE_BUDGET` on the backlog until it is drained. Returning to the window triggers a refresh.

--- a/src-tauri/src/adapters/claude.rs
+++ b/src-tauri/src/adapters/claude.rs
@@ -11,6 +11,10 @@ use std::path::PathBuf;
 
 pub struct ClaudeAdapter {
     roots: Vec<PathBuf>,
+    /// 写进账本的 adapter id。用户声明的自定义来源用的是同一套 Claude 兼容
+    /// JSONL 格式，因此共用这套解析，只换 id——多一份复制粘贴的解析器意味着
+    /// 以后修 bug 要修两遍。
+    adapter_id: &'static str,
 }
 
 #[derive(Clone)]
@@ -63,18 +67,30 @@ impl ClaudeAdapter {
         let home = dirs::home_dir().unwrap_or_default();
         Self {
             roots: vec![home.join(".claude").join("projects")],
+            adapter_id: "claude",
+        }
+    }
+
+    /// 用户在设置里声明的 Claude 兼容 JSONL 目录，合并计入 `custom` 槽位。
+    pub fn for_custom_sources(roots: Vec<PathBuf>) -> Self {
+        Self {
+            roots,
+            adapter_id: "custom",
         }
     }
 
     #[cfg(test)]
     fn with_roots(roots: Vec<PathBuf>) -> Self {
-        Self { roots }
+        Self {
+            roots,
+            adapter_id: "claude",
+        }
     }
 }
 
 impl AgentAdapter for ClaudeAdapter {
     fn id(&self) -> &'static str {
-        "claude"
+        self.adapter_id
     }
 
     fn discover(&self, cutoff_ms: i64) -> Vec<SourceCandidate> {

--- a/src-tauri/src/custom_sources.rs
+++ b/src-tauri/src/custom_sources.rs
@@ -1,0 +1,136 @@
+//! 用户自己声明的用量来源。
+//!
+//! 我们没有逐家适配的 Agent，只要它的会话日志是 **Claude 兼容 JSONL**（这个
+//! 格式的克隆产品很多——我们的 workbuddy adapter 就是一个解析器同时吃
+//! CodeBuddy 与 WorkBuddy），用户在设置里指一下目录就能算进总量，不必等我们
+//! 排期。
+//!
+//! 刻意的边界：
+//! - **只认 Claude 兼容 JSONL 一种格式。** 不做"字段映射"式的通用适配——让用户
+//!   自己填哪个字段是 input、哪个是 output，等于把最容易出错的口径判断推给他，
+//!   而错了不会报错、只会显示一个看着合理的错数字。格式不符就解析不出事件，
+//!   如实显示 0，不猜。
+//! - **合并进一个 `custom` 槽位。** 各来源的名字在「数据统计」里分别列出，
+//!   但图表与占比是合计值。做成动态 Agent 要改动总量、成本、配额、序列全线。
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// app_setting 里的键。
+const SETTING_KEY: &str = "custom_usage_sources";
+
+/// 上限。声明得再多也是用户自己扛扫描开销，但总要有个数防止配置写崩后
+/// 拖垮每次快照。
+const MAX_SOURCES: usize = 16;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomSource {
+    /// 展示名，只用于「数据统计」里区分来源。
+    pub name: String,
+    /// 会话日志所在目录，递归查找其下的 `*.jsonl`。
+    pub path: String,
+}
+
+/// 归一化：去空白、丢掉缺名或缺路径的、按路径去重、截到上限。
+/// 路径用与项目归类同一套归一化（反斜杠转正斜杠、盘符大写、去尾斜杠），
+/// 这样同一个目录写两种形式不会变成两条。
+fn normalized(sources: Vec<CustomSource>) -> Vec<CustomSource> {
+    let mut seen: Vec<String> = Vec::new();
+    let mut out: Vec<CustomSource> = Vec::new();
+    for source in sources {
+        let name = source.name.trim().to_owned();
+        let Some(path) = crate::domain::normalize_project_path(&source.path) else {
+            continue;
+        };
+        if name.is_empty() || seen.contains(&path) {
+            continue;
+        }
+        seen.push(path.clone());
+        out.push(CustomSource { name, path });
+        if out.len() >= MAX_SOURCES {
+            break;
+        }
+    }
+    out
+}
+
+pub fn load(connection: &rusqlite::Connection) -> Result<Vec<CustomSource>> {
+    let Some(raw) = crate::storage::get_app_setting(connection, SETTING_KEY)? else {
+        return Ok(Vec::new());
+    };
+    if raw.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    // 配置损坏时当作没声明，不让用量页因此打不开。
+    Ok(serde_json::from_str::<Vec<CustomSource>>(&raw)
+        .map(normalized)
+        .unwrap_or_default())
+}
+
+pub fn save(
+    connection: &rusqlite::Connection,
+    sources: Vec<CustomSource>,
+) -> Result<Vec<CustomSource>> {
+    let sources = normalized(sources);
+    let raw = serde_json::to_string(&sources).context("failed to serialize custom sources")?;
+    crate::storage::set_app_setting(connection, SETTING_KEY, &raw)?;
+    Ok(sources)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn memory_ledger() -> rusqlite::Connection {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(include_str!("../migrations/001_init.sql"))
+            .unwrap();
+        connection
+    }
+
+    fn source(name: &str, path: &str) -> CustomSource {
+        CustomSource {
+            name: name.into(),
+            path: path.into(),
+        }
+    }
+
+    #[test]
+    fn round_trips_with_normalization_and_dedup() {
+        let connection = memory_ledger();
+        assert!(load(&connection).unwrap().is_empty());
+
+        let saved = save(
+            &connection,
+            vec![
+                source("  SomeBuddy  ", "d:\\logs\\somebuddy\\"),
+                // 同一目录的另一种写法：去重，保留先写的那条。
+                source("重复", "D:/logs/somebuddy"),
+                // 缺名或缺路径的丢掉，不留半条配置。
+                source("", "D:/logs/x"),
+                source("没路径", "   "),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(saved, vec![source("SomeBuddy", "D:/logs/somebuddy")]);
+        assert_eq!(load(&connection).unwrap(), saved);
+    }
+
+    #[test]
+    fn corrupt_configuration_reads_as_no_sources() {
+        let connection = memory_ledger();
+        crate::storage::set_app_setting(&connection, SETTING_KEY, "not json").unwrap();
+        assert!(load(&connection).unwrap().is_empty());
+    }
+
+    #[test]
+    fn the_count_is_capped() {
+        let many: Vec<CustomSource> = (0..40)
+            .map(|index| source(&format!("s{index}"), &format!("D:/logs/{index}")))
+            .collect();
+        assert_eq!(normalized(many).len(), MAX_SOURCES);
+    }
+}

--- a/src-tauri/src/custom_sources_e2e.rs
+++ b/src-tauri/src/custom_sources_e2e.rs
@@ -1,0 +1,131 @@
+//! 自定义来源的端到端验收：声明一个目录 → 扫描 → 事件确实以 `custom` 落账。
+//!
+//! 用真实的 Claude 兼容 JSONL 做样本（本机 `~/.claude/projects` 下就是这个格式），
+//! 验证「用户指一下目录就能算进总量」这条路真的通，而不是只在单测里通。
+
+#[cfg(test)]
+mod tests {
+    use crate::custom_sources::{self, CustomSource};
+    use crate::domain::AGENT_IDS;
+    use std::io::Write;
+
+    /// 一条 Claude 兼容 JSONL 记录：格式与 `~/.claude/projects/**/*.jsonl` 相同。
+    /// 时间取当前之前的若干分钟——写死的时刻换算成本地时间后可能落在"现在"
+    /// 之后，会被周期窗口的上界挡掉。
+    fn message_line(message_id: &str, minutes_ago: i64, input: i64, output: i64) -> String {
+        let timestamp = (chrono::Utc::now() - chrono::Duration::minutes(minutes_ago))
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        format!(
+            r#"{{"type":"assistant","timestamp":"{timestamp}","sessionId":"sess-1","cwd":"D:\\work\\demo","message":{{"id":"{message_id}","model":"some-model-v1","usage":{{"input_tokens":{input},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":{output}}}}}}}"#
+        )
+    }
+
+    #[test]
+    fn a_declared_directory_lands_in_the_custom_slot() {
+        let dir = std::env::temp_dir().join(format!(
+            "metrik-custom-e2e-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("session.jsonl");
+        let mut file = std::fs::File::create(&log).unwrap();
+        writeln!(file, "{}", message_line("msg-a", 120, 100, 20)).unwrap();
+        writeln!(file, "{}", message_line("msg-b", 60, 50, 5)).unwrap();
+        drop(file);
+
+        let database = std::env::temp_dir().join(format!(
+            "metrik-custom-e2e-{}-{}.sqlite3",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+
+        {
+            let connection = crate::storage::open_database(&database).unwrap();
+            custom_sources::save(
+                &connection,
+                vec![CustomSource {
+                    name: "演示来源".into(),
+                    path: dir.to_string_lossy().into_owned(),
+                }],
+            )
+            .unwrap();
+        }
+
+        let quota_cache = std::sync::Mutex::new(std::collections::HashMap::new());
+        let snapshot =
+            crate::engine::build_snapshot(&database, "month", &quota_cache, false).unwrap();
+
+        let custom = snapshot
+            .agents
+            .iter()
+            .find(|agent| agent.id == "custom")
+            .expect("custom 必须是一个可见 Agent");
+        // 两条消息合计 175：(100+20) + (50+5)。
+        assert_eq!(custom.tokens, 175, "自定义来源的用量没有计入 custom 槽位");
+        assert!(custom.detected, "声明了来源就该算检测到");
+
+        // 声明的来源名要在「数据统计」里列出来，否则用户看不到分项。
+        let view = snapshot
+            .sources
+            .iter()
+            .find(|source| source.id == "custom-local")
+            .expect("数据统计里必须有自定义来源这一条");
+        assert!(
+            view.detail.contains("演示来源"),
+            "来源名没有列出：{}",
+            view.detail
+        );
+        assert_eq!(view.quality_label, "精确解析");
+
+        assert!(AGENT_IDS.contains(&"custom"));
+
+        std::fs::remove_file(database).ok();
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// 格式不符的目录不能编数字：解析不出事件就如实是 0，且不该把来源标成出错
+    /// （用户可能只是指错了目录，不是我们读坏了）。
+    #[test]
+    fn a_directory_in_another_format_yields_zero_rather_than_guesses() {
+        let dir = std::env::temp_dir().join(format!(
+            "metrik-custom-e2e-bad-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut file = std::fs::File::create(dir.join("other.jsonl")).unwrap();
+        writeln!(file, r#"{{"totally":"different","tokens":12345}}"#).unwrap();
+        drop(file);
+
+        let database = std::env::temp_dir().join(format!(
+            "metrik-custom-e2e-bad-{}-{}.sqlite3",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        {
+            let connection = crate::storage::open_database(&database).unwrap();
+            custom_sources::save(
+                &connection,
+                vec![CustomSource {
+                    name: "格式不符".into(),
+                    path: dir.to_string_lossy().into_owned(),
+                }],
+            )
+            .unwrap();
+        }
+
+        let quota_cache = std::sync::Mutex::new(std::collections::HashMap::new());
+        let snapshot =
+            crate::engine::build_snapshot(&database, "month", &quota_cache, false).unwrap();
+        let custom = snapshot
+            .agents
+            .iter()
+            .find(|agent| agent.id == "custom")
+            .unwrap();
+        assert_eq!(custom.tokens, 0, "格式不符时绝不能编出数字");
+
+        std::fs::remove_file(database).ok();
+        std::fs::remove_dir_all(dir).ok();
+    }
+}

--- a/src-tauri/src/detect.rs
+++ b/src-tauri/src/detect.rs
@@ -88,6 +88,12 @@ pub fn table() -> Vec<AgentProbe> {
             id: "qoder",
             probe: Probe::Credential(|| coding_quota::qoder_cookie_source().is_some()),
         },
+        AgentProbe {
+            // 自定义来源的"装了"就是"用户声明了"，而规则存在账本里，这里读不到。
+            // 由 engine 在建快照时补判（那里有连接），见 `detected` 的赋值。
+            id: "custom",
+            probe: Probe::Unknown,
+        },
     ]
 }
 

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -7,7 +7,10 @@ use std::path::PathBuf;
 /// qoder 是配额-only：Qoder、QoderWork 与 Qoder CLI 共用同一账户级 Credits
 /// 配额来源。Qoder CLI 的本地遥测 token 字段实测为 0，不能作为用量账本来源。
 /// kimiwork 只保留为内部配额来源，窗口合并到 kimi，不作为独立可见 Agent。
-pub const AGENT_IDS: [&str; 8] = [
+/// custom 是用户在设置里自己声明的 Claude 兼容 JSONL 目录的**合并槽位**：
+/// 我们没接的 Agent，只要日志是这个格式，用户指一下就能算进总量，不必等我们
+/// 逐家适配。多个声明来源合并成这一条，各自的名字在「数据统计」里分别列出。
+pub const AGENT_IDS: [&str; 9] = [
     "codex",
     "claude",
     "zcode",
@@ -16,6 +19,7 @@ pub const AGENT_IDS: [&str; 8] = [
     "antigravity",
     "workbuddy",
     "qoder",
+    "custom",
 ];
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -3,6 +3,7 @@ use crate::adapters::{
     ScanDiagnostics, SourceCandidate, WorkbuddyAdapter, ZcodeAdapter,
 };
 use crate::claude_oauth;
+use crate::custom_sources;
 use crate::detect;
 use crate::domain::ProjectReportRow;
 use crate::domain::{
@@ -714,6 +715,12 @@ fn global_event_bounds(connection: &Connection) -> Result<(Option<i64>, Option<i
 /// 按固定的保留期视界摄取日志。需要解析的源按 mtime 倒序排队，在时间预算内尽量
 /// 解析；没轮到的记进 `report.backfill_pending`，由界面显式标注为「补齐中」。
 fn ingest_sources(connection: &mut Connection, horizon_ms: i64) -> Result<ScanReport> {
+    // 用户声明的目录走同一套 Claude 兼容 JSONL 解析，合并计入 custom 槽位。
+    // 没声明时 roots 为空，discover 直接返回空，等于没有这个 adapter。
+    let custom_roots: Vec<std::path::PathBuf> = custom_sources::load(connection)?
+        .into_iter()
+        .map(|source| std::path::PathBuf::from(source.path))
+        .collect();
     let adapters: Vec<Box<dyn AgentAdapter>> = vec![
         Box::new(CodexAdapter::detected()),
         Box::new(ClaudeAdapter::detected()),
@@ -722,6 +729,7 @@ fn ingest_sources(connection: &mut Connection, horizon_ms: i64) -> Result<ScanRe
         Box::new(KimiAdapter::detected()),
         Box::new(AntigravityAdapter::detected()),
         Box::new(WorkbuddyAdapter::detected()),
+        Box::new(ClaudeAdapter::for_custom_sources(custom_roots)),
     ];
     let mut report = ScanReport::default();
     let mut queue: Vec<(usize, SourceCandidate)> = Vec::new();
@@ -1020,6 +1028,8 @@ fn query_snapshot_at(
 
     // 安装探针只碰文件系统与已配置的凭据，一次快照查一遍即可。
     let installed = detect::installed_agents();
+    // 自定义来源没有安装痕迹可探——"声明了"就是"装了"。
+    let declared_custom = !custom_sources::load(connection)?.is_empty();
 
     let mut models: Vec<ModelSummary> = model_totals
         .into_iter()
@@ -1072,7 +1082,9 @@ fn query_snapshot_at(
                     share: share(totals[agent]),
                     // 有用量必然装了；反过来不成立，所以安装痕迹是主判据、
                     // 用量兜底（Antigravity 没有便宜可靠的安装探针）。
-                    detected: installed.contains(agent) || totals[agent] > 0,
+                    detected: installed.contains(agent)
+                        || totals[agent] > 0
+                        || (*agent == "custom" && declared_custom),
                 }
             })
             .collect(),
@@ -1080,7 +1092,14 @@ fn query_snapshot_at(
         indexing: IndexingView {
             pending: report.backfill_pending,
         },
-        sources: source_views(report, sync::sync_view(connection).ok()),
+        sources: source_views(
+            report,
+            sync::sync_view(connection).ok(),
+            custom_sources::load(connection)?
+                .into_iter()
+                .map(|source| source.name)
+                .collect(),
+        ),
         cost,
     })
 }
@@ -1336,7 +1355,11 @@ fn load_quota(connection: &Connection, adapter_id: &str, window_key: &str) -> Re
     }
 }
 
-fn source_views(report: ScanReport, sync_status: Option<SyncView>) -> Vec<SourceView> {
+fn source_views(
+    report: ScanReport,
+    sync_status: Option<SyncView>,
+    custom_labels: Vec<String>,
+) -> Vec<SourceView> {
     let discovered = |id: &str| report.discovered.get(id).copied().unwrap_or(0);
     let refreshed = |id: &str| report.refreshed.get(id).copied().unwrap_or(0);
     let errors = |id: &str| report.errors.get(id).copied().unwrap_or(0);
@@ -1474,6 +1497,34 @@ fn source_views(report: ScanReport, sync_status: Option<SyncView>) -> Vec<Source
             ),
             quality: "exact".into(),
             quality_label: "精确解析".into(),
+        },
+        SourceView {
+            id: "custom-local".into(),
+            kind: "local".into(),
+            label: "自定义来源".into(),
+            detail: format!(
+                "用户在设置里声明的目录，按 Claude 兼容 JSONL 解析并合并计入「自定义」：{}。发现 {} 个会话，本次更新 {} 个。{}格式不符的目录解析不出事件，如实显示 0，不做猜测。",
+                if custom_labels.is_empty() {
+                    "尚未声明".to_owned()
+                } else {
+                    custom_labels.join("、")
+                },
+                discovered("custom"),
+                refreshed("custom"),
+                coverage_detail(&diagnostics("custom"), errors("custom")),
+            ),
+            quality: if diagnostics("custom").partial_sources > 0 || errors("custom") > 0 {
+                "partial"
+            } else {
+                "exact"
+            }
+            .into(),
+            quality_label: if diagnostics("custom").partial_sources > 0 || errors("custom") > 0 {
+                "数据不完整"
+            } else {
+                "精确解析"
+            }
+            .into(),
         },
         SourceView {
             id: "qoder-quota".into(),
@@ -2269,7 +2320,7 @@ mod tests {
             },
         );
 
-        let views = source_views(report, None);
+        let views = source_views(report, None, Vec::new());
         let codex = views
             .iter()
             .find(|source| source.id == "codex-local")
@@ -2293,7 +2344,7 @@ mod tests {
         let mut report = ScanReport::default();
         report.errors.insert("claude".into(), 1);
 
-        let views = source_views(report, None);
+        let views = source_views(report, None, Vec::new());
         let claude = views
             .iter()
             .find(|source| source.id == "claude-local")
@@ -2313,7 +2364,7 @@ mod tests {
             vec!["检测到 OpenCode 1.2+ 的 SQLite 存储（opencode.db），当前版本尚不支持读取，其中的会话未计入统计".into()],
         );
 
-        let views = source_views(report, None);
+        let views = source_views(report, None, Vec::new());
         let opencode = views
             .iter()
             .find(|source| source.id == "opencode-local")
@@ -2339,7 +2390,7 @@ mod tests {
             },
         );
 
-        let claude = source_views(report, None)
+        let claude = source_views(report, None, Vec::new())
             .into_iter()
             .find(|source| source.id == "claude-local")
             .unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,9 @@ mod app_server;
 mod claude_hook;
 mod claude_oauth;
 mod coding_quota;
+mod custom_sources;
+#[cfg(test)]
+mod custom_sources_e2e;
 mod detect;
 mod domain;
 mod engine;
@@ -463,6 +466,42 @@ async fn export_csv(file_name: String, content: String) -> Result<String, String
     })
     .await
     .map_err(|error| format!("csv export task failed: {error}"))?
+}
+
+/// 用户声明的自定义用量来源。只读，供设置页展示。
+#[tauri::command]
+async fn custom_usage_sources(
+    state: State<'_, AppState>,
+) -> Result<Vec<custom_sources::CustomSource>, String> {
+    let database_path = state.database_path.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let connection =
+            storage::open_database_read_only(&database_path).map_err(|error| error.to_string())?;
+        custom_sources::load(&connection).map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("custom sources task failed: {error}"))?
+}
+
+/// 覆盖式保存。返回归一化后的结果，让界面直接反映实际生效的配置
+/// （去重、去空白后可能与用户输入不同）。
+#[tauri::command]
+async fn set_custom_usage_sources(
+    sources: Vec<custom_sources::CustomSource>,
+    state: State<'_, AppState>,
+) -> Result<Vec<custom_sources::CustomSource>, String> {
+    let database_path = state.database_path.clone();
+    let scan_gate = Arc::clone(&state.scan_gate);
+    tauri::async_runtime::spawn_blocking(move || {
+        let _gate = scan_gate
+            .lock()
+            .map_err(|_| "usage scan lock poisoned".to_owned())?;
+        let connection =
+            storage::open_database(&database_path).map_err(|error| error.to_string())?;
+        custom_sources::save(&connection, sources).map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| format!("set custom sources task failed: {error}"))?
 }
 
 #[tauri::command]
@@ -1073,6 +1112,8 @@ pub fn run() {
             usage_projects,
             project_rules,
             set_project_rules,
+            custom_usage_sources,
+            set_custom_usage_sources,
             export_csv,
             rebuild_local_ledger,
             sync_settings,

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -304,8 +304,11 @@ fn insert_or_merge_usage_event(
     // being completed, and may copy it into a branched session log. Those are
     // observations of one event, so merge each token component monotonically.
     // Fallback Claude keys and all other adapters keep strict payload matching.
+    // 用户声明的自定义来源用的是同一套 Claude 格式，因此有同样的"同一条消息被
+    // 反复观察、计数逐步补齐"行为，必须一并按分量合并；否则每次重扫都会因为
+    // payload 变化被判成身份冲突。
     let mergeable_claude_message =
-        event.adapter_id == "claude" && event.event_key.starts_with("message:");
+        matches!(event.adapter_id, "claude" | "custom") && event.event_key.starts_with("message:");
     // Antigravity has no log: every poll re-reads the live session and returns a
     // full snapshot, so an in-flight generation is observed repeatedly with
     // growing counts. Same shape as Claude — merge component-wise maxima.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,6 +57,8 @@ import {
   getUsageProjects,
   getProjectRules,
   setProjectRules,
+  getCustomSources,
+  setCustomSources,
   getUsageSnapshot,
   rebuildLocalLedger,
   removeSyncDevice,
@@ -177,6 +179,15 @@ const AGENT_META = {
     accent: "#3a7ca5",
     iconSrc: qoderAppIcon,
     iconClass: "agent-icon--qoder",
+  },
+  custom: {
+    // 用户自己声明的 Claude 兼容 JSONL 目录，合并成一条。没有品牌图标，
+    // 用字母牌兜底（AgentMark 已支持）。
+    label: "自定义",
+    // 中性灰蓝：不与任何厂商的品牌色抢，一眼看出它不是某个具体产品。
+    accent: "#6b7280",
+    monogram: "自",
+    iconClass: "agent-icon--custom",
   },
 };
 
@@ -2530,6 +2541,123 @@ function AgentsDisplayCard({ widgetAgents, onToggleWidgetAgent, onMoveWidgetAgen
   );
 }
 
+/// 自定义用量来源：我们没接的 Agent，只要日志是 Claude 兼容 JSONL，
+/// 用户指一下目录就能算进总量，不必等我们排期。
+function CustomSourcesCard({ onSnapshotRefresh }) {
+  const [sources, setSources] = useState(null);
+  const [nameInput, setNameInput] = useState("");
+  const [pathInput, setPathInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getCustomSources()
+      .then((value) => {
+        if (!cancelled) setSources(value);
+      })
+      .catch(() => {
+        if (!cancelled) setFeedback({ tone: "error", message: "自定义来源读取失败。" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const apply = async (next) => {
+    setBusy(true);
+    setFeedback(null);
+    try {
+      // 后端返回归一化后的结果：去重、去空白后可能与输入不同，直接以它为准。
+      const saved = await setCustomSources(next);
+      setSources(saved);
+      onSnapshotRefresh();
+    } catch (error) {
+      setFeedback({ tone: "error", message: `${error}` });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const add = () => {
+    const name = nameInput.trim();
+    const path = pathInput.trim();
+    if (!name || !path) return;
+    apply([...(sources || []), { name, path }]).then(() => {
+      setNameInput("");
+      setPathInput("");
+    });
+  };
+
+  return (
+    <div className="settings-card">
+      <h2>自定义来源</h2>
+      <p className="settings-muted">
+        我们还没适配的 Agent，只要会话日志是 Claude 兼容 JSONL，指定目录后即可计入统计，
+        合并显示为「自定义」。只读取 token 计数，不读对话内容。
+      </p>
+      <p className="settings-muted">
+        格式不符的目录解析不出事件，如实显示 0，不做猜测。各来源的解析情况见「数据统计」。
+      </p>
+      <div className="rules-add">
+        <input
+          value={nameInput}
+          placeholder="显示名"
+          spellCheck={false}
+          onChange={(event) => setNameInput(event.target.value)}
+          aria-label="自定义来源显示名"
+        />
+        <input
+          value={pathInput}
+          placeholder="会话日志目录，递归查找其下的 *.jsonl"
+          spellCheck={false}
+          onChange={(event) => setPathInput(event.target.value)}
+          onKeyDown={(event) => { if (event.key === "Enter") add(); }}
+          aria-label="自定义来源目录"
+        />
+        <button
+          type="button"
+          className="ledger-button"
+          disabled={!nameInput.trim() || !pathInput.trim() || busy}
+          onClick={add}
+        >
+          添加
+        </button>
+      </div>
+      {sources === null ? (
+        <p className="settings-muted">正在读取…</p>
+      ) : sources.length === 0 ? (
+        <p className="settings-muted">还没有自定义来源。</p>
+      ) : (
+        <ul className="settings-device-list">
+          {sources.map((source) => (
+            <li key={source.path}>
+              <span>{source.name}</span>
+              <small title={source.path}>{source.path}</small>
+              <button
+                type="button"
+                className="ledger-button ledger-button--secondary"
+                disabled={busy}
+                onClick={() => apply(sources.filter((item) => item.path !== source.path))}
+              >
+                移除
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {feedback && (
+        <p
+          className={`settings-feedback settings-feedback--${feedback.tone}`}
+          role={feedback.tone === "error" ? "alert" : "status"}
+        >
+          {feedback.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function QoderQuotaCard({ onSnapshotRefresh }) {
   const [status, setStatus] = useState(null);
   const [cookieInput, setCookieInput] = useState("");
@@ -2790,9 +2918,9 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
             detectedAgents={detectedAgents}
           />
         )}
-
         {activeTab.id === "sources" && (
           <>
+            <CustomSourcesCard onSnapshotRefresh={onSnapshotRefresh} />
             <ClaudeHookCard onSnapshotRefresh={onSnapshotRefresh} />
             <QoderQuotaCard onSnapshotRefresh={onSnapshotRefresh} />
           </>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2666,7 +2666,8 @@ html:has(.strip-shell--glass-ink-light) #root {
 .agent-icon--kimi,
 .agent-icon--antigravity,
 .agent-icon--workbuddy,
-.agent-icon--qoder { color: inherit; }
+.agent-icon--qoder,
+.agent-icon--custom { color: inherit; }
 
 .agent-monogram {
   display: grid;

--- a/src/usageClient.js
+++ b/src/usageClient.js
@@ -528,6 +528,36 @@ async function setProjectRules(rules) {
   return invoke("set_project_rules", { rules });
 }
 
+// 浏览器演示模式的自定义来源存在内存里，预览也能走一遍增删流程。
+let demoCustomSources = [];
+
+async function getCustomSources() {
+  if (!isTauriRuntime()) {
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    return [...demoCustomSources];
+  }
+  try {
+    return await invoke("custom_usage_sources");
+  } catch (error) {
+    console.warn("Unable to load custom usage sources.", error);
+    return [];
+  }
+}
+
+async function setCustomSources(sources) {
+  if (!isTauriRuntime()) {
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    demoCustomSources = (sources || [])
+      .map((source) => ({
+        name: String(source.name || "").trim(),
+        path: String(source.path || "").trim().replace(/\\/g, "/").replace(/\/+$/, ""),
+      }))
+      .filter((source) => source.name && source.path);
+    return [...demoCustomSources];
+  }
+  return invoke("set_custom_usage_sources", { sources });
+}
+
 async function getUsageReport() {
   if (!isTauriRuntime()) {
     await new Promise((resolve) => setTimeout(resolve, 220));
@@ -643,6 +673,8 @@ export {
   getUsageProjects,
   getProjectRules,
   setProjectRules,
+  getCustomSources,
+  setCustomSources,
   exportCsvFile,
   rebuildLocalLedger,
   getSyncSettings,


### PR DESCRIPTION
「用户装了别的 Agent，省得再来找我们做」的落地。我们没适配的 Agent，只要会话日志是 **Claude 兼容 JSONL**，用户在设置 → 数据来源里声明目录即可计入总量。这个格式的克隆产品很多——`workbuddy` adapter 本来就是一个解析器同时吃 CodeBuddy 与 WorkBuddy。

## 为什么是这个形态

原计划是「按竞品有算法的都对应上」。实施时撞到两堵墙，值得记下来：

**其一，没有可验证的对象。** 本机装了 Cursor 与 Gemini CLI，但两者都是空壳（`~/.cursor` 只有 `hooks.json`，`~/.gemini` 只有 `settings.json`，时间戳同为 7/31 20:34:30，初始化脚本一起建的，从未使用）；其余 13 个候选一个都没装。而**额度类接口没有自检可用**——刚做的口径自检靠「来源自报总量」，额度接口只给百分比，没有任何东西可对照。照竞品写一个取数，既跑不了，也没有机制在它错时报警。

**其二，`AGENT_IDS` 是定长数组。** `[&str; 8]`，在 `engine.rs` 被引用 18 处，其中四处是 `AGENT_IDS.iter().find(|a| **a == event.adapter)`——**不在名单里的 adapter，事件会被静默丢弃**。所以「用户自己声明来源」不是加个 adapter 就行。

于是选了固定槽位：能解决核心诉求（token 算进总量、有成本估算、看得见我们在读），且**本机可端到端验证**。

## 改动

- `AGENT_IDS` 增加 `custom`（8 → 9）。多个声明来源合并成这一条，各自的名字在「数据统计」里分别列出。做成动态 Agent 要改总量、活跃天、构成、成本、配额、序列全线，且图表配色需动态分配。
- **复用 `ClaudeAdapter`**：加一个 `adapter_id` 字段，`for_custom_sources` 换 id 即可。复制一份解析器意味着以后修 bug 要修两遍。
- 自定义来源进**可合并名单**：同格式必然有同样的「同一条消息被反复观察、计数逐步补齐」行为，不合并会被判成身份冲突。
- 规则存 `app_setting`，归一化去空白/去重/限 16 条，配置损坏时当作未声明。
- 图标用现成的 `.agent-monogram` 兜底，不新增资源。

## 刻意的边界

**只认 Claude 兼容 JSONL 一种格式，不做字段映射式的通用适配。** 让用户自己填哪个字段是 input、哪个是 output，等于把最容易出错的口径判断推给他，而错了不会报错、只会显示一个看着合理的错数字。格式不符就解析不出事件，如实显示 0。

## 验证

新增端到端测试（`custom_sources_e2e.rs`）：声明目录 → 扫描 → **175 tokens 确实以 `custom` 落账**、来源名出现在数据统计、`detected` 为真；另一例确认格式不符的目录如实为 0。

写这个测试时**先失败了一次**：周期字符串只认 `today|week|month`（我传了 `30d`），且写死的 UTC 时刻换算成本地时间后落在「现在」之后被窗口上界挡掉。是测试的问题，不是功能的，已改成相对时间。记在这里是因为它正说明端到端测试值得写——单测全绿并不代表这条路通。

- `cargo fmt --check` 干净、`cargo clippy --all-targets -- -D warnings` 零告警、`cargo test` 191 项（新增 5 项）
- `npm test` 34 项、`npm run build` 通过

## 未做

额度类批量接入（Cursor / Grok 等）暂缓，理由见上：本机无可验证对象，且额度类没有自检兜底。等有真装了的机器再说。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
