### PR TITLE
Release v0.14.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.6",
+      "version": "0.14.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.6"
+version = "0.14.7"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：五个版本文件从 `0.14.6` 升到 `0.14.7`，不含任何产品代码。

产品改动已由 #98、#99 合入并在 `main` 上通过双平台 CI。

## v0.14.7 内容

- **自定义来源**（#99）：用户在设置里声明一个 Claude 兼容 JSONL 目录即可计入统计，合并显示为「自定义」。`AGENT_IDS` 增加 `custom` 槽位，复用 ClaudeAdapter 解析，进可合并名单。只认这一种格式——不做字段映射式适配，那等于把最容易错的口径判断推给用户，而错了不会报错。
- **口径自检**（#98）：来源自报总量时与我们拆出的分量核对，对不上就标「数据不完整」并说明数字可能有误。把安静的错变成响亮的错。

既有账本不受影响：`custom` 是新 adapter id，不碰任何既有事件；未声明来源时该 adapter 等于不存在。`PARSER_VERSION` 未变，不触发重扫。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
