### PR TITLE
Release v0.14.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.7",
+      "version": "0.14.8",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.7"
+version = "0.14.8"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：五个版本文件从 `0.14.7` 升到 `0.14.8`，不含任何产品代码。

产品改动已由 #101 合入并在 `main` 上通过双平台 CI。

## v0.14.8 内容

- **官方额度直连（OAuth）在凭据过期时说实话**（#101）：过去它一边写着「凭据可用」，一边每次查询都被 401 拒掉，真实原因只能从底下一行小字里猜。现在过期就明说，并直接回落到状态栏钩子。
- **删掉一条已被真机证伪的刷新路径**：它原本在 401 后调用官方 CLI 试图刷新 token。实测 `claude auth status --json` 退出码 0、报告已登录，钥匙串里的 `expiresAt` 却停在十小时前纹丝不动；`claude auth` 下也没有任何刷新入口。这次空跑发生在扫描锁内，每次失败要起两个子进程、各等最多 12 秒。净删 48 行。

不做自动刷新是有意的：凭据里那把 refreshToken 通常一次性，我们换了却不写回，用户真正在用的 Claude Code 登录就可能被顶掉。

不涉及账本、解析或迁移；`PARSER_VERSION` 未变，不触发重扫。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
