### PR TITLE
fix: 设置页读取不再排队、更新提示不再卡版本、macOS 设备名不再重名

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -666,12 +666,11 @@ async fn configure_qoder_cookie(cookie: Option<String>) -> Result<QoderCookieVie
 #[tauri::command]
 async fn sync_settings(state: State<'_, AppState>) -> Result<domain::SyncView, String> {
     let database_path = state.database_path.clone();
-    let scan_gate = Arc::clone(&state.scan_gate);
 
+    // 与会话/项目/分组规则同一惯例：设置页的读取不占扫描锁。占了的话，打开
+    // 设置正好赶上一次扫描，整张同步卡片要等扫描结束才出现——界面看着是
+    // 空的，然后突然长出一截。写连接仍然要保留：首次调用会补写设备身份。
     tauri::async_runtime::spawn_blocking(move || {
-        let _gate = scan_gate
-            .lock()
-            .map_err(|_| "usage scan lock poisoned".to_owned())?;
         let connection =
             storage::open_database(&database_path).map_err(|error| error.to_string())?;
         sync::sync_view(&connection).map_err(|error| error.to_string())

--- a/src-tauri/src/sync.rs
+++ b/src-tauri/src/sync.rs
@@ -62,17 +62,62 @@ fn delete_setting(connection: &Connection, key: &str) -> Result<()> {
     Ok(())
 }
 
-fn device_label() -> String {
+/// 旧兜底名。`HOSTNAME` 是 shell 变量，GUI 启动的 macOS 应用拿不到，于是
+/// 每一台 mac 都叫这个名字——列表里一排「此设备」，而且恰恰没有一台是本机。
+/// 保留常量是为了识别并修掉已经存下来的那些。
+const LEGACY_FALLBACK_LABEL: &str = "此设备";
+const FALLBACK_LABEL: &str = "未命名设备";
+
+/// 主机名里可展示的那一段：去掉域名后缀（macOS 常见的 `.local`），
+/// 空串一律当作没拿到。
+fn short_hostname(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let head = trimmed.split('.').next().unwrap_or("").trim();
+    (!head.is_empty()).then(|| head.to_owned())
+}
+
+/// unix 的主机名走 `gethostname(3)`：环境变量在 GUI 进程里不可靠，而这个
+/// 系统调用不依赖 shell。
+#[cfg(unix)]
+fn system_hostname() -> Option<String> {
+    // 256 足够容纳 POSIX 的 HOST_NAME_MAX（Linux 64、macOS 255）。
+    let mut buffer = [0_u8; 256];
+    // SAFETY: 传入自有缓冲区与其真实长度；失败返回非零，此时不读缓冲区。
+    let code = unsafe { libc::gethostname(buffer.as_mut_ptr().cast(), buffer.len()) };
+    if code != 0 {
+        return None;
+    }
+    // 找不到 NUL 说明名字塞满了缓冲区、可能被截断（256 > HOST_NAME_MAX，
+    // 实际到不了）。宁可当作没拿到，也不拿一个残缺的名字当设备名。
+    let end = buffer.iter().position(|byte| *byte == 0).unwrap_or(0);
+    short_hostname(&String::from_utf8_lossy(&buffer[..end]))
+}
+
+#[cfg(not(unix))]
+fn system_hostname() -> Option<String> {
     std::env::var("COMPUTERNAME")
-        .or_else(|_| std::env::var("HOSTNAME"))
         .ok()
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| "此设备".into())
+        .as_deref()
+        .and_then(short_hostname)
+}
+
+fn device_label() -> String {
+    system_hostname().unwrap_or_else(|| FALLBACK_LABEL.into())
 }
 
 /// 返回（并在首次调用时生成）本机的稳定设备标识与名称。
 pub fn device_identity(connection: &Connection) -> Result<(String, String)> {
     let label = match get_setting(connection, SETTING_DEVICE_LABEL)? {
+        // 旧版本在 macOS 上一律存成「此设备」，而这里只在缺失时才写，所以那个
+        // 名字会一直留着。能算出真名字就顶掉它——只认这一个旧兜底值，用户
+        // 自己改过的名字不碰。
+        Some(value) if value == LEGACY_FALLBACK_LABEL => match system_hostname() {
+            Some(hostname) => {
+                set_setting(connection, SETTING_DEVICE_LABEL, &hostname)?;
+                hostname
+            }
+            None => value,
+        },
         Some(value) => value,
         None => {
             let value = device_label();
@@ -431,6 +476,40 @@ mod tests {
         let second = device_identity(&connection).unwrap();
         assert_eq!(first, second);
         assert_eq!(first.0.len(), 16);
+    }
+
+    #[test]
+    fn hostname_drops_the_domain_suffix_and_rejects_empty() {
+        assert_eq!(
+            short_hostname("guoxiaoyudeMac-mini.local").as_deref(),
+            Some("guoxiaoyudeMac-mini")
+        );
+        assert_eq!(short_hostname("  KEROS-PC  ").as_deref(), Some("KEROS-PC"));
+        assert_eq!(short_hostname("a.b.c").as_deref(), Some("a"));
+        assert!(short_hostname("").is_none());
+        assert!(short_hostname("   ").is_none());
+        assert!(short_hostname(".local").is_none());
+    }
+
+    /// 本机能拿到主机名时，旧版在 macOS 上存下的「此设备」要被顶掉；
+    /// 用户自己改过的名字不受影响。
+    #[test]
+    fn the_legacy_fallback_label_is_repaired_but_a_custom_name_is_kept() {
+        let connection = open_test_db();
+        set_setting(&connection, SETTING_DEVICE_LABEL, LEGACY_FALLBACK_LABEL).unwrap();
+        let (_, label) = device_identity(&connection).unwrap();
+        match system_hostname() {
+            Some(hostname) => {
+                assert_eq!(label, hostname);
+                assert_ne!(label, LEGACY_FALLBACK_LABEL);
+            }
+            // 拿不到主机名时不能把名字弄丢，原样留着。
+            None => assert_eq!(label, LEGACY_FALLBACK_LABEL),
+        }
+
+        let connection = open_test_db();
+        set_setting(&connection, SETTING_DEVICE_LABEL, "书房那台").unwrap();
+        assert_eq!(device_identity(&connection).unwrap().1, "书房那台");
     }
 
     #[test]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2187,13 +2187,18 @@ function UpdateBlock({ autoCheck, onAutoCheckChange, availableUpdate }) {
     availableUpdate ? { status: "available", ...availableUpdate } : { status: "idle" },
   );
   // 自动检查在小组件形态就可能发现新版；进设置页时直接呈现，不用再点一次。
+  // 后来的自动检查发现更新的版本时要顶掉手上这一份：否则一直提示第一次发现
+  // 的那个版本，中间发布的都要等装完它才看得见。
   useEffect(() => {
     if (!availableUpdate) return;
-    setState((current) =>
-      current.status === "idle" || current.status === "current"
-        ? { status: "available", ...availableUpdate }
-        : current,
-    );
+    setState((current) => {
+      // 正在检查或下载时不换手上这一份，免得按钮和进度对不上。
+      if (current.status === "checking" || current.status === "installing") return current;
+      if (current.status === "available" && current.version === availableUpdate.version) {
+        return current;
+      }
+      return { status: "available", ...availableUpdate };
+    });
   }, [availableUpdate]);
 
   const check = async () => {
@@ -2222,7 +2227,7 @@ function UpdateBlock({ autoCheck, onAutoCheckChange, availableUpdate }) {
     <div className="settings-subsection">
       <h3>更新</h3>
       <p className="settings-muted">
-        当前版本 {__APP_VERSION__}。每天自动检查一次，新版本以小圆点提示；
+        当前版本 {__APP_VERSION__}。每六小时自动检查一次，新版本以小圆点提示；
         下载与安装由你确认，更新包经签名校验。
       </p>
       <label className="update-autocheck">
@@ -2248,6 +2253,13 @@ function UpdateBlock({ autoCheck, onAutoCheckChange, availableUpdate }) {
                 ? `更新到 ${state.version}`
                 : "检查更新"}
         </button>
+        {/* 有新版待装时主按钮变成"更新到 X"，没有这一个就再也没法重新检查：
+            关掉自动检查的人只能先把旧版装掉，才看得到后面发布的版本。 */}
+        {state.status === "available" && (
+          <button type="button" className="ledger-button ledger-button--secondary" onClick={check}>
+            重新检查
+          </button>
+        )}
       </div>
       {state.status === "current" && (
         <p className="settings-feedback settings-feedback--success" role="status">
@@ -2969,6 +2981,12 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
                 >
                   {feedback.message}
                 </p>
+              )}
+
+              {/* 读取未回来时这张卡片是空的，数据一到就整块长出来，看着像界面
+                  抖了一下。先占住位置并说明在读什么。 */}
+              {!settings && !feedback && (
+                <p className="settings-muted" role="status">读取同步设置…</p>
               )}
 
               {settings && !settings.demo && (
@@ -4465,9 +4483,10 @@ export function App() {
         })
         .catch(() => {}); // 静默失败：提醒是尽力而为，不打扰
     };
-    // 错开启动扫描的高峰再查；之后每天一次。
+    // 错开启动扫描的高峰再查；之后每六小时一次。间隔只在应用连续运行时计时，
+    // 而这是个常驻托盘的程序：按天计的话，一天里发布的版本它一个也看不见。
     const startTimer = window.setTimeout(check, 15000);
-    const interval = window.setInterval(check, 24 * 60 * 60 * 1000);
+    const interval = window.setInterval(check, 6 * 60 * 60 * 1000);
     return () => {
       cancelled = true;
       window.clearTimeout(startTimer);


### PR DESCRIPTION
三个来自实际使用的问题，都是"界面在骗人"或"界面把人卡住"。

## 1. 同步卡片"闪一下"

用户报告点设置里的按钮时界面会闪。窗口层面查下来是干净的（临时探针记录
`page_load` 只有启动那一次，窗口没有 resize/move），真因是布局跳动：

`sync_settings` 占着扫描锁（`lib.rs:667`），打开设置正好赶上一次扫描就得排队。
期间 `settings` 为 `null`，`{settings && ...}` 一个元素都不渲染，卡片是个空壳；
数据一到，本机设备、上次同步、设备列表一起长出来，页面往下撑一截。

- 去掉扫描锁，与 `usage_sessions` / `project_rules` 同一惯例（那两处注释就写着
  "不占用扫描锁"）。写连接保留：首次调用要补写设备身份
- 读取未回来时占位显示「读取同步设置…」

## 2. 更新提示卡在第一次发现的版本

三个问题叠加，结果是"开机后自动检查发现 0.2，之后推 0.3、0.4 都看不见，必须先
把 0.2 装掉才能再检查"：

- `UpdateBlock` 在已提示某版本后丢弃所有后续结果（`App.jsx:2192` 原样返回
  `current`），`install()` 用的也是那个旧的 update 对象
- 主按钮一旦变成「更新到 X」，`onClick` 就切到 install，再没有重新检查的入口
- 自动检查间隔 24 小时，且只在应用连续运行时计时；这是常驻托盘的程序

改为：版本号不同就顶掉旧提示（`checking`/`installing` 时不动手上那份）、有新版
时并排一个「重新检查」、间隔改 6 小时，文案同步。

## 3. macOS 设备名一律是「此设备」

`device_label` 只看 `COMPUTERNAME`（Windows 独有）和 `HOSTNAME`（shell 变量，
GUI 启动的 macOS 应用拿不到），于是每台 mac 都落成兜底名。用户的设备列表里两条
都叫「此设备」，而本机 ID 与它们都不同——恰恰没有一台是"此设备"。

- unix 改走 `gethostname(3)`（unix 已依赖 libc），取第一个点之前的一段以去掉
  `.local`；Windows 保持 `COMPUTERNAME`；兜底文案改为「未命名设备」
- 已存下来的旧兜底名要修：`device_identity` 只在缺失时才写，光改函数对现存的
  mac 无效。识别到存的正是旧兜底值、且能算出真主机名时覆盖它，用户自己改过的
  名字不动
- 传播不需额外动作：下次导出带上新名字，对端导入时 `label = excluded.label`

## 验证

- `cargo test --lib` 194 passed（新增 2 条：主机名截取、旧兜底名修复且不误伤
  自定义名）
- `cargo clippy --all-targets -- -D warnings` 干净，`cargo fmt --check` 干净
- `npm test` 34 passed，`npm run build` 通过

未验证：**三项都没在真机上跑过**。同步卡片与设备名要在 macOS 上开一次设置才算数
（本机是 Windows，unix 分支编译得到但跑不到）；更新那三条要等下一个版本发布后
才验得到。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
