### PR TITLE
Release v0.14.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.8",
+      "version": "0.14.9",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.8"
+version = "0.14.9"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
仅版本号提交：五个版本文件从 `0.14.8` 升到 `0.14.9`，不含任何产品代码。

产品改动已由 #103 合入并在 `main` 上通过双平台 CI。

## v0.14.9 内容

- **设置页读取不再排队**：`sync_settings` 占着扫描锁，打开设置正好赶上一次扫描就得等它跑完，期间整张同步卡片一个元素都不渲染，数据一到再整块长出来。改为与 `usage_sessions` / `project_rules` 同一惯例，并在读取期间显示占位文案。
- **更新提示不再卡在首个版本**：`UpdateBlock` 在已提示某版本后丢弃所有后续检查结果，且主按钮变成「更新到 X」之后再没有重新检查的入口——结果是必须先把旧版装掉才看得到后面发布的版本。现在新版本顶掉旧提示、并排一个「重新检查」，自动检查间隔 24h 改 6h。
- **macOS 设备名不再一律叫「此设备」**：`device_label` 依赖的两个环境变量在 GUI 启动的 macOS 应用里都拿不到。改走 `gethostname(3)`，并修掉已经存下来的旧兜底名（只改函数对现存设备无效，因为标签只在缺失时才写）。

不涉及账本、解析或迁移；`PARSER_VERSION` 未变，不触发重扫。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
