### PR TITLE
Release v0.14.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.14.9",
+  "version": "0.14.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.14.9",
+      "version": "0.14.10",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.14.9",
+  "version": "0.14.10",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.14.9"
+version = "0.14.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.14.9"
+version = "0.14.10"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/src/coding_quota.rs
+++ b/src-tauri/src/coding_quota.rs
@@ -712,7 +712,8 @@ struct GlmCredential {
     region: GlmRegion,
 }
 
-/// GLM key 的全部候选：zcode 的 provider 配置 → 环境变量 → OpenCode `auth.json`。
+/// GLM key 的全部候选：zcode 的 provider 配置 → 环境变量 → 单行明文 key 文件
+/// → OpenCode `auth.json`。
 /// 全部收集、由调用方逐把尝试——不同来源的 key 可能是不同产品的（开放平台 key
 /// 打不通 coding-plan 配额接口），离线分不出真假。
 ///
@@ -749,6 +750,14 @@ fn resolve_glm_credentials() -> Vec<GlmCredential> {
             push(token, GlmRegion::Bigmodel);
         }
     }
+    // 国内 GLM 工具链的单行明文 key 文件，同样按 bigmodel 端点试。
+    for path in glm_plaintext_key_files() {
+        if let Ok(raw) = std::fs::read_to_string(&path) {
+            if let Some(token) = first_key_line(&raw) {
+                push(token, GlmRegion::Bigmodel);
+            }
+        }
+    }
     let opencode = read_opencode_auth();
     if let Some(token) = nonempty(opencode.get("zhipuai-coding-plan")) {
         push(token, GlmRegion::Bigmodel);
@@ -757,6 +766,29 @@ fn resolve_glm_credentials() -> Vec<GlmCredential> {
         push(token, GlmRegion::Zai);
     }
     candidates
+}
+
+/// 国内 GLM 工具链把 key 单独写成一行明文文件的三处落点（取自 CodexBar 的
+/// 凭据来源清单，**未在真机核实**）。读不到就跳过，与其它候选一样逐把尝试。
+fn glm_plaintext_key_files() -> Vec<PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    vec![
+        home.join(".coding-relay").join("glm-api-key"),
+        home.join(".config").join("bigmodel").join("api_key"),
+        home.join(".config").join("zhipu").join("api_key"),
+    ]
+}
+
+/// 单行 key 文件的内容：取首个非空行。这类文件就是"一行一把 key"，
+/// 不做注释识别——真混进别的内容，也只是多试一次请求。
+fn first_key_line(raw: &str) -> Option<String> {
+    raw.trim_start_matches('\u{feff}')
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_owned)
 }
 
 fn zcode_config_paths() -> Vec<PathBuf> {
@@ -1516,6 +1548,19 @@ mod tests {
         assert_eq!(map.get("zhipuai-coding-plan").unwrap(), "glm-secret");
         assert_eq!(map.get("kimi-for-coding").unwrap(), "sk-kimi-secret");
         assert!(!map.contains_key("blank"), "空 key 过滤掉");
+    }
+
+    #[test]
+    fn first_key_line_takes_leading_nonempty_line() {
+        assert_eq!(
+            first_key_line("\n  abc123.def456  \ntrailing\n").unwrap(),
+            "abc123.def456"
+        );
+        assert_eq!(
+            first_key_line("\u{feff}key-with-bom\n").unwrap(),
+            "key-with-bom"
+        );
+        assert_eq!(first_key_line("   \n\n"), None);
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.14.9",
+  "version": "0.14.10",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## 改动

多认三处 GLM coding-plan key 的单行明文文件落点：

- `~/.coding-relay/glm-api-key`
- `~/.config/bigmodel/api_key`
- `~/.config/zhipu/api_key`

此前 `resolve_glm_credentials` 只看 zcode 的 provider 配置、环境变量和 OpenCode
`auth.json`，把 key 放在上述文件里的用户会显示「配额不可用」。三处按既有的候选
逐把尝试机制并入，区域归 bigmodel。

来源是 CodexBar 的凭据来源清单（该项目文档明确 z.ai / 国内 GLM 都是 API key 认证，
没有 OAuth 这条路）。**路径未在真机核实**——读不到就跳过，对现有用户行为无变化。

仍然只接主动暴露的明文凭据，不解密任何加密存储的凭据。

## 版本

0.14.9 → 0.14.10，五个版本文件同步。

## 验证

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 195 passed / 0 failed
- [x] 新增单测 `first_key_line_takes_leading_nonempty_line`（首个非空行、BOM、全空白三种输入）
- [ ] 三处路径的真机验证：本机没有这些文件，无法确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)
