### PR TITLE
Embed macOS widget in 0.15.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,13 @@ jobs:
           - platform: windows-latest
             args: ""
             rust-targets: ""
+            widget-archs: ""
           # Intel + Apple Silicon 通用包。macOS 尚未实机验收，Release 说明里
           # 必须标明这一点。
           - platform: macos-latest
             args: "--target universal-apple-darwin"
             rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
+            widget-archs: "arm64 x86_64"
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -54,6 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          METRIK_WIDGET_ARCHS: ${{ matrix.widget-archs }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: Metrik ${{ github.ref_name }}
@@ -61,3 +64,15 @@ jobs:
           prerelease: false
           includeUpdaterJson: true
           args: ${{ matrix.args }}
+
+      - name: Verify WidgetKit extension is embedded
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          app_path="$(find src-tauri/target -path '*/release/bundle/macos/Metrik.app' -type d -print -quit)"
+          test -n "$app_path"
+          test -x "$app_path/Contents/PlugIns/MetrikWidget.appex/Contents/MacOS/MetrikWidget"
+          test -x "$app_path/Contents/Helpers/metrik-widget-publish"
+          test -x "$app_path/Contents/Helpers/metrik-widget-reload"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Contents/PlugIns/MetrikWidget.appex/Contents/Info.plist")" = "app.metrik.desktop.widget"
+          codesign --verify --deep --strict --verbose=2 "$app_path"

--- a/WidgetExtension/Info.plist
+++ b/WidgetExtension/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleExecutable</key>
     <string>MetrikWidget</string>
     <key>CFBundleIdentifier</key>
-    <string>app.metrik.desktop.widget-preview.widget</string>
+    <string>app.metrik.desktop.widget</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>XPC!</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.15.0</string>
+    <string>0.15.1</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -105,6 +105,15 @@ change.
 
 - Compact mode is a native menu-bar panel that follows current system
   appearance and material. It is not a floating Windows-style strip.
+- The optional desktop component is a native WidgetKit extension embedded at
+  `Metrik.app/Contents/PlugIns/MetrikWidget.appex`; shipping only its source or
+  a standalone preview host does not count as releasing the feature.
+- WidgetKit owns desktop material, corner shape, placement, tint mode, and
+  accessibility adaptations. Metrik does not paint a second outer card or
+  expose an opacity slider for the system widget.
+- The host and extension share only a compact sanitised snapshot through their
+  App Group. It contains derived totals and quota metadata, never prompts,
+  responses, credentials, or raw source paths.
 - The panel material is system vibrancy from the HUD family, kept in the
   active state because the non-activating panel never becomes key. The
   glass-density slider adjusts a scrim above vibrancy, so blur stays native

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "metrik",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "node --test src/platformDetection.test.js src/windowGeometry.test.js src/glassAppearance.test.js src/quotaWindows.test.js",
+    "test": "node --test src/platformDetection.test.js src/windowGeometry.test.js src/glassAppearance.test.js src/quotaWindows.test.js src/macosWidgetBundle.test.js",
     "preview": "vite preview",
     "pricing:update": "node --use-env-proxy scripts/update-pricing.mjs",
     "tauri": "tauri",

--- a/scripts/build-macos-widget-extension.sh
+++ b/scripts/build-macos-widget-extension.sh
@@ -1,0 +1,102 @@
+#!/bin/zsh
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  exit 0
+fi
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_DIR="${SCRIPT_DIR:h}"
+BUILD_DIR="$PROJECT_DIR/.build/macos-widget-extension"
+APPEX_BUNDLE="$BUILD_DIR/MetrikWidget.appex"
+APPEX_BINARY="$APPEX_BUNDLE/Contents/MacOS/MetrikWidget"
+APPEX_RESOURCES="$APPEX_BUNDLE/Contents/Resources"
+HELPERS_DIR="$BUILD_DIR/Helpers"
+SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
+APP_VERSION="$(node -p "require('$PROJECT_DIR/package.json').version")"
+APP_BUILD_NUMBER="${GITHUB_RUN_NUMBER:-1}"
+
+# A universal Tauri release needs a universal extension too. Local arm64/x86_64
+# builds may override this to one architecture to keep iteration fast.
+if [[ -n "${METRIK_WIDGET_ARCHS:-}" ]]; then
+  ARCHS=(${=METRIK_WIDGET_ARCHS})
+elif [[ "${TAURI_ENV_ARCH:-}" == "universal" ]]; then
+  ARCHS=(arm64 x86_64)
+else
+  ARCHS=("$(uname -m)")
+fi
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$APPEX_BUNDLE/Contents/MacOS" "$APPEX_RESOURCES" "$HELPERS_DIR" "$BUILD_DIR/arch"
+
+build_universal() {
+  local output="$1"
+  shift
+  local name="${output:t}"
+  local binaries=()
+  local arch
+  for arch in "${ARCHS[@]}"; do
+    local arch_output="$BUILD_DIR/arch/$name-$arch"
+    xcrun swiftc \
+      -parse-as-library \
+      -O \
+      -target "${arch}-apple-macosx14.0" \
+      -sdk "$SDK_PATH" \
+      "$@" \
+      -o "$arch_output"
+    binaries+=("$arch_output")
+  done
+  if (( ${#binaries[@]} == 1 )); then
+    ditto "${binaries[1]}" "$output"
+  else
+    xcrun lipo -create "${binaries[@]}" -output "$output"
+  fi
+  chmod +x "$output"
+}
+
+echo "Building Metrik WidgetKit extension for ${ARCHS[*]}..."
+build_universal "$APPEX_BINARY" \
+  -application-extension \
+  -framework AppKit \
+  -framework SwiftUI \
+  -framework WidgetKit \
+  -Xlinker -e \
+  -Xlinker _NSExtensionMain \
+  "$PROJECT_DIR/WidgetExtension/Sources/MetrikWidgetModels.swift" \
+  "$PROJECT_DIR/WidgetExtension/Sources/MetrikWidgetViews.swift" \
+  "$PROJECT_DIR/WidgetExtension/Sources/MetrikWidgetBundle.swift"
+
+ditto "$PROJECT_DIR/WidgetExtension/Info.plist" "$APPEX_BUNDLE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $APP_VERSION" "$APPEX_BUNDLE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $APP_BUILD_NUMBER" "$APPEX_BUNDLE/Contents/Info.plist"
+
+for asset in \
+  chatgpt-app-icon.png \
+  claude-app-icon.jpg \
+  zcode-app-icon.png \
+  opencode-app-icon.png \
+  kimi-app-icon.png \
+  antigravity-app-icon.png
+do
+  ditto "$PROJECT_DIR/src/assets/$asset" "$APPEX_RESOURCES/$asset"
+done
+
+build_universal "$HELPERS_DIR/metrik-widget-publish" \
+  -framework Foundation \
+  "$PROJECT_DIR/WidgetExtension/Sources/MetrikWidgetPublisher.swift"
+build_universal "$HELPERS_DIR/metrik-widget-reload" \
+  -framework WidgetKit \
+  "$PROJECT_DIR/WidgetExtension/Sources/MetrikWidgetReloader.swift"
+
+# This is ad-hoc bundle integrity, not Developer ID distribution signing. The
+# nested extension must be sealed before Tauri seals the outer app bundle.
+codesign --force --sign - \
+  --entitlements "$PROJECT_DIR/WidgetExtension/MetrikWidget.entitlements" \
+  "$APPEX_BUNDLE"
+codesign --force --sign - \
+  --entitlements "$PROJECT_DIR/src-tauri/entitlements.macOS.plist" \
+  "$HELPERS_DIR/metrik-widget-publish"
+codesign --force --sign - "$HELPERS_DIR/metrik-widget-reload"
+codesign --verify --strict --verbose=2 "$APPEX_BUNDLE"
+
+echo "Prepared WidgetKit bundle: $APPEX_BUNDLE"

--- a/scripts/build-macos-widget-preview.sh
+++ b/scripts/build-macos-widget-preview.sh
@@ -57,6 +57,9 @@ ditto "$PROJECT_DIR/WidgetExtension/Info.plist" "$APPEX_BUNDLE/Contents/Info.pli
 /usr/libexec/PlistBuddy \
   -c "Set :CFBundleVersion $PREVIEW_BUILD_NUMBER" \
   "$APPEX_BUNDLE/Contents/Info.plist"
+/usr/libexec/PlistBuddy \
+  -c "Set :CFBundleIdentifier $WIDGET_ID" \
+  "$APPEX_BUNDLE/Contents/Info.plist"
 for asset in \
   chatgpt-app-icon.png \
   claude-app-icon.jpg \

--- a/scripts/prepare-macos-widget.mjs
+++ b/scripts/prepare-macos-widget.mjs
@@ -1,0 +1,12 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+// Tauri runs beforeBundleCommand on every release platform. WidgetKit only
+// exists on macOS, so Windows intentionally has nothing to prepare.
+if (process.platform === "darwin") {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+  execFileSync("/bin/zsh", [path.join(scriptDirectory, "build-macos-widget-extension.sh")], {
+    stdio: "inherit",
+  });
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.15.0"
+version = "0.15.1"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,12 +1,13 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build",
+    "beforeBundleCommand": "node scripts/prepare-macos-widget.mjs",
     "frontendDist": "../dist"
   },
   "app": {
@@ -60,6 +61,16 @@
     "category": "DeveloperTool",
     "shortDescription": "Accurate, local-first AI agent usage monitoring",
     "publisher": "keros68",
-    "copyright": "Copyright © 2026 keros68"
+    "copyright": "Copyright © 2026 keros68",
+    "macOS": {
+      "minimumSystemVersion": "14.0",
+      "signingIdentity": "-",
+      "entitlements": "entitlements.macOS.plist",
+      "files": {
+        "PlugIns/MetrikWidget.appex": "../.build/macos-widget-extension/MetrikWidget.appex",
+        "Helpers/metrik-widget-publish": "../.build/macos-widget-extension/Helpers/metrik-widget-publish",
+        "Helpers/metrik-widget-reload": "../.build/macos-widget-extension/Helpers/metrik-widget-reload"
+      }
+    }
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2469,6 +2469,22 @@ function AppearanceCard({ theme, onThemeChange, glassAlpha, onGlassAlpha, glassT
   );
 }
 
+function NativeMacWidgetCard() {
+  if (!IS_MAC) return null;
+  return (
+    <div className="settings-card desktop-widget-setting">
+      <div>
+        <span className="desktop-widget-setting-kicker">macOS</span>
+        <h2>桌面小组件</h2>
+        <p className="settings-muted">
+          在桌面空白处右键“编辑小组件”，搜索 Metrik 后添加。透明材质、圆角和摆放由 macOS 管理。
+        </p>
+      </div>
+      <span className="desktop-widget-native-badge">系统原生</span>
+    </div>
+  );
+}
+
 function AgentListColumn({ title, hint, agents, detected, onToggle, onMove }) {
   // 已选的按显示顺序排前面，未选的按默认顺序垫后。
   const rows = agentIdsInDisplayOrder(agents);
@@ -2905,20 +2921,23 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
 
       <div className="settings-grid">
         {activeTab.id === "appearance" && (
-          <AppearanceCard
-            theme={theme}
-            onThemeChange={onThemeChange}
-            glassAlpha={glassAlpha}
-            onGlassAlpha={onGlassAlpha}
-            glassTint={glassTint}
-            onGlassTint={onGlassTint}
-            glassInk={glassInk}
-            onGlassInk={onGlassInk}
-            uiScale={uiScale}
-            onUiScale={onUiScale}
-            stripScale={stripScale}
-            onStripScale={onStripScale}
-          />
+          <>
+            <AppearanceCard
+              theme={theme}
+              onThemeChange={onThemeChange}
+              glassAlpha={glassAlpha}
+              onGlassAlpha={onGlassAlpha}
+              glassTint={glassTint}
+              onGlassTint={onGlassTint}
+              glassInk={glassInk}
+              onGlassInk={onGlassInk}
+              uiScale={uiScale}
+              onUiScale={onUiScale}
+              stripScale={stripScale}
+              onStripScale={onStripScale}
+            />
+            <NativeMacWidgetCard />
+          </>
         )}
 
         {activeTab.id === "display" && (

--- a/src/macosWidgetBundle.test.js
+++ b/src/macosWidgetBundle.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const tauriConfig = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8"));
+const widgetInfo = fs.readFileSync("WidgetExtension/Info.plist", "utf8");
+
+test("macOS release embeds the native WidgetKit extension and helpers", () => {
+  assert.equal(
+    tauriConfig.build.beforeBundleCommand,
+    "node scripts/prepare-macos-widget.mjs",
+  );
+  assert.deepEqual(tauriConfig.bundle.macOS.files, {
+    "PlugIns/MetrikWidget.appex":
+      "../.build/macos-widget-extension/MetrikWidget.appex",
+    "Helpers/metrik-widget-publish":
+      "../.build/macos-widget-extension/Helpers/metrik-widget-publish",
+    "Helpers/metrik-widget-reload":
+      "../.build/macos-widget-extension/Helpers/metrik-widget-reload",
+  });
+});
+
+test("production widget uses the host app bundle namespace", () => {
+  assert.match(widgetInfo, /<string>app\.metrik\.desktop\.widget<\/string>/);
+  assert.doesNotMatch(widgetInfo, /widget-preview/);
+});


### PR DESCRIPTION
## Summary

- Builds the macOS WidgetKit extension and its data helpers during the Tauri bundle phase.
- Embeds the extension at Metrik.app/Contents/PlugIns/MetrikWidget.appex with the production bundle identifier.
- Adds a release assertion that fails if the extension or helpers are missing.
- Adds macOS settings guidance for finding Metrik in the system widget gallery.
- Prepares version 0.15.1.

## Root cause

v0.15.0 shipped the WidgetKit source and local preview script, but the standard Tauri release workflow never compiled or embedded the .appex. The installed DMG therefore could not register a Metrik widget.

## Validation

- npm test: 36 passed
- npm run build
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test: 200 passed, 6 ignored
- Universal WidgetKit binary: arm64 + x86_64
- codesign --verify --deep --strict passed on the bundled Metrik.app
- pluginkit recognizes app.metrik.desktop.widget (0.15.1)
