### PR TITLE
Fix macOS agent selection synchronization

### DIFF
--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -149,7 +149,10 @@ change.
   plus official remaining percentage for every selected agent, `--` for
   unavailable data, and `~` for stale data.
 - Clicking any status item opens the anchored compact panel. Agent selection
-  updates immediately and always keeps at least one agent.
+  updates immediately across the separate settings window, compact panel,
+  WidgetKit snapshot, and menu-bar status items, and always keeps at least one
+  agent. A hidden window must never write an older selection back over the
+  current one during its next data refresh.
 - Provider names are not repeated as menu-bar text, and the menu structure must
   not copy another product's layout or multi-account detail.
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -364,25 +364,40 @@ async fn usage_snapshot(
         let _ = &widget_agents;
 
         #[cfg(target_os = "macos")]
-        let widget_agents = widget_agents
+        let requested_widget_agents = widget_agents
             .as_deref()
             .map(widget_snapshot::normalize_agent_filter);
 
         #[cfg(target_os = "macos")]
-        if let Some(agents) = widget_agents.as_ref() {
-            let save_result = storage::open_database(&database_path).and_then(|connection| {
-                let encoded = serde_json::to_string(agents)?;
-                storage::set_app_setting(
+        let widget_agents = storage::open_database(&database_path)
+            .and_then(|connection| {
+                let saved = storage::get_app_setting(
                     &connection,
                     widget_snapshot::AGENT_FILTER_SETTING_KEY,
-                    &encoded,
-                )
+                )?;
+
+                // 数据轮询不是设置写入通道：一旦有权威选择，任何窗口携带的旧
+                // widget_agents 都只能被忽略。首次升级没有保存值时，才用调用
+                // 窗口的 localStorage 播种一次。
+                let (resolved, should_persist) = widget_snapshot::resolve_agent_filter(
+                    saved.as_deref(),
+                    requested_widget_agents.as_deref(),
+                );
+                if should_persist {
+                    let agents = resolved.as_ref().expect("initial selection is present");
+                    let encoded = serde_json::to_string(agents)?;
+                    storage::set_app_setting(
+                        &connection,
+                        widget_snapshot::AGENT_FILTER_SETTING_KEY,
+                        &encoded,
+                    )?;
+                }
+                Ok(resolved)
+            })
+            .unwrap_or_else(|error| {
+                eprintln!("Metrik could not read its WidgetKit Agent selection ({error:#})");
+                requested_widget_agents.filter(|agents| !agents.is_empty())
             });
-            if let Err(error) = save_result {
-                // 选择持久化只服务于下次冷启动；当前快照仍应正常发布。
-                eprintln!("Metrik could not remember its WidgetKit Agent selection ({error:#})");
-            }
-        }
 
         #[cfg(target_os = "macos")]
         if let Err(error) = widget_snapshot::persist(&snapshot, widget_agents.as_deref()) {
@@ -395,6 +410,54 @@ async fn usage_snapshot(
     })
     .await
     .map_err(|error| format!("usage scan task failed: {error}"))?
+}
+
+/// 设置窗口显式提交 macOS Agent 选择。它是唯一允许覆盖已保存选择的通道；
+/// 普通 usage_snapshot 轮询只能读取该值，防止隐藏 WebView 用旧状态回滚设置。
+#[tauri::command]
+async fn set_macos_agent_selection(
+    agents: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let agents = widget_snapshot::normalize_agent_filter(&agents);
+        if agents.is_empty() {
+            return Err("macOS 菜单栏至少保留一个 Agent".into());
+        }
+        let database_path = state.database_path.clone();
+        let scan_gate = Arc::clone(&state.scan_gate);
+        tauri::async_runtime::spawn_blocking(move || {
+            let _gate = scan_gate
+                .lock()
+                .map_err(|_| "usage scan lock poisoned".to_owned())?;
+            let connection =
+                storage::open_database(&database_path).map_err(|error| error.to_string())?;
+            let encoded = serde_json::to_string(&agents).map_err(|error| error.to_string())?;
+            storage::set_app_setting(
+                &connection,
+                widget_snapshot::AGENT_FILTER_SETTING_KEY,
+                &encoded,
+            )
+            .map_err(|error| error.to_string())?;
+            drop(connection);
+
+            // 选择本身不需要重新扫描 Agent 日志；用缓存快照即可立刻更新
+            // WidgetKit 内容与时间线，额度/用量数值保持现有来源语义。
+            let snapshot = engine::build_cached_snapshot(&database_path, "today")
+                .map_err(|error| error.to_string())?;
+            widget_snapshot::persist(&snapshot, Some(&agents))
+                .map_err(|error| error.to_string())?;
+            Ok(())
+        })
+        .await
+        .map_err(|error| format!("macOS Agent selection task failed: {error}"))?
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (agents, state);
+        Err("macOS Agent 选择仅用于 macOS".into())
+    }
 }
 
 /// 只读历史报告：只查询本地账本已有数据，绝不触发日志扫描，不与 `usage_snapshot`
@@ -1204,6 +1267,7 @@ pub fn run() {
             open_expanded_window,
             set_macos_desktop_widget_visible,
             resize_macos_panel,
+            set_macos_agent_selection,
             update_macos_status_items
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -60,6 +60,8 @@ const ZCODE_MARK: &[u8] = include_bytes!("../../src/assets/zcode-app-icon.png");
 const OPENCODE_MARK: &[u8] = include_bytes!("../../src/assets/opencode-app-icon.png");
 const KIMI_MARK: &[u8] = include_bytes!("../../src/assets/kimi-app-icon.png");
 const ANTIGRAVITY_MARK: &[u8] = include_bytes!("../../src/assets/antigravity-app-icon.png");
+const WORKBUDDY_MARK: &[u8] = include_bytes!("../../src/assets/workbuddy-app-icon.png");
+const QODER_MARK: &[u8] = include_bytes!("../../src/assets/qoder-app-icon.png");
 
 #[derive(Clone, Copy)]
 struct StatusItemSpec {
@@ -68,7 +70,7 @@ struct StatusItemSpec {
     icon: &'static [u8],
 }
 
-const STATUS_ITEMS: [StatusItemSpec; 6] = [
+const STATUS_ITEMS: [StatusItemSpec; 8] = [
     StatusItemSpec {
         id: "codex",
         name: "ChatGPT",
@@ -98,6 +100,16 @@ const STATUS_ITEMS: [StatusItemSpec; 6] = [
         id: "antigravity",
         name: "Antigravity",
         icon: ANTIGRAVITY_MARK,
+    },
+    StatusItemSpec {
+        id: "workbuddy",
+        name: "WorkBuddy",
+        icon: WORKBUDDY_MARK,
+    },
+    StatusItemSpec {
+        id: "qoder",
+        name: "Qoder",
+        icon: QODER_MARK,
     },
 ];
 
@@ -565,6 +577,12 @@ fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_visible_agent_has_a_menu_bar_status_item() {
+        let status_ids = STATUS_ITEMS.map(|item| item.id);
+        assert_eq!(status_ids, crate::domain::AGENT_IDS);
+    }
 
     #[test]
     fn status_title_clamps_percentages_and_marks_stale_data() {

--- a/src-tauri/src/widget_snapshot.rs
+++ b/src-tauri/src/widget_snapshot.rs
@@ -30,6 +30,27 @@ pub fn normalize_agent_filter(agent_filter: &[String]) -> Vec<String> {
     })
 }
 
+/// Resolve the single authoritative macOS selection. Once a valid saved value exists,
+/// a window-provided value is only a stale rendering hint and must never replace it.
+/// The boolean says whether the caller should persist a one-time initial selection.
+pub fn resolve_agent_filter(
+    saved: Option<&str>,
+    requested: Option<&[String]>,
+) -> (Option<Vec<String>>, bool) {
+    let saved = saved
+        .and_then(|encoded| serde_json::from_str::<Vec<String>>(encoded).ok())
+        .map(|agents| normalize_agent_filter(&agents))
+        .filter(|agents| !agents.is_empty());
+    if saved.is_some() {
+        return (saved, false);
+    }
+    let initial = requested
+        .map(normalize_agent_filter)
+        .filter(|agents| !agents.is_empty());
+    let should_persist = initial.is_some();
+    (initial, should_persist)
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WidgetSnapshot<'a> {
@@ -317,6 +338,23 @@ mod tests {
             "kimi".to_owned(),
         ];
         assert_eq!(normalize_agent_filter(&filter), ["kimi"]);
+    }
+
+    #[test]
+    fn saved_selection_wins_over_a_stale_window_request() {
+        let requested = vec!["codex".to_owned(), "claude".to_owned()];
+        let (resolved, should_persist) =
+            resolve_agent_filter(Some(r#"["zcode","kimi","codex"]"#), Some(&requested));
+        assert_eq!(resolved.unwrap(), ["zcode", "kimi", "codex"]);
+        assert!(!should_persist);
+    }
+
+    #[test]
+    fn first_valid_window_selection_seeds_missing_saved_state_once() {
+        let requested = vec!["kimi".to_owned(), "codex".to_owned()];
+        let (resolved, should_persist) = resolve_agent_filter(None, Some(&requested));
+        assert_eq!(resolved.unwrap(), ["kimi", "codex"]);
+        assert!(should_persist);
     }
 
     #[test]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,6 +67,7 @@ import {
   UI_SCALE_RANGE,
   applyStartupUiScale,
   applyWindowMode,
+  broadcastMacAgentSelection,
   broadcastMacAppearance,
   checkForUpdate,
   closeWindow,
@@ -76,6 +77,7 @@ import {
   isMacPlatform,
   isWindowsPlatform,
   minimizeWindow,
+  onMacAgentSelection,
   onMacAppearance,
   onScaleFactorChanged,
   onTrayShowExpanded,
@@ -4410,27 +4412,28 @@ export function App() {
       window.clearInterval(interval);
     };
   }, [autoUpdateCheck]);
+  const commitWidgetAgents = useCallback((next) => {
+    setWidgetAgents(next);
+    localStorage.setItem("metrik:widgetAgents", JSON.stringify(next));
+    // macOS 的设置页和菜单栏面板不共享 React 状态，也收不到彼此的 storage
+    // 事件。立即广播选择，避免隐藏面板下一轮轮询把旧列表写回菜单栏/WidgetKit。
+    if (IS_MAC) runWindowAction(() => broadcastMacAgentSelection(next));
+  }, []);
   const handleToggleWidgetAgent = useCallback((agentId) => {
-    setWidgetAgents((current) => {
-      // 新勾选的排到末尾（数组顺序就是显示顺序，与胶囊条同一套语义）。
-      const next = current.includes(agentId)
-        ? current.filter((id) => id !== agentId)
-        : [...current, agentId];
-      if (!next.length) return current; // 至少保留一个
-      localStorage.setItem("metrik:widgetAgents", JSON.stringify(next));
-      return next;
-    });
-  }, []);
+    // 新勾选的排到末尾（数组顺序就是显示顺序，与胶囊条同一套语义）。
+    const next = widgetAgents.includes(agentId)
+      ? widgetAgents.filter((id) => id !== agentId)
+      : [...widgetAgents, agentId];
+    if (!next.length) return; // 至少保留一个
+    commitWidgetAgents(next);
+  }, [commitWidgetAgents, widgetAgents]);
   const handleMoveWidgetAgent = useCallback((agentId) => {
-    setWidgetAgents((current) => {
-      const next = [...current];
-      const index = next.indexOf(agentId);
-      if (index <= 0) return current;
-      [next[index - 1], next[index]] = [next[index], next[index - 1]];
-      localStorage.setItem("metrik:widgetAgents", JSON.stringify(next));
-      return next;
-    });
-  }, []);
+    const next = [...widgetAgents];
+    const index = next.indexOf(agentId);
+    if (index <= 0) return;
+    [next[index - 1], next[index]] = [next[index], next[index - 1]];
+    commitWidgetAgents(next);
+  }, [commitWidgetAgents, widgetAgents]);
   const [loading, setLoading] = useState(true);
   const [rebuildState, setRebuildState] = useState({ status: "idle", message: "" });
   const [report, setReport] = useState(null);
@@ -4657,6 +4660,35 @@ export function App() {
       unlistenPromise.then((unlisten) => unlisten());
     };
   }, []);
+
+  useEffect(() => {
+    if (!IS_MAC || !isDesktop()) return undefined;
+    const unlistenPromise = onMacAgentSelection((payload) => {
+      if (!Array.isArray(payload.agents)) return;
+      const next = normalizeVisibleAgentList(payload.agents);
+      if (!next.length) return;
+      // emit 会回到发送窗口；内容相同时保留原数组，避免无意义快照刷新。
+      setWidgetAgents((current) => {
+        if (current.length === next.length && current.every((id, index) => id === next[index])) {
+          return current;
+        }
+        localStorage.setItem("metrik:widgetAgents", JSON.stringify(next));
+        return next;
+      });
+    });
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!IS_MAC || !isDesktop() || viewMode !== "expanded" || activeNav !== "settings") {
+      return;
+    }
+    // 升级自愈：旧版本可能让设置窗口与隐藏面板各自留下不同 localStorage。
+    // 用户打开设置页时，以屏幕上正在展示的勾选为准主动同步一次，不要求再点一遍。
+    runWindowAction(() => broadcastMacAgentSelection(widgetAgents));
+  }, [activeNav, viewMode]);
 
   // 边缘挂靠：拖到屏幕上缘自动收起，鼠标碰边弹出。
   useEffect(() => {

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -573,6 +573,22 @@ async function onMacAppearance(handler) {
   return listen("metrik://mac-appearance", (event) => handler(event.payload || {}));
 }
 
+/// macOS 的设置页与菜单栏面板是两个独立 WebView。Agent 选择必须走事件总线，
+/// 不能依赖 localStorage 的 storage 事件（WKWebView 不会跨这两个窗口派发它）。
+async function broadcastMacAgentSelection(agents) {
+  if (!isDesktop() || !isMacPlatform()) return;
+  const { emit } = await import("@tauri-apps/api/event");
+  // 先让两个 WebView 同帧更新，再持久化为后端权威选择并刷新 WidgetKit。
+  await emit("metrik://mac-agent-selection", { agents }).catch(() => {});
+  await invoke("set_macos_agent_selection", { agents });
+}
+
+async function onMacAgentSelection(handler) {
+  if (!isDesktop() || !isMacPlatform()) return () => {};
+  const { listen } = await import("@tauri-apps/api/event");
+  return listen("metrik://mac-agent-selection", (event) => handler(event.payload || {}));
+}
+
 /// 拖动结束后持久化窗口位置（compact 与 strip 各记各的；expanded 不记）。
 async function startPositionMemory(getMode) {
   if (isMacPlatform()) return () => {};
@@ -1301,6 +1317,7 @@ export {
   WINDOW_SIZES,
   applyStartupUiScale,
   applyWindowMode,
+  broadcastMacAgentSelection,
   broadcastMacAppearance,
   checkForUpdate,
   closeWindow,
@@ -1311,6 +1328,7 @@ export {
   isWindowsPlatform,
   minimizeWindow,
   normalizeUiScale,
+  onMacAgentSelection,
   onMacAppearance,
   onScaleFactorChanged,
   onTrayShowExpanded,


### PR DESCRIPTION
## What changed

- Synchronize macOS Agent selection across the separate settings and menu-bar panel WebViews.
- Persist one authoritative selection so background polling cannot restore a stale list.
- Refresh WidgetKit immediately when the selection changes.
- Add WorkBuddy and Qoder to the native menu-bar status-item registry.

## Root cause

The macOS settings window and compact panel each kept independent React/localStorage state. A hidden window could submit its older list during the next usage refresh, replacing the newer setting. The native menu-bar registry also only covered six of the eight selectable Agents.

## Validation

- `npm test` (38 passed)
- `npm run build`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` (203 passed, 6 ignored)
- Native macOS preview startup and eight-status-item registration smoke check
