### PR TITLE
Release v0.16.1

### DIFF
--- a/WidgetExtension/Info.plist
+++ b/WidgetExtension/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>XPC!</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.16.0</string>
+    <string>0.16.1</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.16.0"
+version = "0.16.1"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Release v0.16.1

Patch release for the macOS Agent selection synchronization fix merged in #113.

### Included fix

- Keep menu-bar status items, compact panel, settings, and WidgetKit on one Agent selection.
- Prevent hidden-window polling from restoring stale selections.
- Add native menu-bar status items for WorkBuddy and Qoder.

### Version files

- package.json / package-lock.json
- src-tauri Cargo.toml / Cargo.lock
- src-tauri/tauri.conf.json
- WidgetExtension/Info.plist

### Validation

- Version files agree at 0.16.1.
- Feature PR passed Windows and macOS CI.
