### PR TITLE
Release v0.16.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,4 +75,13 @@ jobs:
           test -x "$app_path/Contents/Helpers/metrik-widget-publish"
           test -x "$app_path/Contents/Helpers/metrik-widget-reload"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Contents/PlugIns/MetrikWidget.appex/Contents/Info.plist")" = "app.metrik.desktop.widget"
+
+          host_info="$app_path/Contents/Info.plist"
+          widget_info="$app_path/Contents/PlugIns/MetrikWidget.appex/Contents/Info.plist"
+          host_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$host_info")"
+          widget_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$widget_info")"
+          host_release="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$host_info")"
+          widget_release="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$widget_info")"
+          test "$widget_build" = "$host_build"
+          test "$widget_release" = "$host_release"
           codesign --verify --deep --strict --verbose=2 "$app_path"

--- a/.learnings/LEARNINGS.md
+++ b/.learnings/LEARNINGS.md
@@ -10,7 +10,7 @@ Corrections, insights, and knowledge gaps captured during development.
 
 **Logged**: 2026-08-12T21:55:00+08:00
 **Priority**: high
-**Status**: in_progress
+**Status**: resolved
 **Area**: macOS shell
 
 ### Summary
@@ -28,8 +28,8 @@ Give every local WidgetKit build a monotonically changing bundle build number, t
 - Tags: widgetkit, cache, native-qa
 
 ### Resolution
-- **Reopened**: 2026-08-12T22:05:00+08:00
-- **Notes**: Unique build numbers and a live helper RunLoop made chronod accept the reload and regenerate a timeline, but the user's installed widget still rendered blank. Do not treat timeline acceptance as visual verification. Added privacy-safe extension diagnostics for App Group access, file reads, JSON decoding, and decoded Agent count; diagnosis remains open until the installed card visibly renders.
+- **Resolved**: 2026-08-13T12:46:35+08:00
+- **Notes**: The snapshot publisher and extension were both correct. WidgetKit generated the new timeline but chronod rejected it because the extension alone used a timestamp `CFBundleVersion` that differed from the containing app. Production builds now give the containing app and extension the same build and release versions, and release CI verifies the final bundle. A production-form local install then decoded the live three-Agent snapshot, returned `Reload success` for both widget kinds, updated all four timeline files, and visibly changed the desktop card from 241.7M / GLM 96% to 31.2M / GLM 93%.
 
 ---
 

--- a/WidgetExtension/Info.plist
+++ b/WidgetExtension/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>XPC!</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.16.1</string>
+    <string>0.16.2</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -108,6 +108,11 @@ change.
 - The optional desktop component is a native WidgetKit extension embedded at
   `Metrik.app/Contents/PlugIns/MetrikWidget.appex`; shipping only its source or
   a standalone preview host does not count as releasing the feature.
+- The containing app and embedded WidgetKit extension use the same
+  `CFBundleVersion` and release version. Production builds never assign a
+  per-build timestamp only to the extension: WidgetKit validates the archived
+  bundle stub against LaunchServices before accepting a refreshed timeline.
+  Release packaging must reject a version mismatch.
 - The WidgetKit snapshot follows the user's compact-widget Agent selection and
   order exactly. Large widgets use a density-responsive grid for every selected
   Agent rather than a fixed six-item slice, and cold startup must not replace a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/scripts/build-macos-widget-extension.sh
+++ b/scripts/build-macos-widget-extension.sh
@@ -14,10 +14,13 @@ APPEX_RESOURCES="$APPEX_BUNDLE/Contents/Resources"
 HELPERS_DIR="$BUILD_DIR/Helpers"
 SDK_PATH="$(xcrun --sdk macosx --show-sdk-path)"
 APP_VERSION="$(node -p "require('$PROJECT_DIR/package.json').version")"
-# Every extension build needs a monotonic value across both local and CI installs:
-# WidgetKit otherwise keeps a previously registered binary/timeline. A UTC build
-# timestamp also prevents a local build from outranking a later CI run number.
-APP_BUILD_NUMBER="$(date -u +%Y%m%d%H%M%S)"
+# WidgetKit archives the extension's bundle stub into every timeline and validates it
+# against LaunchServices before accepting a reload. The extension therefore has to use
+# the containing app's build version; giving only the extension a per-build timestamp
+# leaves upgraded installations with incompatible cached bundle stubs. Release versions
+# are already unique and serialized by CI, while the isolated preview app uses its own
+# bundle identifier and build sequence for local visual iteration.
+APP_BUILD_NUMBER="$APP_VERSION"
 
 # A universal Tauri release needs a universal extension too. Local arm64/x86_64
 # builds may override this to one architecture to keep iteration fast.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.16.1"
+version = "0.16.2"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/macosWidgetBundle.test.js
+++ b/src/macosWidgetBundle.test.js
@@ -24,6 +24,10 @@ const publisherInfo = fs.readFileSync(
   "WidgetExtension/MetrikWidgetPublisher.Info.plist",
   "utf8",
 );
+const widgetBuildScript = fs.readFileSync(
+  "scripts/build-macos-widget-extension.sh",
+  "utf8",
+);
 
 test("macOS release embeds the native WidgetKit extension and helpers", () => {
   assert.equal(
@@ -68,4 +72,12 @@ test("production widget never substitutes gallery preview data", () => {
 test("timeline reloader identifies as the containing Metrik app", () => {
   assert.match(reloaderInfo, /<string>app\.metrik\.desktop<\/string>/);
   assert.match(reloaderSource, /RunLoop\.current\.run/);
+});
+
+test("production widget uses the containing app build version", () => {
+  assert.match(widgetBuildScript, /APP_BUILD_NUMBER="\$APP_VERSION"/);
+  assert.doesNotMatch(
+    widgetBuildScript,
+    /APP_BUILD_NUMBER=.*(?:date|GITHUB_RUN_NUMBER)/,
+  );
 });


### PR DESCRIPTION
## What changed

- Fix macOS WidgetKit timeline refresh after app upgrades by matching the embedded extension build version to its containing app.
- Add source and final-bundle release guards for host/extension version parity.
- Bump the hotfix release to v0.16.2.

## Root cause

The extension used a timestamp-only `CFBundleVersion` while the containing app used the release version. WidgetKit could read the new snapshot but chronod rejected the generated timeline as a bundle-version mismatch, leaving an old desktop-widget timeline visible.

## Validation

- `npm test` (39 passing)
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` (203 passing; 6 live-data smoke tests ignored by design)
- macOS production bundle/signature check; native WidgetKit reload accepted and displayed the current snapshot.