### PR TITLE
Release v0.16.3

### DIFF
--- a/WidgetExtension/Info.plist
+++ b/WidgetExtension/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>XPC!</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.16.2</string>
+    <string>0.16.3</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>LSMinimumSystemVersion</key>

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -117,6 +117,11 @@ change.
   order exactly. Large widgets use a density-responsive grid for every selected
   Agent rather than a fixed six-item slice, and cold startup must not replace a
   saved selection with the full registry.
+- Timeline reloads are budgeted by WidgetKit at the app level, so snapshot
+  publishing never calls `reloadTimelines`: routine freshness comes from the
+  five-minute timeline policy, and explicit reloads fire only on a user Agent
+  selection change and once per app launch. Burning the budget on polling
+  freezes the widget on a stale snapshot.
 - Gallery placeholders may use illustrative data, but an installed production
   widget whose shared snapshot is unavailable renders an explicit empty state;
   it never presents the six-Agent gallery preview as live user data.
@@ -153,11 +158,23 @@ change.
 - The menu bar uses Metrik's own minimal grammar: one monochrome provider icon
   plus official remaining percentage for every selected agent, `--` for
   unavailable data, and `~` for stale data.
+- Status items are fixed slots with stable AppKit autosave names, all created
+  once at app startup and never removed or re-created within a session.
+  Every native item remains visible to ControlCenter; deselecting an agent
+  clears the slot and collapses its `NSStatusItem.length` to zero, while
+  selecting it restores variable length. Toggling `NSStatusItem.isVisible`
+  retains the object but Tahoe reinserts it at a new menu-bar position, so it
+  cannot preserve the user's order. Removing/recreating items can additionally
+  be silently rejected or misassociated. Empty titles must be written as an
+  empty string because the current tray dependency treats a `None` title as
+  “leave unchanged”.
 - Clicking any status item opens the anchored compact panel. Agent selection
   updates immediately across the separate settings window, compact panel,
   WidgetKit snapshot, and menu-bar status items, and always keeps at least one
-  agent. A hidden window must never write an older selection back over the
-  current one during its next data refresh.
+  agent. The backend database holds the single authoritative selection: every
+  window reads it on startup and only an explicit settings toggle may overwrite
+  it, so a hidden window can never write an older selection back over the
+  current one — not during a data refresh, and not from its stale local cache.
 - Provider names are not repeated as menu-bar text, and the menu structure must
   not copy another product's layout or multi-account detail.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2203,6 +2203,7 @@ dependencies = [
  "image",
  "libc",
  "objc",
+ "objc2-foundation",
  "rusqlite",
  "rustls",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.16.2"
+version = "0.16.3"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"
@@ -46,6 +46,9 @@ libc = "0.2"
 # 菜单栏面板：把 main 窗口换成不抢焦点的 NSPanel。crates.io 上没有 Tauri 2 版本，
 # 只能走 git 分支；上游停更时需要自行维护。
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2" }
+# Tauri 暴露底层 NSStatusItem，但稳定槽位需要直接设置 autosaveName 与 length：
+# tray-icon 的 set_visible(false) 会删除对象，set_title(None) 则不会清空旧标题。
+objc2-foundation = { version = "0.3", default-features = false, features = ["NSString"] }
 # 直接设置窗口级 NSAppearance（tao 的 set_theme 只动全应用外观，macOS 26 的
 # 标题栏不跟随它）。cocoa/objc 随 tauri-nspanel 已在依赖树中。
 objc = "0.2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -448,6 +448,9 @@ async fn set_macos_agent_selection(
                 .map_err(|error| error.to_string())?;
             widget_snapshot::persist(&snapshot, Some(&agents))
                 .map_err(|error| error.to_string())?;
+            // 用户显式操作，即时 reload 一次让小组件马上换选择；频率受操作次数
+            // 限制，不会耗尽 WidgetKit 的应用级刷新配额（轮询路径不 reload）。
+            widget_snapshot::reload_timelines();
             Ok(())
         })
         .await
@@ -456,6 +459,36 @@ async fn set_macos_agent_selection(
     #[cfg(not(target_os = "macos"))]
     {
         let _ = (agents, state);
+        Err("macOS Agent 选择仅用于 macOS".into())
+    }
+}
+
+/// 读取后端保存的 macOS Agent 权威选择。macOS 的设置窗口、菜单栏面板、桌面组件
+/// 是各自独立的 WebView，localStorage 互不同步，本地值只能当缓存；各窗口启动时
+/// 以此为准。空数组表示还没有保存过选择（首次启动），窗口退回本地缓存播种。
+#[tauri::command]
+async fn get_macos_agent_selection(state: State<'_, AppState>) -> Result<Vec<String>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let database_path = state.database_path.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+            let connection =
+                storage::open_database(&database_path).map_err(|error| error.to_string())?;
+            let saved =
+                storage::get_app_setting(&connection, widget_snapshot::AGENT_FILTER_SETTING_KEY)
+                    .map_err(|error| error.to_string())?;
+            Ok(
+                widget_snapshot::resolve_agent_filter(saved.as_deref(), None)
+                    .0
+                    .unwrap_or_default(),
+            )
+        })
+        .await
+        .map_err(|error| format!("macOS Agent selection task failed: {error}"))?
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = state;
         Err("macOS Agent 选择仅用于 macOS".into())
     }
 }
@@ -1020,20 +1053,52 @@ fn resize_macos_panel(app: tauri::AppHandle, width: f64, height: f64) -> Result<
 
 /// macOS 菜单栏按用户选择显示 Agent 图标和官方额度；其它平台没有对应状态项，
 /// 前端也不会调用。None 表示额度不可用，不能按 0% 处理。
+/// 显示哪些 Agent 以后端保存的权威选择为准：设置窗口、菜单栏面板、桌面组件是
+/// 各自独立的 WebView，任何窗口携带的旧列表都不能把已勾选的 Agent 抹掉；
+/// 调用方只提供各 Agent 的额度值（按 id 对照，与顺序无关）。
 #[tauri::command]
 fn update_macos_status_items(
     app: tauri::AppHandle,
+    state: State<'_, AppState>,
     agents: Vec<String>,
     remaining: Vec<Option<f64>>,
     stale: Vec<bool>,
 ) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
+        if agents.len() != remaining.len() || agents.len() != stale.len() {
+            return Err("macOS 菜单栏状态项参数长度不一致".into());
+        }
+        let saved = storage::open_database(&state.database_path)
+            .and_then(|connection| {
+                storage::get_app_setting(&connection, widget_snapshot::AGENT_FILTER_SETTING_KEY)
+            })
+            .unwrap_or_else(|error| {
+                eprintln!("Metrik could not read its menu bar Agent selection ({error:#})");
+                None
+            });
+        // 调用方的 agents/remaining/stale 是等长平行数组，先按 id 建值对照表，
+        // 再按权威选择重排；权威选择里缺值的 Agent 按不可用显示 "--"。
+        let mut values: std::collections::HashMap<&str, (Option<f64>, bool)> =
+            std::collections::HashMap::new();
+        for index in 0..agents.len() {
+            values.insert(agents[index].as_str(), (remaining[index], stale[index]));
+        }
+        let (resolved, _) = widget_snapshot::resolve_agent_filter(saved.as_deref(), Some(&agents));
+        let agents = resolved.unwrap_or_default();
+        let remaining: Vec<Option<f64>> = agents
+            .iter()
+            .map(|id| values.get(id.as_str()).and_then(|value| value.0))
+            .collect();
+        let stale: Vec<bool> = agents
+            .iter()
+            .map(|id| values.get(id.as_str()).is_some_and(|value| value.1))
+            .collect();
         macos::update_status_items(&app, &agents, &remaining, &stale)
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (app, agents, remaining, stale);
+        let _ = (app, state, agents, remaining, stale);
         Err("菜单栏用量状态项仅用于 macOS".into())
     }
 }
@@ -1209,6 +1274,9 @@ pub fn run() {
                         if let Err(error) = widget_snapshot::persist(&snapshot, Some(&agents)) {
                             eprintln!("Metrik could not seed its WidgetKit snapshot ({error:#})");
                         }
+                        // 每次启动 reload 一次：升级安装后让小组件立刻用新快照和新
+                        // extension 重建时间线。每进程一次，不影响刷新配额。
+                        widget_snapshot::reload_timelines();
                     }
                 }
                 Err(error) => {
@@ -1268,6 +1336,7 @@ pub fn run() {
             set_macos_desktop_widget_visible,
             resize_macos_panel,
             set_macos_agent_selection,
+            get_macos_agent_selection,
             update_macos_status_items
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -13,11 +13,12 @@
 use std::sync::Mutex;
 
 use image::imageops::FilterType;
+use objc2_foundation::NSString;
 use tauri::image::Image;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{
-    ActivationPolicy, AppHandle, LogicalSize, Manager, PhysicalPosition, Rect, WebviewUrl,
+    ActivationPolicy, AppHandle, LogicalSize, Manager, PhysicalPosition, Rect, Runtime, WebviewUrl,
     WebviewWindowBuilder,
 };
 use tauri_nspanel::cocoa::appkit::{NSMainMenuWindowLevel, NSWindowCollectionBehavior};
@@ -117,6 +118,58 @@ const STATUS_ITEMS: [StatusItemSpec; 8] = [
 /// 用它把面板对齐到图标下方；托盘的任何一次事件（点击/移入/移动）都会刷新。
 static TRAY_RECT: Mutex<Option<(f64, f64, f64, f64)>> = Mutex::new(None);
 
+/// 菜单栏状态槽：一个槽位持有一个长期存活的 NSStatusItem，内容可换、永不删除
+/// （删除后的重建会被 macOS 26 的 ControlCenter 编号机制拒收，见 update_status_items）。
+struct StatusSlot {
+    tray_id: String,
+    agent: Option<String>,
+}
+
+static STATUS_SLOTS: std::sync::LazyLock<Mutex<Vec<StatusSlot>>> =
+    std::sync::LazyLock::new(|| Mutex::new(Vec::new()));
+
+fn status_slot_autosave_name(index: usize) -> String {
+    format!("app.metrik.desktop.status-slot-{index}")
+}
+
+/// tray-icon 0.24.1 的 set_visible(false) 会从 NSStatusBar 删除 NSStatusItem；
+/// 原生 isVisible 虽保留对象，但 Tahoe 会把重新显示的项插到新位置。保持所有项
+/// 始终 visible，仅用 length=0 折叠空槽，既不留 18px 空位，也不改变槽位顺序。
+fn set_native_status_slot_collapsed<R: Runtime>(
+    tray: &tauri::tray::TrayIcon<R>,
+    collapsed: bool,
+) -> Result<(), String> {
+    tray.with_inner_tray_icon(move |inner| {
+        let status_item = inner
+            .ns_status_item()
+            .ok_or_else(|| "macOS NSStatusItem 不可用".to_owned())?;
+        status_item.setLength(if collapsed { 0.0 } else { -1.0 });
+        Ok::<(), String>(())
+    })
+    .map_err(|error| error.to_string())?
+}
+
+/// 多状态项应用应给每个长期槽设置稳定 autosaveName。设置后立即用原生
+/// length=0 折叠初始空槽，避免八个 18px 空白按钮闪现在菜单栏。
+fn initialize_native_status_slot<R: Runtime>(
+    tray: &tauri::tray::TrayIcon<R>,
+    autosave_name: String,
+) -> Result<(), String> {
+    tray.with_inner_tray_icon(move |inner| {
+        let status_item = inner
+            .ns_status_item()
+            .ok_or_else(|| "macOS NSStatusItem 不可用".to_owned())?;
+        let autosave_name = NSString::from_str(&autosave_name);
+        status_item.setAutosaveName(Some(&autosave_name));
+        // autosaveName 会恢复上次持久化的可见性；旧测试版可能把它存成 false。
+        // 固定槽必须始终留在 ControlCenter 集合中，隐藏只由零长度承担。
+        status_item.setVisible(true);
+        status_item.setLength(0.0);
+        Ok::<(), String>(())
+    })
+    .map_err(|error| error.to_string())?
+}
+
 fn normalized_percent(value: Option<f64>) -> Option<u8> {
     value
         .filter(|value| value.is_finite())
@@ -190,36 +243,65 @@ pub fn update_status_items(
     }
 
     eprintln!("Metrik status items requested: {}", agents.join(","));
-    for spec in STATUS_ITEMS {
-        let Some(tray) = app.tray_by_id(spec.id) else {
-            return Err(format!("macOS {} 菜单栏状态项不存在", spec.name));
-        };
-        let selected_index = agents.iter().position(|agent| agent == spec.id);
-        tray.set_visible(selected_index.is_some())
-            .map_err(|error| error.to_string())?;
-        eprintln!(
-            "Metrik status item {} visible={}",
-            spec.id,
-            selected_index.is_some()
-        );
-        let Some(index) = selected_index else {
+    let mut slots = STATUS_SLOTS.lock().unwrap();
+    // 8 个状态槽在启动时一次性建齐（见 setup_tray），会话内只更新内容并通过
+    // NSStatusItem.length 在 0 / variable 之间折叠和展开：
+    // macOS 26 的 ControlCenter 给状态项密集编号并异步托管，会话中途新建或
+    // 删除重建都可能被静默拒托管或显示错位，isVisible 重新显示还会改变顺序。
+    // 取消勾选会折叠并清空槽位，但底层 NSStatusItem 始终可见、存活且不离队。
+    for index in 0..slots.len() {
+        let Some(tray) = app.tray_by_id(&slots[index].tray_id) else {
+            eprintln!("Metrik 菜单栏状态槽 {} 不存在，跳过", slots[index].tray_id);
             continue;
         };
-        let item_remaining = remaining[index];
-        let item_stale = stale[index];
-        tray.set_title(Some(status_item_title(item_remaining, item_stale)))
-            .map_err(|error| error.to_string())?;
-        let label = match normalized_percent(item_remaining) {
-            Some(percent) => format!("{} {percent}% 剩余", spec.name),
-            None => format!("{} 配额不可用", spec.name),
-        };
-        let suffix = if item_stale {
-            " · 数据可能已过期"
-        } else {
-            ""
-        };
-        tray.set_tooltip(Some(format!("Metrik · {label}{suffix}")))
-            .map_err(|error| error.to_string())?;
+        if index < agents.len() {
+            // 槽位 0 最先创建、位置最靠右；把选择列表末尾的 Agent 放槽 0，
+            // 菜单栏从左到右就与选择列表的顺序一致。
+            let position = agents.len() - 1 - index;
+            let agent = &agents[position];
+            let Some(spec) = STATUS_ITEMS.iter().find(|spec| spec.id == agent) else {
+                eprintln!("Metrik 未知 Agent {agent}，跳过菜单栏状态项");
+                continue;
+            };
+            let agent_changed = slots[index].agent.as_deref() != Some(agent.as_str());
+            if agent_changed {
+                // 换 Agent 时先折叠，避免 icon/title 分步更新期间短暂组合出旧标题
+                // + 新图标；状态项仍在托管集合中，物理顺序不变。
+                set_native_status_slot_collapsed(&tray, true)?;
+                let icon = provider_status_icon(spec.icon)?;
+                tray.set_icon_with_as_template(Some(icon), true)
+                    .map_err(|error| error.to_string())?;
+            }
+            let item_remaining = remaining[position];
+            let item_stale = stale[position];
+            tray.set_title(Some(status_item_title(item_remaining, item_stale)))
+                .map_err(|error| error.to_string())?;
+            let label = match normalized_percent(item_remaining) {
+                Some(percent) => format!("{} {percent}% 剩余", spec.name),
+                None => format!("{} 配额不可用", spec.name),
+            };
+            let suffix = if item_stale {
+                " · 数据可能已过期"
+            } else {
+                ""
+            };
+            tray.set_tooltip(Some(format!("Metrik · {label}{suffix}")))
+                .map_err(|error| error.to_string())?;
+            slots[index].agent = Some(agent.clone());
+            set_native_status_slot_collapsed(&tray, false)?;
+            eprintln!("Metrik status slot {} = {}", slots[index].tray_id, agent);
+        } else if slots[index].agent.take().is_some() {
+            // tray-icon 0.24.1 在 macOS 上把 set_title(None) 实现为 no-op，必须传
+            // 空字符串才能真正覆盖旧百分比；否则就会留下无图标的 “97%” 幻影。
+            set_native_status_slot_collapsed(&tray, true)?;
+            tray.set_title(Some(""))
+                .map_err(|error| error.to_string())?;
+            tray.set_icon_with_as_template(None, true)
+                .map_err(|error| error.to_string())?;
+            tray.set_tooltip(Some("Metrik"))
+                .map_err(|error| error.to_string())?;
+            eprintln!("Metrik status slot {} cleared", slots[index].tray_id);
+        }
     }
 
     Ok(())
@@ -500,23 +582,16 @@ fn remember_tray_rect(window_scale: f64, rect: Rect) {
     *TRAY_RECT.lock().unwrap() = Some((position.x, position.y, size.width, size.height));
 }
 
-fn build_status_item(
-    app: &mut tauri::App,
-    spec: StatusItemSpec,
-    icon: Image<'static>,
-    visible: bool,
-) -> tauri::Result<()> {
-    // 每个 Agent 状态项都能独立打开同一个面板，右键菜单也保持一致。
+fn build_status_slot(app: &AppHandle, tray_id: &str, slot_index: usize) -> tauri::Result<()> {
+    // 每个状态槽都能独立打开同一个面板，右键菜单也保持一致。
     let toggle = MenuItem::with_id(app, "toggle", "显示 / 隐藏", true, None::<&str>)?;
     let expanded = MenuItem::with_id(app, "expanded", "完整视图", true, None::<&str>)?;
     let settings = MenuItem::with_id(app, "settings", "设置", true, None::<&str>)?;
     let quit = MenuItem::with_id(app, "quit", "退出 Metrik", true, None::<&str>)?;
     let menu = Menu::with_items(app, &[&toggle, &expanded, &settings, &quit])?;
 
-    let tray = TrayIconBuilder::with_id(spec.id)
-        .tooltip(format!("Metrik · {}", spec.name))
-        .title(status_item_title(None, false))
-        .icon(icon)
+    let tray = TrayIconBuilder::with_id(tray_id)
+        .tooltip("Metrik")
         .icon_as_template(true)
         .menu(&menu)
         .show_menu_on_left_click(false)
@@ -557,19 +632,27 @@ fn build_status_item(
             }
         })
         .build(app)?;
-    tray.set_visible(visible)?;
+    initialize_native_status_slot(&tray, status_slot_autosave_name(slot_index))
+        .map_err(|error| tauri::Error::Anyhow(anyhow::Error::msg(error)))?;
     Ok(())
 }
 
 fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
     // Metrik 自己的状态栏语法：每个已选 Agent 一个品牌状态项，只带额度数字。
     // 不复制第三方工具的多账户、重置倒计时或菜单布局。
-    // macOS 会把后创建的状态项放在左侧，所以反向创建，最终视觉顺序与设置列表一致。
-    for spec in STATUS_ITEMS.into_iter().rev() {
-        let icon = provider_status_icon(spec.icon)
-            .map_err(|error| tauri::Error::Anyhow(anyhow::Error::msg(error)))?;
-        let visible = matches!(spec.id, "codex" | "claude");
-        build_status_item(app, spec, icon, visible)?;
+    // 全部槽位在启动时一次建齐并设稳定 autosaveName，之后整个会话只做内容更新
+    // 和原生 length 折叠/展开：
+    // macOS 26 的 ControlCenter 对会话中途新建/删除的状态项会静默拒托管或错位，
+    // 底层 NSStatusItem 绝不删除或重建。
+    let handle = app.app_handle();
+    let mut slots = STATUS_SLOTS.lock().unwrap();
+    for index in 0..STATUS_ITEMS.len() {
+        let tray_id = format!("metrik-status-{index}");
+        build_status_slot(handle, &tray_id, index)?;
+        slots.push(StatusSlot {
+            tray_id,
+            agent: None,
+        });
     }
     Ok(())
 }
@@ -603,5 +686,15 @@ mod tests {
             assert!(icon.rgba().chunks_exact(4).any(|pixel| pixel[3] > 200));
             assert!(icon.rgba().chunks_exact(4).any(|pixel| pixel[3] == 0));
         }
+    }
+
+    #[test]
+    fn status_slots_have_stable_unique_autosave_names() {
+        let names: Vec<_> = (0..STATUS_ITEMS.len())
+            .map(status_slot_autosave_name)
+            .collect();
+        let unique: std::collections::HashSet<_> = names.iter().collect();
+        assert_eq!(unique.len(), STATUS_ITEMS.len());
+        assert_eq!(names[0], "app.metrik.desktop.status-slot-0");
     }
 }

--- a/src-tauri/src/widget_snapshot.rs
+++ b/src-tauri/src/widget_snapshot.rs
@@ -237,11 +237,16 @@ pub fn persist(snapshot: &UsageSnapshot, agent_filter: Option<&[String]>) -> Res
         write_atomically(&path, &bytes)?;
         path
     };
-    reload_timelines();
+    // 这里刻意不 reload 时间线：persist 挂在数据轮询上（索引期可达每秒数次），
+    // 而 reloadTimelines 消耗 WidgetKit 的应用级刷新配额，配额耗尽后 chronod 会把
+    // 所有刷新推迟一小时以上，小组件反而冻在旧快照。常规刷新由时间线策略
+    // （.after(5min)，不占配额）完成；即时 reload 只在用户显式改勾选时触发。
     Ok(path)
 }
 
-fn reload_timelines() {
+/// 用户显式更改 Agent 选择后调用，让小组件立刻反映新选择。次数受用户操作频率
+/// 限制，不会耗尽 WidgetKit 刷新配额。
+pub fn reload_timelines() {
     let Ok(executable) = std::env::current_exe() else {
         return;
     };

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,6 +71,7 @@ import {
   broadcastMacAppearance,
   checkForUpdate,
   closeWindow,
+  getMacAgentSelection,
   getAutostart,
   installUpdate,
   isDesktop,
@@ -4682,13 +4683,29 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    if (!IS_MAC || !isDesktop() || viewMode !== "expanded" || activeNav !== "settings") {
-      return;
-    }
-    // 升级自愈：旧版本可能让设置窗口与隐藏面板各自留下不同 localStorage。
-    // 用户打开设置页时，以屏幕上正在展示的勾选为准主动同步一次，不要求再点一遍。
-    runWindowAction(() => broadcastMacAgentSelection(widgetAgents));
-  }, [activeNav, viewMode]);
+    if (!IS_MAC || !isDesktop()) return undefined;
+    let cancelled = false;
+    // 权威 Agent 选择在后端数据库：设置窗口、菜单栏面板、桌面组件各有独立的
+    // localStorage（WKWebView 不共享），本地值只是缓存。启动时以后端为准，
+    // 任何窗口的旧缓存都不能把已勾选的 Agent 从菜单栏和 WidgetKit 抹掉；
+    // 后端还没保存过（首次启动）时保留本地缓存，由首轮轮询播种。
+    getMacAgentSelection()
+      .then((agents) => {
+        const next = normalizeVisibleAgentList(agents || []);
+        if (cancelled || !next.length) return;
+        setWidgetAgents((current) => {
+          if (current.length === next.length && current.every((id, index) => id === next[index])) {
+            return current;
+          }
+          localStorage.setItem("metrik:widgetAgents", JSON.stringify(next));
+          return next;
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // 边缘挂靠：拖到屏幕上缘自动收起，鼠标碰边弹出。
   useEffect(() => {

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -578,9 +578,17 @@ async function onMacAppearance(handler) {
 async function broadcastMacAgentSelection(agents) {
   if (!isDesktop() || !isMacPlatform()) return;
   const { emit } = await import("@tauri-apps/api/event");
-  // 先让两个 WebView 同帧更新，再持久化为后端权威选择并刷新 WidgetKit。
-  await emit("metrik://mac-agent-selection", { agents }).catch(() => {});
+  // 先落库为后端权威选择，再通知其它窗口；接收窗口收到事件后会立刻刷新
+  // 菜单栏状态项，顺序反过来会让它读到落库前的旧选择。
   await invoke("set_macos_agent_selection", { agents });
+  await emit("metrik://mac-agent-selection", { agents }).catch(() => {});
+}
+
+/// 后端持久化的 macOS Agent 权威选择。各窗口 localStorage 互不同步（独立
+/// WebView），本地值只是缓存；空数组表示后端还没保存过（首次启动）。
+async function getMacAgentSelection() {
+  if (!isDesktop() || !isMacPlatform()) return [];
+  return invoke("get_macos_agent_selection").catch(() => []);
 }
 
 async function onMacAgentSelection(handler) {
@@ -1322,6 +1330,7 @@ export {
   checkForUpdate,
   closeWindow,
   getAutostart,
+  getMacAgentSelection,
   installUpdate,
   isDesktop,
   isMacPlatform,


### PR DESCRIPTION
## 变更
- 修复 macOS Tahoe 菜单栏多状态项丢失、编号碰撞和幻影标题。
- 固定原生状态槽并使用稳定 autosaveName，未选槽以零长度折叠。
- 统一 macOS Agent 选择的 SQLite 权威来源，修复 WidgetKit 刷新配额耗尽。
- 发布版本统一为 0.16.3。

## 根因
Tahoe 的 ControlCenter 会托管并异步编号 NSStatusItem；删除/重建会导致碰撞。另有 tray-icon 0.24.1 的 set_title(None) no-op，导致旧百分比残留。

## 验证
- npm test: 39/39
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test: 204 passed, 6 ignored
- macOS 0.16.3 .app 构建、WidgetKit 嵌入、代码签名验证通过
- Tahoe 原生 3→5→2→5→3 菜单栏回归通过

macOS 已完成本机验收；Windows 由 CI 负责交叉平台构建与测试。