### PR TITLE
feat(linux): support Ubuntu 24.04 x86_64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,10 @@ jobs:
           # 没有实机验收之前不声称可用。
           - platform: macos-latest
             target: aarch64-apple-darwin
+          # Linux 发布基线固定为 Ubuntu 24.04 x86_64；ubuntu-latest 的滚动
+          # 升级不能替代目标系统本身的编译与打包验证。
+          - platform: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -94,6 +98,18 @@ jobs:
         with:
           workspaces: src-tauri
           key: ${{ matrix.platform }}
+
+      - name: Install Linux desktop dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            patchelf
 
       - name: Install frontend dependencies
         run: npm ci
@@ -116,3 +132,15 @@ jobs:
       - name: Test
         run: cargo test
         working-directory: src-tauri
+
+      # cargo test 不能覆盖 WebKitGTK 链接与 bundle 元数据；Linux job 同时
+      # 产出两个正式分发格式作为烟测。PR 不需要更新器私钥。
+      - name: Linux bundle smoke check
+        if: runner.os == 'Linux'
+        run: >-
+          npm run desktop:build --
+          --target x86_64-unknown-linux-gnu
+          --bundles deb,appimage
+          --config '{"bundle":{"createUpdaterArtifacts":false}}'
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: "1"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ Thumbs.db
 .playwright-cli/
 output/
 
+# 本项目持久化的本机构建环境与安装产物；避免使用会在重启后清理的 /tmp。
+.local-env/
+.local-artifacts/
+
 # 本机配置与凭据
 .env
 .env.*

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -52,4 +52,4 @@ This is a small binary and low idle CPU result, but it is not a native-toolkit m
 ## Acceptance boundary
 
 - Verified: Windows 10/11 x64 release executable and both installer formats.
-- Not yet delivered: Windows ARM64, cross-device sync, code signing, and a formal provider-mark permission review before mass commercial distribution.
+- Not yet delivered: Linux release-page artifacts, Windows ARM64, cross-device sync, code signing, and a formal provider-mark permission review before mass commercial distribution. Ubuntu 24.04 x86_64 `.deb` and `.AppImage` generation is CI-validated but is not an upstream release.

--- a/ACCEPTANCE.md
+++ b/ACCEPTANCE.md
@@ -52,4 +52,4 @@ This is a small binary and low idle CPU result, but it is not a native-toolkit m
 ## Acceptance boundary
 
 - Verified: Windows 10/11 x64 release executable and both installer formats.
-- Not yet delivered: macOS/Linux artifacts, Windows ARM64, cross-device sync, code signing, and a formal provider-mark permission review before mass commercial distribution.
+- Not yet delivered: Windows ARM64, cross-device sync, code signing, and a formal provider-mark permission review before mass commercial distribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,21 +16,23 @@ Before changing code:
 
 ## Scope and platform boundaries
 
-Classify each change as `shared`, `macOS shell`, `Windows shell`, or a declared
-combination.
+Classify each change as `shared`, `macOS shell`, `Windows shell`, `Linux shell`,
+or a declared combination.
 
 - Shared work includes adapters, quota parsing, storage, sync, settings
   contracts, and statistics. Implement it behind platform-neutral interfaces
-  and verify it on both operating systems.
+  and verify it on all supported operating systems.
 - Develop and visually approve macOS shell behavior on macOS and Windows shell
-  behavior on Windows. Do not copy platform-specific window forms, materials,
-  positioning, or menu-bar/taskbar behavior between shells.
+  behavior on Windows. Develop Linux shell behavior on Ubuntu 24.04 x86_64,
+  with the default Wayland session as the portability baseline. Do not copy
+  platform-specific window forms, materials, positioning, or menu-bar/taskbar
+  behavior between shells.
 - Platform selection must use native `cfg(target_os)` code and Tauri's
   compile-time platform signal. WebView user-agent detection is not an
   authoritative platform switch.
-- Pull requests should state their affected scope. CI must build and test both
-  Windows and macOS, and every affected shell needs a native smoke check before
-  release.
+- Pull requests should state their affected scope. CI must build and test
+  Windows, macOS, and Ubuntu 24.04 x86_64, and every affected shell needs a
+  native smoke check before release.
 - Do not bump application versions during feature work. Release preparation is
   a separate, serialized maintainer operation.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Metrik 是一款桌面常驻工具，统一查看本机各个 AI 编程 Agent �
 [![Download](https://img.shields.io/github/v/release/keros68/metrik?label=下载&color=success)](https://github.com/keros68/metrik/releases/latest)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 [![Tauri](https://img.shields.io/badge/Tauri-2-24C8DB.svg)](https://tauri.app/)
-[![Platform](https://img.shields.io/badge/Windows%20%7C%20macOS%20%7C%20Ubuntu-0078D6.svg)](#平台支持)
+[![Platform](https://img.shields.io/badge/Windows%20%7C%20macOS%20%7C%20Ubuntu%20CI-0078D6.svg)](#平台支持)
 
-[下载最新版](https://github.com/keros68/metrik/releases/latest)：Windows `.exe`、macOS 通用 `.dmg`、Ubuntu 24.04 x86_64 `.deb` / `.AppImage`。安装包未签名，首次运行需手动放行系统安全校验；Release 页附 SHA256 校验值。
+[下载最新版](https://github.com/keros68/metrik/releases/latest)：Windows `.exe`、macOS 通用 `.dmg`。Ubuntu 24.04 x86_64 的 `.deb` / `.AppImage` 已由 PR CI 构建验证，但在上游 Release 工作流加入 Linux 发布任务前不会出现在 Release 页。安装包未签名，首次运行需手动放行系统安全校验；Release 页附 SHA256 校验值。
 
 <p align="center">
   <img src="design/shot-glass.jpg" alt="Metrik 桌面小组件与配额胶囊条 · 透明档">
@@ -106,7 +106,7 @@ cargo test live_snapshot_smoke_test -- --ignored --nocapture  # 读本机真实�
 ## 已知限制
 
 1. 安装包未做数字签名，首次运行需手动放行；Windows 未预装 WebView2 时安装程序需联网获取运行时。
-2. Linux 预编译包当前仅支持 Ubuntu 24.04 x86_64；其它发行版与架构需自行构建。AppImage 若无法显示托盘，请确认桌面环境已启用 StatusNotifier/AppIndicator 支持。
+2. 上游 Release 当前仅发布 Windows 与 macOS 安装包；Ubuntu 24.04 x86_64 的 `.deb` / `.AppImage` 生成流程已通过 CI 构建与冒烟测试，但目前仍需自行构建。其它发行版与架构尚未验证。AppImage 若无法显示托盘，请确认桌面环境已启用 StatusNotifier/AppIndicator 支持。
 3. Antigravity 需对应 IDE 处于运行状态才有数据。
 4. 首次索引大体量日志会占用一段 CPU 与磁盘，界面可正常操作，未覆盖完整历史的数值会标注说明。
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Metrik 是一款桌面常驻工具，统一查看本机各个 AI 编程 Agent �
 [![Download](https://img.shields.io/github/v/release/keros68/metrik?label=下载&color=success)](https://github.com/keros68/metrik/releases/latest)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 [![Tauri](https://img.shields.io/badge/Tauri-2-24C8DB.svg)](https://tauri.app/)
-[![Platform](https://img.shields.io/badge/Windows%20%7C%20macOS-0078D6.svg)](#已知限制)
+[![Platform](https://img.shields.io/badge/Windows%20%7C%20macOS%20%7C%20Ubuntu-0078D6.svg)](#平台支持)
 
-[下载最新版](https://github.com/keros68/metrik/releases/latest)：Windows `.exe`、macOS 通用 `.dmg`。安装包未签名，首次运行需手动放行系统安全校验；Release 页附 SHA256 校验值。
+[下载最新版](https://github.com/keros68/metrik/releases/latest)：Windows `.exe`、macOS 通用 `.dmg`、Ubuntu 24.04 x86_64 `.deb` / `.AppImage`。安装包未签名，首次运行需手动放行系统安全校验；Release 页附 SHA256 校验值。
 
 <p align="center">
   <img src="design/shot-glass.jpg" alt="Metrik 桌面小组件与配额胶囊条 · 透明档">
@@ -38,6 +38,7 @@ Metrik 是一款桌面常驻工具，统一查看本机各个 AI 编程 Agent �
 
 - Windows：320 × 320 桌面小组件，可收缩为横向或纵向配额胶囊条；支持深色 / 浅色 / 透明三档玻璃材质、0.75–2.0 缩放、边缘自动隐藏与置顶常驻。
 - macOS：菜单栏状态项与面板、原生 WidgetKit 桌面小组件，点击菜单栏项目可展开完整统计页面。
+- Ubuntu 24.04 x86_64：紧凑卡片、贴合内容的横向 / 纵向配额胶囊条、完整统计视图与系统托盘；组件使用 CSS 玻璃回退。X11 会话支持按形态记忆位置与边缘自动隐藏；Wayland 下由桌面合成器管理窗口位置。置顶后控件全部失活，鼠标进入时可按设置立即降低透明度或完全隐藏；从托盘打开设置后才能取消置顶。
 
 ## 支持的 Agent
 
@@ -58,7 +59,7 @@ Metrik 是一款桌面常驻工具，统一查看本机各个 AI 编程 Agent �
 ## 核心功能
 
 1. **配额卡片**：各 Agent 剩余额度、进度、重置倒计时与消耗节奏预估。主数值取余量最低的窗口，日常是 5 小时，更长周期的窗口告急时改取该窗口。
-2. **配额胶囊条（Windows）**：收缩成一根横条或竖条，每格只有图标与剩余占比，固定、横竖切换、还原这些按钮平时收起，点「…」就地展开；展示哪些 Agent、按什么排序可配置，卡片与胶囊条各自独立。
+2. **配额胶囊条（Windows / Ubuntu）**：收缩成一根横条或竖条，每格只有图标与剩余占比，固定、横竖切换、还原这些按钮平时收起，点「…」就地展开；展示哪些 Agent、按什么排序可配置，卡片与胶囊条各自独立。
 3. **统计与报表**：26 周热力图、周趋势折线、Agent 占比环形图、项目走势；用量页以项目为主视图（占比环形 + 排名列表），点击项目进入该项目的会话明细，项目总表与会话明细都可导出 CSV。项目按各 Agent 记录的工作目录归集，默认向上合并到 git 仓库根，也可手动登记项目根或隐藏目录；读不到目录的用量单独列出。完整面板分概览、用量、报告、设置四页，主题可跟随系统或手动指定。
 4. **多设备同步**：指定共享文件夹（坚果云 / OneDrive / Syncthing 均可），各设备导出近 30 天统计事件并自动合并，无云端服务。
 5. **系统能力**：托盘常驻、可选开机自启、单实例运行。更新检查由设置页手动触发，是本应用唯一主动发起的网络请求；更新包经 minisign 校验，签名不符拒绝安装。
@@ -82,7 +83,14 @@ Metrik 是一款桌面常驻工具，统一查看本机各个 AI 编程 Agent �
 
 ## 开发
 
-依赖 Node.js 22+、Rust 1.88+。
+依赖 Node.js 22+、Rust 1.88+。Ubuntu 24.04 还需安装 Tauri 的 WebKitGTK 与 AppIndicator 构建依赖：
+
+```bash
+sudo apt-get update
+sudo apt-get install --no-install-recommends \
+  build-essential curl wget file libssl-dev libwebkit2gtk-4.1-dev \
+  libayatana-appindicator3-dev librsvg2-dev libxdo-dev patchelf
+```
 
 ```bash
 npm install
@@ -98,7 +106,7 @@ cargo test live_snapshot_smoke_test -- --ignored --nocapture  # 读本机真实�
 ## 已知限制
 
 1. 安装包未做数字签名，首次运行需手动放行；Windows 未预装 WebView2 时安装程序需联网获取运行时。
-2. 仅提供 Windows 与 macOS 预编译包，Linux 需自行构建。
+2. Linux 预编译包当前仅支持 Ubuntu 24.04 x86_64；其它发行版与架构需自行构建。AppImage 若无法显示托盘，请确认桌面环境已启用 StatusNotifier/AppIndicator 支持。
 3. Antigravity 需对应 IDE 处于运行状态才有数据。
 4. 首次索引大体量日志会占用一段 CPU 与磁盘，界面可正常操作，未覆盖完整历史的数值会标注说明。
 

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -216,12 +216,14 @@ change.
 - A pinned compact or strip surface responds immediately to pointer hover. The
   user can choose either a configurable opacity or complete visual hiding; it
   restores immediately on pointer exit so an always-on-top monitor does not
-  visually obscure the desktop beneath it. On X11, hover appearance is driven
-  by a dedicated native `XQueryPointer` connection and physical window bounds,
-  independent of WebKit's input delivery after the surface becomes transparent.
-  Wayland deliberately withholds global pointer coordinates, so it uses local
-  window-boundary events and retains a visually imperceptible input surface for
-  complete hiding.
+  visually obscure the desktop beneath it. On X11, complete hiding also removes
+  the native window from cursor hit-testing so the invisible surface never
+  blocks clicks intended for the desktop or another application. Hover
+  appearance and restoration are driven by a dedicated native `XQueryPointer`
+  connection and physical window bounds, independent of WebKit input delivery
+  after the surface becomes transparent and click-through. Wayland deliberately
+  withholds global pointer coordinates, so it uses local window-boundary events
+  and retains a visually imperceptible input surface for complete hiding.
 - Linux pinning is a read-only presentation surface: its controls and drag
   regions are inactive, and only Linux Settings or the Linux tray menu can
   cancel pinning. The native window retains pointer input solely to drive

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -200,6 +200,40 @@ change.
 - Provider names are not repeated as menu-bar text, and the menu structure must
   not copy another product's layout or multi-account detail.
 
+### Linux
+
+- The supported Linux release baseline is Ubuntu 24.04 on x86_64. Releases
+  provide both a Debian package and an AppImage built on that exact runner.
+- Linux uses the floating compact card, horizontal/vertical quota strip, and
+  expanded view. It uses the shared content hierarchy, not Windows DWM APIs or
+  macOS panel/WidgetKit behavior.
+- The default Ubuntu Wayland session remains the safe window-management
+  baseline: the compositor owns placement because Wayland deliberately
+  withholds global window and pointer coordinates. Under X11, compact,
+  horizontal-strip, and vertical-strip positions are persisted independently;
+  invalid off-screen positions are rejected, and edge auto-hide is enabled.
+  Always-on-top remains a best-effort compositor request.
+- A pinned compact or strip surface responds immediately to pointer hover. The
+  user can choose either a configurable opacity or complete visual hiding; it
+  restores immediately on pointer exit so an always-on-top monitor does not
+  visually obscure the desktop beneath it. On X11, hover appearance is driven
+  by a dedicated native `XQueryPointer` connection and physical window bounds,
+  independent of WebKit's input delivery after the surface becomes transparent.
+  Wayland deliberately withholds global pointer coordinates, so it uses local
+  window-boundary events and retains a visually imperceptible input surface for
+  complete hiding.
+- Linux pinning is a read-only presentation surface: its controls and drag
+  regions are inactive, and only Linux Settings or the Linux tray menu can
+  cancel pinning. The native window retains pointer input solely to drive
+  immediate hover appearance; content controls must never receive those events.
+- Compact and strip surfaces use the CSS glass fallback. Linux desktop stacks
+  do not expose one blur protocol with consistent WebKitGTK behavior, so a
+  successful-looking platform effect must not be treated as proof of native
+  blur.
+- Closing the main window keeps the application in the system tray when the
+  desktop exposes StatusNotifier/AppIndicator items. The tray menu remains the
+  explicit way to restore the window or quit.
+
 ## Window state and statistics
 
 - Pinning belongs only to floating forms. Expanded mode is always a normal

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -216,12 +216,13 @@ change.
 - A pinned compact or strip surface responds immediately to pointer hover. The
   user can choose either a configurable opacity or complete visual hiding; it
   restores immediately on pointer exit so an always-on-top monitor does not
-  visually obscure the desktop beneath it. On X11, complete hiding also removes
-  the native window from cursor hit-testing so the invisible surface never
-  blocks clicks intended for the desktop or another application. Hover
-  appearance and restoration are driven by a dedicated native `XQueryPointer`
-  connection and physical window bounds, independent of WebKit input delivery
-  after the surface becomes transparent and click-through. Wayland deliberately
+  visually obscure the desktop beneath it. On X11, both fade and complete-hide
+  remove the native window from cursor hit-testing while hovered, so the passive
+  pinned surface never blocks clicks intended for the desktop or another
+  application. Hover appearance and restoration are driven by a dedicated
+  native `XQueryPointer` connection and physical window bounds, independent of
+  WebKit input delivery after the surface becomes transparent and click-through.
+  Wayland deliberately
   withholds global pointer coordinates, so it uses local window-boundary events
   and retains a visually imperceptible input surface for complete hiding.
 - Linux pinning is a read-only presentation surface: its controls and drag

--- a/scripts/prepare-macos-widget.mjs
+++ b/scripts/prepare-macos-widget.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 // Tauri runs beforeBundleCommand on every release platform. WidgetKit only
-// exists on macOS, so Windows intentionally has nothing to prepare.
+// exists on macOS, so Windows and Linux intentionally have nothing to prepare.
 if (process.platform === "darwin") {
   const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
   execFileSync("/bin/zsh", [path.join(scriptDirectory, "build-macos-widget-extension.sh")], {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2199,6 +2199,8 @@ dependencies = [
  "anyhow",
  "chrono",
  "dirs 6.0.0",
+ "gdkx11",
+ "gtk",
  "hex",
  "image",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,12 @@ tauri-plugin-single-instance = "2"
 # 原生 statusLine：委托超时后按进程组终止（killpg），和 Windows 的进程树终止对齐。
 libc = "0.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# 取得 GTK 顶层窗口的 XID 后直接用 XQueryPointer(window)。窗口内相对坐标与
+# X11 几何天然同尺度，避开 HiDPI/多显示器下 GTK 逻辑坐标和根物理坐标混用。
+gtk = "0.18"
+gdkx11 = "0.18"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 # 菜单栏面板：把 main 窗口换成不抢焦点的 NSPanel。crates.io 上没有 Tauri 2 版本，
 # 只能走 git 分支；上游停更时需要自行维护。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,51 +81,12 @@ fn read_linux_startup_position(app: &tauri::AppHandle) -> Option<LinuxStartupPos
     serde_json::from_slice(&contents).ok()
 }
 
-/// One-time compatibility import for positions saved by older Linux builds in
-/// WebKit localStorage. Its UTF-16 value is safe, app-owned coordinate data;
-/// no arbitrary WebView data is read or copied.
-#[cfg(target_os = "linux")]
-fn read_legacy_linux_startup_position(app: &tauri::AppHandle) -> Option<LinuxStartupPosition> {
-    let path = app
-        .path()
-        .app_local_data_dir()
-        .ok()?
-        .join("localstorage/tauri_localhost_0.localstorage");
-    let connection =
-        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
-            .ok()?;
-    let bytes: Vec<u8> = connection
-        .query_row(
-            "SELECT value FROM ItemTable WHERE key = 'metrik:widgetPosition'",
-            [],
-            |row| row.get(0),
-        )
-        .ok()?;
-    let words: Vec<u16> = bytes
-        .chunks_exact(2)
-        .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
-        .collect();
-    let value = String::from_utf16(&words).ok()?;
-    let position: serde_json::Value = serde_json::from_str(&value).ok()?;
-    Some(LinuxStartupPosition {
-        x: position.get("x")?.as_i64()?.try_into().ok()?,
-        y: position.get("y")?.as_i64()?.try_into().ok()?,
-        // Older Linux versions saved the GTK outer origin but set_position
-        // expects the content origin. Mutter's normal frame offset is learned
-        // and persisted precisely after the first move in the new format.
-        offset_x: 0,
-        offset_y: 37,
-    })
-}
-
 #[cfg(target_os = "linux")]
 fn restore_linux_startup_position(app: &tauri::AppHandle) {
     let Some(window) = app.get_webview_window("main") else {
         return;
     };
-    if let Some(position) =
-        read_linux_startup_position(app).or_else(|| read_legacy_linux_startup_position(app))
-    {
+    if let Some(position) = read_linux_startup_position(app) {
         let _ = window.set_position(tauri::PhysicalPosition::new(
             position.x.saturating_add(position.offset_x),
             position.y.saturating_add(position.offset_y),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,8 @@ mod engine;
 #[cfg(target_os = "macos")]
 mod macos;
 mod pi_providers;
+#[cfg(target_os = "linux")]
+mod pinned_hover;
 mod pricing;
 mod projects;
 mod quota;
@@ -24,6 +26,8 @@ use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -42,6 +46,104 @@ struct AppState {
     database_path: PathBuf,
     scan_gate: Arc<Mutex<()>>,
     quota_cache: SharedQuotaCache,
+    #[cfg(target_os = "linux")]
+    pinned_hover_monitor: Arc<pinned_hover::Monitor>,
+}
+
+/// Linux 首窗必须在 WebView 初始化前决定位置，否则 GTK 会先映射默认居中的
+/// 窗口，再由前端 localStorage 移动，造成肉眼可见的闪烁。
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct LinuxStartupPosition {
+    x: i32,
+    y: i32,
+    #[serde(default)]
+    offset_x: i32,
+    #[serde(default)]
+    offset_y: i32,
+}
+
+#[cfg(target_os = "linux")]
+const LINUX_STARTUP_POSITION_FILE: &str = "linux-startup-position.json";
+
+#[cfg(target_os = "linux")]
+fn linux_startup_position_path(app: &tauri::AppHandle) -> Option<PathBuf> {
+    app.path()
+        .app_local_data_dir()
+        .ok()
+        .map(|directory| directory.join(LINUX_STARTUP_POSITION_FILE))
+}
+
+#[cfg(target_os = "linux")]
+fn read_linux_startup_position(app: &tauri::AppHandle) -> Option<LinuxStartupPosition> {
+    let path = linux_startup_position_path(app)?;
+    let contents = fs::read(path).ok()?;
+    serde_json::from_slice(&contents).ok()
+}
+
+/// One-time compatibility import for positions saved by older Linux builds in
+/// WebKit localStorage. Its UTF-16 value is safe, app-owned coordinate data;
+/// no arbitrary WebView data is read or copied.
+#[cfg(target_os = "linux")]
+fn read_legacy_linux_startup_position(app: &tauri::AppHandle) -> Option<LinuxStartupPosition> {
+    let path = app
+        .path()
+        .app_local_data_dir()
+        .ok()?
+        .join("localstorage/tauri_localhost_0.localstorage");
+    let connection =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .ok()?;
+    let bytes: Vec<u8> = connection
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = 'metrik:widgetPosition'",
+            [],
+            |row| row.get(0),
+        )
+        .ok()?;
+    let words: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+        .collect();
+    let value = String::from_utf16(&words).ok()?;
+    let position: serde_json::Value = serde_json::from_str(&value).ok()?;
+    Some(LinuxStartupPosition {
+        x: position.get("x")?.as_i64()?.try_into().ok()?,
+        y: position.get("y")?.as_i64()?.try_into().ok()?,
+        // Older Linux versions saved the GTK outer origin but set_position
+        // expects the content origin. Mutter's normal frame offset is learned
+        // and persisted precisely after the first move in the new format.
+        offset_x: 0,
+        offset_y: 37,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn restore_linux_startup_position(app: &tauri::AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    if let Some(position) =
+        read_linux_startup_position(app).or_else(|| read_legacy_linux_startup_position(app))
+    {
+        let _ = window.set_position(tauri::PhysicalPosition::new(
+            position.x.saturating_add(position.offset_x),
+            position.y.saturating_add(position.offset_y),
+        ));
+    } else {
+        // 首次安装没有位置可恢复时才居中；后续启动永远使用持久化坐标。
+        let _ = window.center();
+    }
+    let _ = window.show();
+}
+
+/// Linux 托盘菜单和前端的置顶状态保持同一份权威值，以便菜单项准确显示
+/// “置顶”或“取消置顶”。该状态只属于 Linux shell，Windows/macOS 不会编译它。
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct LinuxTrayPinMenu {
+    pinned: AtomicBool,
+    item: Mutex<Option<tauri::menu::MenuItem<tauri::Wry>>>,
 }
 
 fn sqlite_sidecar_path(database_path: &Path, suffix: &str) -> PathBuf {
@@ -1067,6 +1169,93 @@ fn set_tray_quota_icon(
     }
 }
 
+/// X11 允许客户端读取和恢复全局窗口坐标；Wayland 刻意不暴露这套能力。
+/// 前端据此决定是否启用位置记忆、钳位与边缘挂靠，而不是把所有 Linux
+/// 会话一律降级。
+#[cfg(target_os = "linux")]
+fn linux_session_supports_global_window_coordinates(
+    session: &str,
+    has_wayland_display: bool,
+    has_x11_display: bool,
+) -> bool {
+    let session = session.to_ascii_lowercase();
+    if session == "wayland" || has_wayland_display {
+        return false;
+    }
+    session == "x11" || has_x11_display
+}
+
+#[cfg(target_os = "linux")]
+#[tauri::command]
+fn linux_supports_global_window_coordinates() -> bool {
+    linux_session_supports_global_window_coordinates(
+        &std::env::var("XDG_SESSION_TYPE").unwrap_or_default(),
+        std::env::var_os("WAYLAND_DISPLAY").is_some(),
+        std::env::var_os("DISPLAY").is_some(),
+    )
+}
+
+/// Configure the pinned widget's native hover watcher. On X11 one long-lived
+/// worker queries window-relative pointer coordinates and changes the GTK
+/// toplevel opacity directly.
+#[cfg(target_os = "linux")]
+#[tauri::command]
+fn configure_pinned_hover(
+    window: tauri::WebviewWindow,
+    state: State<'_, AppState>,
+    enabled: bool,
+    target_opacity: f64,
+) -> bool {
+    pinned_hover::configure(
+        window,
+        Arc::clone(&state.pinned_hover_monitor),
+        enabled,
+        target_opacity,
+    )
+}
+
+/// Synchronize the Linux tray item's label after a settings-page change.
+#[cfg(target_os = "linux")]
+#[tauri::command]
+fn sync_linux_tray_pinned(state: State<'_, LinuxTrayPinMenu>, pinned: bool) {
+    state.pinned.store(pinned, Ordering::Release);
+    if let Ok(item) = state.item.lock() {
+        if let Some(item) = item.as_ref() {
+            let _ = item.set_text(if pinned { "取消置顶" } else { "置顶" });
+        }
+    }
+}
+
+/// Persist the exact GTK outer position and its inner/outer offset whenever a
+/// Linux floating form is moved. This small native file is intentionally
+/// separate from WebKit localStorage so setup can restore it before the first
+/// WebView frame is ever mapped.
+#[cfg(target_os = "linux")]
+#[tauri::command]
+fn persist_linux_startup_position(
+    app: tauri::AppHandle,
+    x: i32,
+    y: i32,
+    offset_x: i32,
+    offset_y: i32,
+) -> Result<(), String> {
+    let Some(path) = linux_startup_position_path(&app) else {
+        return Err("Linux application data directory is unavailable".into());
+    };
+    let position = LinuxStartupPosition {
+        x,
+        y,
+        offset_x,
+        offset_y,
+    };
+    let encoded = serde_json::to_vec(&position).map_err(|error| error.to_string())?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Linux startup position has no parent directory".to_string())?;
+    fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    fs::write(path, encoded).map_err(|error| error.to_string())
+}
+
 #[tauri::command]
 async fn claude_hook_status() -> Result<claude_hook::ClaudeHookStatus, String> {
     tauri::async_runtime::spawn_blocking(|| {
@@ -1257,6 +1446,9 @@ fn update_macos_status_items(
 #[cfg(all(desktop, not(target_os = "macos")))]
 const TRAY_SHOW_EXPANDED: &str = "tray://show-expanded";
 
+#[cfg(target_os = "linux")]
+const TRAY_SET_PINNED: &str = "tray://set-pinned";
+
 #[cfg(all(desktop, not(target_os = "macos")))]
 fn toggle_main_window(app: &tauri::AppHandle) {
     let Some(window) = app.get_webview_window("main") else {
@@ -1281,9 +1473,19 @@ fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
 
     let toggle = MenuItem::with_id(app, "toggle", "显示 / 隐藏", true, None::<&str>)?;
     let expanded = MenuItem::with_id(app, "expanded", "显示完整视图", true, None::<&str>)?;
+    #[cfg(target_os = "linux")]
+    let pinned = MenuItem::with_id(app, "pinned", "置顶", true, None::<&str>)?;
     let separator = PredefinedMenuItem::separator(app)?;
     let quit = MenuItem::with_id(app, "quit", "退出 Metrik", true, None::<&str>)?;
+    #[cfg(target_os = "linux")]
+    let menu = Menu::with_items(app, &[&toggle, &expanded, &pinned, &separator, &quit])?;
+    #[cfg(not(target_os = "linux"))]
     let menu = Menu::with_items(app, &[&toggle, &expanded, &separator, &quit])?;
+
+    #[cfg(target_os = "linux")]
+    if let Ok(mut item) = app.state::<LinuxTrayPinMenu>().item.lock() {
+        *item = Some(pinned.clone());
+    }
 
     let mut tray = TrayIconBuilder::with_id("main")
         .tooltip("Metrik")
@@ -1296,6 +1498,17 @@ fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
             // expanded 时自己会 show + focus，托盘再动窗口只会抢出闪帧。
             "expanded" => {
                 let _ = app.emit(TRAY_SHOW_EXPANDED, ());
+            }
+            #[cfg(target_os = "linux")]
+            "pinned" => {
+                let state = app.state::<LinuxTrayPinMenu>();
+                let next = !state.pinned.fetch_xor(true, Ordering::AcqRel);
+                if let Ok(item) = state.item.lock() {
+                    if let Some(item) = item.as_ref() {
+                        let _ = item.set_text(if next { "取消置顶" } else { "置顶" });
+                    }
+                }
+                let _ = app.emit(TRAY_SET_PINNED, next);
             }
             "quit" => app.exit(0),
             _ => {}
@@ -1363,6 +1576,12 @@ pub fn run() {
             // 与 Windows 的"单窗口变形 + 自绘按钮"完全分开。
             #[cfg(target_os = "macos")]
             macos::setup(app)?;
+
+            #[cfg(target_os = "linux")]
+            app.manage(LinuxTrayPinMenu::default());
+
+            #[cfg(target_os = "linux")]
+            restore_linux_startup_position(app.app_handle());
 
             #[cfg(all(desktop, not(target_os = "macos")))]
             setup_tray(app)?;
@@ -1447,6 +1666,8 @@ pub fn run() {
                 database_path,
                 scan_gate: Arc::new(Mutex::new(())),
                 quota_cache: Arc::new(Mutex::new(HashMap::new())),
+                #[cfg(target_os = "linux")]
+                pinned_hover_monitor: Arc::new(pinned_hover::Monitor::default()),
             });
             Ok(())
         })
@@ -1483,6 +1704,14 @@ pub fn run() {
             configure_qwen_cookie,
             set_taskbar_button,
             set_tray_quota_icon,
+            #[cfg(target_os = "linux")]
+            linux_supports_global_window_coordinates,
+            #[cfg(target_os = "linux")]
+            configure_pinned_hover,
+            #[cfg(target_os = "linux")]
+            sync_linux_tray_pinned,
+            #[cfg(target_os = "linux")]
+            persist_linux_startup_position,
             set_native_theme,
             open_expanded_window,
             set_macos_desktop_widget_visible,
@@ -1529,6 +1758,23 @@ pub fn publish_widget_snapshot_from_database(_database_path: &Path) -> Result<Pa
 mod tests {
     use super::*;
     use rusqlite::Connection;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_global_coordinates_are_enabled_only_for_x11_sessions() {
+        assert!(linux_session_supports_global_window_coordinates(
+            "x11", false, true
+        ));
+        assert!(linux_session_supports_global_window_coordinates(
+            "", false, true
+        ));
+        assert!(!linux_session_supports_global_window_coordinates(
+            "wayland", true, true
+        ));
+        assert!(!linux_session_supports_global_window_coordinates(
+            "", true, true
+        ));
+    }
 
     struct TestDirectory(PathBuf);
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,5 +21,16 @@ fn main() {
         return;
     }
 
+    // Ubuntu 24.04's WebKitGTK can select its DMA-BUF renderer before Tauri
+    // creates the first window.  With NVIDIA's proprietary driver that path
+    // may fail every GBM allocation, leaving the tray alive while the WebView
+    // never paints.  Set the documented WebKitGTK compatibility switch here,
+    // before any GTK/WebKit initialization.  An explicit caller-provided value
+    // still wins so developers can retest the renderer as drivers evolve.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     metrik_lib::run();
 }

--- a/src-tauri/src/pinned_hover.rs
+++ b/src-tauri/src/pinned_hover.rs
@@ -4,6 +4,8 @@ use tauri::WebviewWindow;
 
 #[cfg(target_os = "linux")]
 const HOVER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(8);
+#[cfg(target_os = "linux")]
+const IDLE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
 
 /// One long-lived hover worker per application process. Reconfiguring pinning
 /// only changes atomics; it never creates competing X11 clients or lets a stale
@@ -27,12 +29,12 @@ pub fn configure(
     {
         if !super::linux_supports_global_window_coordinates() {
             monitor.enabled.store(false, Ordering::Release);
-            set_native_opacity(&window, 1.0);
+            apply_native_hover_state(&window, false, 1.0);
             return false;
         }
         let Some(window_id) = x11_window_id(&window) else {
             monitor.enabled.store(false, Ordering::Release);
-            set_native_opacity(&window, 1.0);
+            apply_native_hover_state(&window, false, 1.0);
             return false;
         };
         monitor.window_id.store(window_id, Ordering::Release);
@@ -42,12 +44,12 @@ pub fn configure(
 
         if !enabled {
             monitor.enabled.store(false, Ordering::Release);
-            set_native_opacity(&window, 1.0);
+            apply_native_hover_state(&window, false, 1.0);
             return false;
         }
         if !ensure_worker(window.clone(), Arc::clone(&monitor)) {
             monitor.enabled.store(false, Ordering::Release);
-            set_native_opacity(&window, 1.0);
+            apply_native_hover_state(&window, false, 1.0);
             return false;
         }
         // Repeated startup assertions are intentionally idempotent: do not
@@ -107,40 +109,77 @@ fn watch_x11_pointer(window: WebviewWindow, monitor: Arc<Monitor>, pointer: X11P
     let mut last_window_id = 0;
     let mut last_target_bits = 1.0_f64.to_bits();
     loop {
+        if !monitor.enabled.load(Ordering::Acquire) {
+            if last_inside {
+                apply_native_hover_state(&window, false, 1.0);
+                last_inside = false;
+            }
+            std::thread::sleep(IDLE_POLL_INTERVAL);
+            continue;
+        }
+
         let visible = match window.is_visible() {
             Ok(visible) => visible,
             Err(_) => break,
         };
-        let enabled = monitor.enabled.load(Ordering::Acquire) && visible;
+        if !visible {
+            if last_inside {
+                apply_native_hover_state(&window, false, 1.0);
+                last_inside = false;
+            }
+            std::thread::sleep(IDLE_POLL_INTERVAL);
+            continue;
+        }
+
         let window_id = monitor.window_id.load(Ordering::Acquire);
         let target_bits = monitor.target_opacity_bits.load(Ordering::Acquire);
-        let inside = if enabled {
-            pointer
-                .inside_window(window_id)
-                // A transient X11 query failure keeps the previous state so
-                // the widget never flashes back to full opacity for one poll.
-                .unwrap_or(last_inside)
-        } else {
-            false
-        };
+        let inside = pointer
+            .inside_window(window_id)
+            // A transient X11 query failure keeps the previous state so the
+            // widget never flashes back to full opacity for one poll.
+            .unwrap_or(last_inside);
 
         if inside != last_inside
             || window_id != last_window_id
             || (inside && target_bits != last_target_bits)
         {
-            let opacity = if inside {
-                f64::from_bits(target_bits).clamp(0.0, 1.0)
-            } else {
-                1.0
-            };
-            set_native_opacity(&window, opacity);
+            apply_native_hover_state(&window, inside, f64::from_bits(target_bits));
             last_inside = inside;
             last_window_id = window_id;
             last_target_bits = target_bits;
         }
         std::thread::sleep(HOVER_POLL_INTERVAL);
     }
-    set_native_opacity(&window, 1.0);
+    apply_native_hover_state(&window, false, 1.0);
+}
+
+#[cfg(target_os = "linux")]
+fn hover_state(inside: bool, target_opacity: f64) -> (f64, bool) {
+    let opacity = if inside {
+        target_opacity.clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    // Opacity alone only changes painting: an invisible X11 window still owns
+    // its input region and swallows clicks. Complete-hide mode must therefore
+    // disable native cursor hit-testing until the global pointer leaves the
+    // unchanged window bounds. Fade mode deliberately keeps normal hit-testing.
+    (opacity, inside && opacity == 0.0)
+}
+
+#[cfg(target_os = "linux")]
+fn apply_native_hover_state(window: &WebviewWindow, inside: bool, target_opacity: f64) {
+    let (opacity, ignore_cursor_events) = hover_state(inside, target_opacity);
+
+    if ignore_cursor_events {
+        // Hide first, then expose the desktop underneath to input. On restore,
+        // reverse the order so a visible widget never remains click-through.
+        set_native_opacity(window, opacity);
+        let _ = window.set_ignore_cursor_events(true);
+    } else {
+        let _ = window.set_ignore_cursor_events(false);
+        set_native_opacity(window, opacity);
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -288,7 +327,7 @@ impl Drop for X11Pointer {
 
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
-    use super::point_inside_window;
+    use super::{hover_state, point_inside_window};
 
     #[test]
     fn window_hit_test_uses_half_open_relative_bounds() {
@@ -302,5 +341,20 @@ mod tests {
     fn negative_relative_coordinates_are_outside() {
         assert!(!point_inside_window(-1, 0, 320, 320));
         assert!(!point_inside_window(0, -1, 320, 320));
+    }
+
+    #[test]
+    fn complete_hide_disables_native_cursor_hit_testing() {
+        assert_eq!(hover_state(true, 0.0), (0.0, true));
+    }
+
+    #[test]
+    fn fade_keeps_native_cursor_hit_testing() {
+        assert_eq!(hover_state(true, 0.35), (0.35, false));
+    }
+
+    #[test]
+    fn pointer_exit_restores_visibility_and_hit_testing() {
+        assert_eq!(hover_state(false, 0.0), (1.0, false));
     }
 }

--- a/src-tauri/src/pinned_hover.rs
+++ b/src-tauri/src/pinned_hover.rs
@@ -160,11 +160,11 @@ fn hover_state(inside: bool, target_opacity: f64) -> (f64, bool) {
     } else {
         1.0
     };
-    // Opacity alone only changes painting: an invisible X11 window still owns
-    // its input region and swallows clicks. Complete-hide mode must therefore
-    // disable native cursor hit-testing until the global pointer leaves the
-    // unchanged window bounds. Fade mode deliberately keeps normal hit-testing.
-    (opacity, inside && opacity == 0.0)
+    // Opacity only controls painting: both fade and complete-hide are passive
+    // presentation modes and must let clicks reach the desktop underneath.
+    // The independent XQueryPointer worker still knows when the global pointer
+    // leaves the unchanged bounds and restores normal hit-testing immediately.
+    (opacity, inside)
 }
 
 #[cfg(target_os = "linux")]
@@ -349,8 +349,8 @@ mod tests {
     }
 
     #[test]
-    fn fade_keeps_native_cursor_hit_testing() {
-        assert_eq!(hover_state(true, 0.35), (0.35, false));
+    fn fade_disables_native_cursor_hit_testing() {
+        assert_eq!(hover_state(true, 0.35), (0.35, true));
     }
 
     #[test]

--- a/src-tauri/src/pinned_hover.rs
+++ b/src-tauri/src/pinned_hover.rs
@@ -1,0 +1,306 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use tauri::WebviewWindow;
+
+#[cfg(target_os = "linux")]
+const HOVER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(8);
+
+/// One long-lived hover worker per application process. Reconfiguring pinning
+/// only changes atomics; it never creates competing X11 clients or lets a stale
+/// watcher overwrite a newer setting.
+#[derive(Default)]
+pub struct Monitor {
+    enabled: AtomicBool,
+    target_opacity_bits: AtomicU64,
+    window_id: AtomicU64,
+    started: AtomicBool,
+    available: AtomicBool,
+}
+
+pub fn configure(
+    window: WebviewWindow,
+    monitor: Arc<Monitor>,
+    enabled: bool,
+    target_opacity: f64,
+) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        if !super::linux_supports_global_window_coordinates() {
+            monitor.enabled.store(false, Ordering::Release);
+            set_native_opacity(&window, 1.0);
+            return false;
+        }
+        let Some(window_id) = x11_window_id(&window) else {
+            monitor.enabled.store(false, Ordering::Release);
+            set_native_opacity(&window, 1.0);
+            return false;
+        };
+        monitor.window_id.store(window_id, Ordering::Release);
+        monitor
+            .target_opacity_bits
+            .store(target_opacity.clamp(0.0, 1.0).to_bits(), Ordering::Release);
+
+        if !enabled {
+            monitor.enabled.store(false, Ordering::Release);
+            set_native_opacity(&window, 1.0);
+            return false;
+        }
+        if !ensure_worker(window.clone(), Arc::clone(&monitor)) {
+            monitor.enabled.store(false, Ordering::Release);
+            set_native_opacity(&window, 1.0);
+            return false;
+        }
+        // Repeated startup assertions are intentionally idempotent: do not
+        // force opacity back to 1 between two identical pinned=true calls.
+        monitor.enabled.store(true, Ordering::Release);
+        monitor.available.load(Ordering::Acquire)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (window, monitor, enabled, target_opacity);
+        false
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_worker(window: WebviewWindow, monitor: Arc<Monitor>) -> bool {
+    if monitor.available.load(Ordering::Acquire) {
+        return true;
+    }
+    if monitor
+        .started
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return monitor.available.load(Ordering::Acquire);
+    }
+
+    let (ready_sender, ready_receiver) = std::sync::mpsc::sync_channel(1);
+    let worker_monitor = Arc::clone(&monitor);
+    let spawn_result = std::thread::Builder::new()
+        .name("metrik-pinned-hover".into())
+        .spawn(move || {
+            let Some(pointer) = X11Pointer::connect() else {
+                worker_monitor.started.store(false, Ordering::Release);
+                let _ = ready_sender.send(false);
+                return;
+            };
+            worker_monitor.available.store(true, Ordering::Release);
+            let _ = ready_sender.send(true);
+            watch_x11_pointer(window, Arc::clone(&worker_monitor), pointer);
+            worker_monitor.available.store(false, Ordering::Release);
+            worker_monitor.started.store(false, Ordering::Release);
+        });
+    if spawn_result.is_err() {
+        monitor.started.store(false, Ordering::Release);
+        return false;
+    }
+    ready_receiver
+        .recv_timeout(std::time::Duration::from_millis(250))
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn watch_x11_pointer(window: WebviewWindow, monitor: Arc<Monitor>, pointer: X11Pointer) {
+    let mut last_inside = false;
+    let mut last_window_id = 0;
+    let mut last_target_bits = 1.0_f64.to_bits();
+    loop {
+        let visible = match window.is_visible() {
+            Ok(visible) => visible,
+            Err(_) => break,
+        };
+        let enabled = monitor.enabled.load(Ordering::Acquire) && visible;
+        let window_id = monitor.window_id.load(Ordering::Acquire);
+        let target_bits = monitor.target_opacity_bits.load(Ordering::Acquire);
+        let inside = if enabled {
+            pointer
+                .inside_window(window_id)
+                // A transient X11 query failure keeps the previous state so
+                // the widget never flashes back to full opacity for one poll.
+                .unwrap_or(last_inside)
+        } else {
+            false
+        };
+
+        if inside != last_inside
+            || window_id != last_window_id
+            || (inside && target_bits != last_target_bits)
+        {
+            let opacity = if inside {
+                f64::from_bits(target_bits).clamp(0.0, 1.0)
+            } else {
+                1.0
+            };
+            set_native_opacity(&window, opacity);
+            last_inside = inside;
+            last_window_id = window_id;
+            last_target_bits = target_bits;
+        }
+        std::thread::sleep(HOVER_POLL_INTERVAL);
+    }
+    set_native_opacity(&window, 1.0);
+}
+
+#[cfg(target_os = "linux")]
+fn point_inside_window(pointer_x: i32, pointer_y: i32, width: u32, height: u32) -> bool {
+    pointer_x >= 0
+        && pointer_y >= 0
+        && i64::from(pointer_x) < i64::from(width)
+        && i64::from(pointer_y) < i64::from(height)
+}
+
+#[cfg(target_os = "linux")]
+fn x11_window_id(window: &WebviewWindow) -> Option<u64> {
+    use gtk::prelude::*;
+
+    let gtk_window = window.gtk_window().ok()?;
+    let gdk_window = gtk_window.window()?;
+    let x11_window = gdk_window.downcast::<gdkx11::X11Window>().ok()?;
+    Some(x11_window.xid())
+}
+
+#[cfg(target_os = "linux")]
+fn set_native_opacity(window: &WebviewWindow, opacity: f64) {
+    use gtk::prelude::*;
+
+    let dispatcher = window.clone();
+    let target = window.clone();
+    let _ = dispatcher.run_on_main_thread(move || {
+        if let Ok(gtk_window) = target.gtk_window() {
+            gtk_window.set_opacity(opacity);
+        }
+    });
+}
+
+#[cfg(target_os = "linux")]
+mod xlib {
+    use std::ffi::{c_char, c_int, c_uint, c_ulong};
+
+    #[repr(C)]
+    pub struct Display {
+        _private: [u8; 0],
+    }
+
+    pub type Window = c_ulong;
+
+    #[link(name = "X11")]
+    extern "C" {
+        pub fn XOpenDisplay(display_name: *const c_char) -> *mut Display;
+        pub fn XQueryPointer(
+            display: *mut Display,
+            window: Window,
+            root_return: *mut Window,
+            child_return: *mut Window,
+            root_x_return: *mut c_int,
+            root_y_return: *mut c_int,
+            window_x_return: *mut c_int,
+            window_y_return: *mut c_int,
+            mask_return: *mut c_uint,
+        ) -> c_int;
+        pub fn XGetGeometry(
+            display: *mut Display,
+            drawable: Window,
+            root_return: *mut Window,
+            x_return: *mut c_int,
+            y_return: *mut c_int,
+            width_return: *mut c_uint,
+            height_return: *mut c_uint,
+            border_width_return: *mut c_uint,
+            depth_return: *mut c_uint,
+        ) -> c_int;
+        pub fn XCloseDisplay(display: *mut Display) -> c_int;
+    }
+}
+
+/// The X11 connection is opened, queried and eventually closed by the same
+/// worker thread. GTK owns its own display connection on the main thread.
+#[cfg(target_os = "linux")]
+struct X11Pointer {
+    display: *mut xlib::Display,
+}
+
+#[cfg(target_os = "linux")]
+impl X11Pointer {
+    fn connect() -> Option<Self> {
+        let display = unsafe { xlib::XOpenDisplay(std::ptr::null()) };
+        (!display.is_null()).then_some(Self { display })
+    }
+
+    fn inside_window(&self, window: xlib::Window) -> Option<bool> {
+        let mut root_return = 0;
+        let mut child_return = 0;
+        let mut root_x = 0;
+        let mut root_y = 0;
+        let mut window_x = 0;
+        let mut window_y = 0;
+        let mut mask = 0;
+        let success = unsafe {
+            xlib::XQueryPointer(
+                self.display,
+                window,
+                &mut root_return,
+                &mut child_return,
+                &mut root_x,
+                &mut root_y,
+                &mut window_x,
+                &mut window_y,
+                &mut mask,
+            )
+        };
+        if success == 0 {
+            return None;
+        }
+
+        let mut geometry_root = 0;
+        let mut x = 0;
+        let mut y = 0;
+        let mut width = 0;
+        let mut height = 0;
+        let mut border_width = 0;
+        let mut depth = 0;
+        let geometry_success = unsafe {
+            xlib::XGetGeometry(
+                self.display,
+                window,
+                &mut geometry_root,
+                &mut x,
+                &mut y,
+                &mut width,
+                &mut height,
+                &mut border_width,
+                &mut depth,
+            )
+        };
+        (geometry_success != 0).then_some(point_inside_window(window_x, window_y, width, height))
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for X11Pointer {
+    fn drop(&mut self) {
+        unsafe {
+            xlib::XCloseDisplay(self.display);
+        }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::point_inside_window;
+
+    #[test]
+    fn window_hit_test_uses_half_open_relative_bounds() {
+        assert!(point_inside_window(0, 0, 320, 28));
+        assert!(point_inside_window(319, 27, 320, 28));
+        assert!(!point_inside_window(320, 27, 320, 28));
+        assert!(!point_inside_window(319, 28, 320, 28));
+    }
+
+    #[test]
+    fn negative_relative_coordinates_are_outside() {
+        assert!(!point_inside_window(-1, 0, 320, 320));
+        assert!(!point_inside_window(0, -1, 320, 320));
+    }
+}

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,24 @@
+{
+  "app": {
+    "windows": [
+      {
+        "title": "Metrik",
+        "width": 320,
+        "height": 320,
+        "minWidth": 320,
+        "minHeight": 320,
+        "resizable": false,
+        "maximizable": false,
+        "decorations": false,
+        "transparent": true,
+        "shadow": false,
+        "alwaysOnTop": false,
+        "skipTaskbar": true,
+        "preventOverflow": true,
+        "fullscreen": false,
+        "center": false,
+        "visible": false
+      }
+    ]
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,12 +80,14 @@ import {
   getAutostart,
   installUpdate,
   isDesktop,
+  isLinuxPlatform,
   isMacPlatform,
   isWindowsPlatform,
   minimizeWindow,
   onMacAgentSelection,
   onMacAppearance,
   onScaleFactorChanged,
+  onTrayPinnedChange,
   onTrayShowExpanded,
   openExpandedWindow,
   readStripScale,
@@ -102,10 +104,12 @@ import {
   updateMacStatusItems,
   updateTrayQuotaBadge,
   setWindowGlass,
+  setPinnedHoverTargetOpacity,
   setWindowPinned,
   setWindowUiScale,
   startEdgeDock,
   startPositionMemory,
+  syncLinuxTrayPinned,
   stripContentSize,
   toggleMaximizeWindow,
 } from "./windowClient";
@@ -121,6 +125,7 @@ import {
 const IS_MAC = isMacPlatform();
 // Windows 任务栏托盘可换成余量数字徽标；其它平台没有这条路径。
 const IS_WINDOWS = isWindowsPlatform();
+const IS_LINUX = isLinuxPlatform();
 
 const UsagePlot = lazy(() =>
   import("./UsagePlot").then((module) => ({ default: module.UsagePlot })),
@@ -1222,6 +1227,10 @@ function StripBar({
   // 指针离开自动收回。窗口尺寸本来就跟着内容测量走，这里不用另外调窗。
   const [controlsOpen, setControlsOpen] = useState(false);
   const toggleControls = useCallback(() => setControlsOpen((open) => !open), []);
+  // 一旦进入置顶只读态，立即丢弃胶囊的临时操作面板状态，只保留数据展示。
+  useEffect(() => {
+    if (pinned && IS_LINUX) setControlsOpen(false);
+  }, [pinned]);
   const shellAppearance = glassShellAppearance("strip", {
     transparent,
     glassMode,
@@ -1316,6 +1325,8 @@ function StripBar({
       ref={shellRef}
       className={shellAppearance.className}
       data-glass-surface={shellAppearance.trueAlpha ? "true-alpha" : undefined}
+      data-pinned={pinned && IS_LINUX ? "true" : undefined}
+      inert={pinned && IS_LINUX ? true : undefined}
       {...dragProps}
       {...glassProps}
       onPointerLeave={handlePointerLeave}
@@ -1374,7 +1385,7 @@ function StripBar({
           配额不可用
         </span>
       )}
-      <div className={`strip-controls ${controlsOpen ? "strip-controls--open" : ""}`}>
+      <div className={`strip-controls ${controlsOpen && !(pinned && IS_LINUX) ? "strip-controls--open" : ""}`}>
         {availableUpdate && (
           <span className="strip-control-slot">
             <button
@@ -1396,18 +1407,20 @@ function StripBar({
             className={`status-dot ${loading ? "status-dot--loading" : ""} ${snapshot.loadError ? "status-dot--error" : ""}`}
             aria-hidden="true"
           />
-          <button
-            type="button"
-            className={`strip-button strip-button--menu ${controlsOpen ? "strip-button--active" : ""}`}
-            onClick={toggleControls}
-            aria-label={controlsOpen ? "收起控制按钮" : "展开控制按钮"}
-            aria-expanded={controlsOpen}
-            title={controlsOpen ? "收起控制按钮" : "展开控制按钮"}
-          >
-            <DotsThree size={16} weight={buttonWeight} aria-hidden="true" />
-          </button>
+          {!(pinned && IS_LINUX) && (
+            <button
+              type="button"
+              className={`strip-button strip-button--menu ${controlsOpen ? "strip-button--active" : ""}`}
+              onClick={toggleControls}
+              aria-label={controlsOpen ? "收起控制按钮" : "展开控制按钮"}
+              aria-expanded={controlsOpen}
+              title={controlsOpen ? "收起控制按钮" : "展开控制按钮"}
+            >
+              <DotsThree size={16} weight={buttonWeight} aria-hidden="true" />
+            </button>
+          )}
         </span>
-        {controlsOpen && (
+        {controlsOpen && !(pinned && IS_LINUX) && (
           <>
             {!IS_MAC && (
               <button
@@ -1597,6 +1610,8 @@ function CompactWidget({
       ref={shellRef}
       className={shellAppearance.className}
       data-glass-surface={shellAppearance.trueAlpha ? "true-alpha" : undefined}
+      data-pinned={pinned && IS_LINUX ? "true" : undefined}
+      inert={pinned && IS_LINUX ? true : undefined}
       {...glassPointerProps(shellAppearance.edgeInteractive)}
       style={shellAppearance.style}
     >
@@ -1628,16 +1643,18 @@ function CompactWidget({
             />
           )}
         </div>
-        <WindowActions
-          mode="compact"
-          pinned={pinned}
-          transparent={transparent}
-          glassTint={glassTint}
-          macMinimal={IS_MAC}
-          onToggleMode={onExpand}
-          onTogglePinned={onTogglePinned}
-          onToggleTransparent={onToggleTransparent}
-        />
+        {!(pinned && IS_LINUX) && (
+          <WindowActions
+            mode="compact"
+            pinned={pinned}
+            transparent={transparent}
+            glassTint={glassTint}
+            macMinimal={IS_MAC}
+            onToggleMode={onExpand}
+            onTogglePinned={onTogglePinned}
+            onToggleTransparent={onToggleTransparent}
+          />
+        )}
       </header>
 
       <div className="widget-content">
@@ -2399,8 +2416,20 @@ const GLASS_INK_OPTIONS = [
   { id: "light", label: "白色字" },
 ];
 
+const PINNED_HOVER_OPTIONS = [
+  { id: "fade", label: "降低透明度" },
+  { id: "hide", label: "完全隐藏" },
+];
+// X11 主通道不依赖透明窗口继续接收 DOM 事件，因此隐藏可以真正降到 0；
+// 无全局坐标的本地回落会在 CSS 中保留 0.1% alpha 以维持命中区域。
+const PINNED_HIDDEN_OPACITY = 0;
+
 function normalizeGlassInk(value) {
   return GLASS_INK_OPTIONS.some((option) => option.id === value) ? value : "dark";
+}
+
+function normalizePinnedHoverMode(value) {
+  return PINNED_HOVER_OPTIONS.some((option) => option.id === value) ? value : "fade";
 }
 
 function SliderRow({ label, hint, min, max, step, percent, ariaLabel, onChange }) {
@@ -2424,7 +2453,7 @@ function SliderRow({ label, hint, min, max, step, percent, ariaLabel, onChange }
   );
 }
 
-function AppearanceCard({ theme, onThemeChange, glassAlpha, onGlassAlpha, glassTint, onGlassTint, glassInk, onGlassInk, uiScale, onUiScale, stripScale, onStripScale }) {
+function AppearanceCard({ theme, onThemeChange, glassAlpha, onGlassAlpha, glassTint, onGlassTint, glassInk, onGlassInk, uiScale, onUiScale, stripScale, onStripScale, pinned, onPinnedChange, pinnedHoverMode, onPinnedHoverMode, pinnedHoverOpacity, onPinnedHoverOpacity }) {
   return (
     <div className="settings-card">
       <h2>外观与缩放</h2>
@@ -2445,7 +2474,7 @@ function AppearanceCard({ theme, onThemeChange, glassAlpha, onGlassAlpha, glassT
         ))}
       </div>
       {/* macOS 面板材质跟随系统 vibrancy，不提供组件外观选项；
-          深/浅配色只针对 Windows 的卡片与胶囊。 */}
+          深/浅配色用于 Windows 与 Linux 的卡片和胶囊。 */}
       {!IS_MAC && (
         <div className="settings-subsection">
           <h3>组件外观</h3>
@@ -2522,6 +2551,65 @@ function AppearanceCard({ theme, onThemeChange, glassAlpha, onGlassAlpha, glassT
           percent={Math.round(stripScale * 100)}
           ariaLabel="胶囊缩放百分比"
           onChange={onStripScale}
+        />
+      )}
+      {IS_LINUX && (
+        <div className="settings-subsection">
+          <h3>置顶展示</h3>
+          <p className="settings-muted">
+            置顶后卡片和胶囊的全部控件、拖动与点击都会失活；只能回到此设置取消。
+          </p>
+          <div className="theme-toggle" role="group" aria-label="置顶展示模式">
+            <button
+              type="button"
+              className={!pinned ? "is-selected" : ""}
+              aria-pressed={!pinned}
+              onClick={() => onPinnedChange(false)}
+            >
+              正常交互
+            </button>
+            <button
+              type="button"
+              className={pinned ? "is-selected" : ""}
+              aria-pressed={pinned}
+              onClick={() => onPinnedChange(true)}
+            >
+              置顶只读
+            </button>
+          </div>
+        </div>
+      )}
+      {IS_LINUX && (
+        <div className="settings-subsection">
+          <h3>置顶悬停行为</h3>
+          <p className="settings-muted">
+            鼠标进入置顶卡片或胶囊时立即生效，移开后立即恢复。
+          </p>
+          <div className="theme-toggle" role="group" aria-label="置顶悬停行为">
+            {PINNED_HOVER_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                className={pinnedHoverMode === option.id ? "is-selected" : ""}
+                aria-pressed={pinnedHoverMode === option.id}
+                onClick={() => onPinnedHoverMode(option.id)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      {IS_LINUX && pinnedHoverMode === "fade" && (
+        <SliderRow
+          label="悬停不透明度"
+          hint="数值越低，鼠标经过时越接近完全透明。"
+          min={5}
+          max={90}
+          step={5}
+          percent={Math.round(pinnedHoverOpacity * 100)}
+          ariaLabel="置顶悬停不透明度百分比"
+          onChange={onPinnedHoverOpacity}
         />
       )}
     </div>
@@ -2893,7 +2981,7 @@ function QwenQuotaCard({ onSnapshotRefresh }) {
   );
 }
 
-function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, detectedAgents, trayBadgeEnabled, onToggleTrayBadge, glassAlpha, onGlassAlpha, glassTint, onGlassTint, glassInk, onGlassInk, uiScale, onUiScale, stripScale, onStripScale, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
+function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, detectedAgents, trayBadgeEnabled, onToggleTrayBadge, glassAlpha, onGlassAlpha, glassTint, onGlassTint, glassInk, onGlassInk, uiScale, onUiScale, stripScale, onStripScale, pinned, onPinnedChange, pinnedHoverMode, onPinnedHoverMode, pinnedHoverOpacity, onPinnedHoverOpacity, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
   const [settings, setSettings] = useState(null);
   const [directoryInput, setDirectoryInput] = useState("");
   const [busy, setBusy] = useState(false);
@@ -2996,6 +3084,12 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
               onUiScale={onUiScale}
               stripScale={stripScale}
               onStripScale={onStripScale}
+              pinned={pinned}
+              onPinnedChange={onPinnedChange}
+              pinnedHoverMode={pinnedHoverMode}
+              onPinnedHoverMode={onPinnedHoverMode}
+              pinnedHoverOpacity={pinnedHoverOpacity}
+              onPinnedHoverOpacity={onPinnedHoverOpacity}
             />
             <NativeMacWidgetCard />
           </>
@@ -4432,6 +4526,23 @@ export function App() {
   const [activeNav, setActiveNav] = useState(initialNav);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [pinned, setPinned] = useState(() => localStorage.getItem("metrik:pinned") === "true");
+  const [pinnedHoverMode, setPinnedHoverMode] = useState(() =>
+    normalizePinnedHoverMode(localStorage.getItem("metrik:pinnedHoverMode")),
+  );
+  const [pinnedHoverOpacity, setPinnedHoverOpacity] = useState(() => {
+    const stored = Number(localStorage.getItem("metrik:pinnedHoverOpacity"));
+    return Number.isFinite(stored) && stored >= 0.05 && stored <= 0.9 ? stored : 0.14;
+  });
+  const handlePinnedHoverMode = useCallback((next) => {
+    const value = normalizePinnedHoverMode(next);
+    setPinnedHoverMode(value);
+    localStorage.setItem("metrik:pinnedHoverMode", value);
+  }, []);
+  const handlePinnedHoverOpacity = useCallback((next) => {
+    const value = Math.min(0.9, Math.max(0.05, next));
+    setPinnedHoverOpacity(value);
+    localStorage.setItem("metrik:pinnedHoverOpacity", String(value));
+  }, []);
   // 卡片与胶囊固定使用玻璃材质，用户只在深色、浅色和透明三种外观间选择。
   // expanded 仍通过 viewMode 单独关闭玻璃绘制。
   const transparent = true;
@@ -4508,7 +4619,7 @@ export function App() {
     if (IS_MAC) runWindowAction(() => broadcastMacAppearance({ glassAlpha: next }));
   }, []);
   // 组件外观：深色 HUD / 透亮白（苹果式白 tint + 深色文字）/ 透明（不铺材质，
-  // 直接透出桌面）。用户可选，记住选择。只作用于 Windows 的卡片与胶囊；
+  // 直接透出桌面）。用户可选，记住选择。作用于 Windows 与 Linux 的卡片和胶囊；
   // macOS 面板材质跟随系统 vibrancy，不提供此项。
   const [glassTint, setGlassTint] = useState(() => {
     const legacyDisabled = localStorage.getItem("metrik:transparent") === "false";
@@ -4711,6 +4822,7 @@ export function App() {
     // macOS 面板由系统管层级和位置：不置顶、不恢复坐标。
     if (IS_MAC) return;
     if (pinned) runWindowAction(() => setWindowPinned(true));
+    runWindowAction(() => syncLinuxTrayPinned(pinned));
     // 小组件回到上次摆放的位置（含固定位置），坐标已不在任何屏幕上时居中。
     // strip 形态的启动定位在 strip 专属 effect 里做。
     if (viewMode === "compact") {
@@ -4731,6 +4843,22 @@ export function App() {
   stripOrientationRef.current = stripOrientation;
   // 变形前的形态：applyWindowMode 的 fromMode 用它按形态分别记位，互不污染。
   const previousViewModeRef = useRef(viewMode);
+
+  useLayoutEffect(() => {
+    if (!IS_LINUX) return undefined;
+    const opacity = pinnedHoverMode === "hide"
+      ? PINNED_HIDDEN_OPACITY
+      : pinnedHoverOpacity;
+    setPinnedHoverTargetOpacity(opacity);
+    document.documentElement.style.setProperty("--pinned-hover-target-opacity", String(opacity));
+    document.documentElement.dataset.pinnedHoverMode = pinnedHoverMode;
+  }, [pinnedHoverMode, pinnedHoverOpacity]);
+
+  useEffect(() => () => {
+    if (!IS_LINUX) return;
+    document.documentElement.style.removeProperty("--pinned-hover-target-opacity");
+    delete document.documentElement.dataset.pinnedHoverMode;
+  }, []);
 
   // 拖动后记住小组件位置，供下次启动恢复。
   useEffect(() => {
@@ -5191,7 +5319,9 @@ export function App() {
   useEffect(() => {
     if (IS_MAC) return undefined;
     const stopPromise = onTrayShowExpanded(() => {
-      setActiveNav("overview");
+      // 置顶悬浮层已经完全只读；托盘打开完整视图时直达设置，让用户有一条
+      // 明确且唯一的解除路径。未置顶仍按原行为进入概览。
+      setActiveNav(IS_LINUX && pinnedRef.current ? "settings" : "overview");
       handleWindowMode("expanded");
     });
     return () => {
@@ -5199,14 +5329,30 @@ export function App() {
     };
   }, [handleWindowMode]);
 
-  const handleTogglePinned = useCallback(() => {
-    setPinned((current) => {
-      const next = !current;
-      localStorage.setItem("metrik:pinned", String(next));
-      runWindowAction(() => setWindowPinned(next));
-      return next;
+  const handlePinnedChange = useCallback((next) => {
+    const value = Boolean(next);
+    setPinned(value);
+    localStorage.setItem("metrik:pinned", String(value));
+    // 完整视图始终是普通窗口；在设置中选择“置顶只读”只为下次回到悬浮形态
+    // 预设状态，不能让 1120×760 的设置窗口本身盖住其它应用。
+    runWindowAction(async () => {
+      await setWindowPinned(value && viewModeRef.current !== "expanded");
+      await syncLinuxTrayPinned(value);
     });
   }, []);
+
+  const handleTogglePinned = useCallback(() => {
+    handlePinnedChange(!pinnedRef.current);
+  }, [handlePinnedChange]);
+
+  // Linux 托盘菜单已在原生层先更新了菜单文案；这里把其目标值写入 UI、
+  // localStorage 与窗口层级。Windows/macOS 不订阅该 Linux 专用事件。
+  useEffect(() => {
+    const stopPromise = onTrayPinnedChange((next) => handlePinnedChange(next));
+    return () => {
+      stopPromise.then((stop) => stop?.());
+    };
+  }, [handlePinnedChange]);
 
   // 标题栏的 ◐ 按钮与设置页保持同一模型，只循环深色、浅色、透明三种组件外观。
   // 技术层的 off 只属于 expanded/回落状态，不作为第四种配色暴露。
@@ -5258,24 +5404,26 @@ export function App() {
 
   if (viewMode === "strip" && !IS_MAC) {
     return (
-      <StripBar
-        snapshot={snapshot}
-        agents={stripAgents}
-        pinned={pinned}
-        loading={appBusy}
-        transparent={transparent}
-        glassAlpha={shellGlassAlpha}
-        glassMode={glassMode}
-        glassTint={glassTint}
-        glassInk={glassInk}
-        orientation={stripOrientation}
-        onToggleOrientation={handleToggleStripOrientation}
-        onTogglePinned={handleTogglePinned}
-        onRestore={() => handleWindowMode("compact")}
-        onExpand={() => handleWindowMode("expanded")}
-        availableUpdate={availableUpdate}
-        onOpenUpdate={handleOpenUpdate}
-      />
+      <>
+        <StripBar
+          snapshot={snapshot}
+          agents={stripAgents}
+          pinned={pinned}
+          loading={appBusy}
+          transparent={transparent}
+          glassAlpha={shellGlassAlpha}
+          glassMode={glassMode}
+          glassTint={glassTint}
+          glassInk={glassInk}
+          orientation={stripOrientation}
+          onToggleOrientation={handleToggleStripOrientation}
+          onTogglePinned={handleTogglePinned}
+          onRestore={() => handleWindowMode("compact")}
+          onExpand={() => handleWindowMode("expanded")}
+          availableUpdate={availableUpdate}
+          onOpenUpdate={handleOpenUpdate}
+        />
+      </>
     );
   }
 
@@ -5443,6 +5591,12 @@ export function App() {
             onUiScale={handleUiScale}
             stripScale={stripScale}
             onStripScale={handleStripScale}
+            pinned={pinned}
+            onPinnedChange={handlePinnedChange}
+            pinnedHoverMode={pinnedHoverMode}
+            onPinnedHoverMode={handlePinnedHoverMode}
+            pinnedHoverOpacity={pinnedHoverOpacity}
+            onPinnedHoverOpacity={handlePinnedHoverOpacity}
             theme={theme}
             onThemeChange={handleThemeChange}
             autoUpdateCheck={autoUpdateCheck}

--- a/src/platformDetection.test.js
+++ b/src/platformDetection.test.js
@@ -11,6 +11,10 @@ test("compiled Windows platform wins over a Mac-like webview user-agent", () => 
   assert.equal(detectRuntimePlatform("windows", "Mozilla/5.0 (Macintosh)"), "windows");
 });
 
+test("compiled Linux platform wins over a Windows-like webview user-agent", () => {
+  assert.equal(detectRuntimePlatform("linux", "Mozilla/5.0 (Windows NT 10.0)"), "linux");
+});
+
 test("browser previews fall back to a narrowly matched user-agent", () => {
   assert.equal(detectRuntimePlatform(null, "Mozilla/5.0 (Macintosh; Intel Mac OS X)"), "macos");
   assert.equal(detectRuntimePlatform(null, "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"), "windows");

--- a/src/styles.css
+++ b/src/styles.css
@@ -1357,6 +1357,32 @@ html:has(.strip-shell) #root {
   border-radius: 6px;
 }
 
+/* Linux 置顶后整个悬浮形态是纯展示层。inert 负责键盘/辅助技术语义，这条再明确
+   禁掉全部控件命中；窗口自身仍保留边界指针事件，以便立即隐藏或淡出。 */
+.widget-shell[data-pinned="true"] *,
+.strip-shell[data-pinned="true"] * {
+  pointer-events: none !important;
+}
+
+.widget-shell[data-pinned="true"],
+.strip-shell[data-pinned="true"] {
+  pointer-events: auto;
+}
+
+/* Wayland/网页回落改变整个 renderer 的 opacity，而不是某个 shell 的 :hover。
+   X11 主路径由 QueryPointer 直接控制 GTK 顶层 opacity，不会命中本规则；
+   回落同样不设 transition，命中后的下一帧就完成切换。 */
+html[data-pinned-hover-active="true"] body {
+  opacity: var(--pinned-hover-target-opacity, 0) !important;
+  transition: none !important;
+}
+
+/* Wayland 不允许客户端读取全局指针位置。本地回落不能把输入面完全抹掉，
+   0.1% 肉眼等同隐藏，但仍让 WebKitGTK 有机会收到 pointerout 并恢复。 */
+html[data-pinned-hover-driver="local"][data-pinned-hover-mode="hide"][data-pinned-hover-active="true"] body {
+  opacity: 0.001 !important;
+}
+
 /* macOS：条带同样使用跟随系统的 menu vibrancy；原生材质拿不到时走
    上面的近实心配方，不套这条。 */
 .strip-shell--mac:not(.strip-shell--glass-css) {

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -299,9 +299,9 @@ async function ensurePositionAfterShow(api, appWindow, target) {
 /// 显示器的 scaleFactor 算物理尺寸；不能先按当前屏幕算完再搬过去。
 /// 记忆坐标来自 outerPosition()，但 Linux/GTK（GNOME X11 实测）下 setPosition
 /// 把目标解释成内容区（inner）原点：直接回填 outer 坐标会让窗口再上移一截
-/// （本机 _NET_FRAME_EXTENTS 顶部恒为 37px），每次重启累计一次。恢复时把
-/// inner−outer 偏移补回目标，让内容区落在用户上次摆放的位置。Windows 无边框
-/// 窗口内外坐标一致，Wayland 不走这条路径，偏移自然为 0。
+/// 并在每次重启累计窗口管理器的装饰偏移。恢复时动态测量 inner−outer 偏移并
+/// 补回目标，让内容区落在用户上次摆放的位置；不假设特定窗口管理器或固定像素。
+/// Windows 无边框窗口内外坐标一致，Wayland 不走这条路径，偏移自然为 0。
 async function positionRestoreOffset(api, appWindow) {
   if (!isLinuxPlatform() || !(await supportsGlobalWindowCoordinates())) {
     return { x: 0, y: 0 };
@@ -320,12 +320,12 @@ async function positionRestoreOffset(api, appWindow) {
   };
   const first = await read();
   if (first && (first.x !== 0 || first.y !== 0)) return first;
-  for (let i = 0; i < 10; i += 1) {
-    await new Promise((resolve) => window.setTimeout(resolve, 150));
-    const offset = await read();
-    if (offset && (offset.x !== 0 || offset.y !== 0)) return offset;
-  }
-  return first || { x: 0, y: 0 };
+
+  // GTK may report a temporary zero before the first map settles. One mapped
+  // sample is enough: zero is also a legitimate decoration offset and must not
+  // stall every frameless-window restore for another 1.5 seconds.
+  await new Promise((resolve) => window.setTimeout(resolve, 150));
+  return (await read()) || first || { x: 0, y: 0 };
 }
 
 async function floatingPlacement(api, mode, logicalSize, contentScale) {

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -204,7 +204,10 @@ async function applyStartupUiScale(mode) {
   // tauri.conf 的 320×320 只负责首帧；内容可能因 75% 缩放或单行 Agent
   // 收到更小，启动路径也必须像形态切换一样解除配置最小尺寸。
   await appWindow.setMinSize(null);
-  await appWindow.setResizable(false);
+  // GTK 会把初始不可缩放的尺寸当成硬约束；这只在 Linux 启动路径解除。
+  // Windows 保留原有的启动时锁定行为。
+  if (isLinuxPlatform()) await appWindow.setResizable(true).catch(() => {});
+  else await appWindow.setResizable(false);
   const physical = await scaledPhysicalSize(
     api,
     appWindow,
@@ -213,15 +216,28 @@ async function applyStartupUiScale(mode) {
     uiScale,
     placement.monitor?.scaleFactor,
   );
-  await appWindow.setSize(physical);
-  await reconcileFloatingSizeAfterShow(
-    api,
-    appWindow,
-    size.width,
-    height,
-    uiScale,
-    physical,
-  );
+  try {
+    await appWindow.setSize(physical);
+    await reconcileFloatingSizeAfterShow(
+      api,
+      appWindow,
+      size.width,
+      height,
+      uiScale,
+      physical,
+    );
+  } catch (error) {
+    // 隐藏状态下某些 GTK 合成器会暂时拒绝 resize；位置已经在前一步恢复，
+    // 不能因为首帧尺寸校正失败把应用永久留在托盘。
+    console.warn("Unable to apply the hidden Linux startup size.", error);
+  } finally {
+    // Linux 首窗在 tauri.linux.conf.json 中以 hidden 创建。位置和首帧尺寸已
+    // 全部恢复后才首次映射，避免 GTK 先按默认居中位置闪现再移动。
+    if (isLinuxPlatform()) {
+      await appWindow.show().catch(() => {});
+      await appWindow.setFocus().catch(() => {});
+    }
+  }
 }
 
 /// 窗口重设尺寸后可能伸出屏幕（固定状态下竖条切横条最典型：位置不动、
@@ -231,6 +247,7 @@ async function applyStartupUiScale(mode) {
 /// knownOuter：调用方刚算出的物理尺寸。setSize 异步生效，紧接着读 outerSize
 /// 会拿到旧值（实测拿到过 ~0），把变高的窗口钳错——传入时跳过 outerSize 读取。
 async function clampIntoWorkArea(api, appWindow, knownOuter = null) {
+  if (isLinuxPlatform() && !(await supportsGlobalWindowCoordinates())) return false;
   const [pos, readOuter, monitors] = await Promise.all([
     appWindow.outerPosition().catch(() => null),
     knownOuter ? null : appWindow.outerSize().catch(() => null),
@@ -267,6 +284,7 @@ async function clampIntoWorkArea(api, appWindow, knownOuter = null) {
 /// Windows 偶尔丢弃隐藏窗口的 setPosition：显示后校验一次坐标，
 /// 与钳位/居中后的预期不符就补发并重新钳位（否则窗口"复位"到变形前位置）。
 async function ensurePositionAfterShow(api, appWindow, target) {
+  if (isLinuxPlatform() && !(await supportsGlobalWindowCoordinates())) return;
   if (!target) return;
   const current = await appWindow.outerPosition().catch(() => null);
   if (!current) return;
@@ -279,7 +297,41 @@ async function ensurePositionAfterShow(api, appWindow, target) {
 
 /// 形态记忆位置可能在另一台 DPI 不同的屏幕上。先用目标坐标选显示器，再用该
 /// 显示器的 scaleFactor 算物理尺寸；不能先按当前屏幕算完再搬过去。
+/// 记忆坐标来自 outerPosition()，但 Linux/GTK（GNOME X11 实测）下 setPosition
+/// 把目标解释成内容区（inner）原点：直接回填 outer 坐标会让窗口再上移一截
+/// （本机 _NET_FRAME_EXTENTS 顶部恒为 37px），每次重启累计一次。恢复时把
+/// inner−outer 偏移补回目标，让内容区落在用户上次摆放的位置。Windows 无边框
+/// 窗口内外坐标一致，Wayland 不走这条路径，偏移自然为 0。
+async function positionRestoreOffset(api, appWindow) {
+  if (!isLinuxPlatform() || !(await supportsGlobalWindowCoordinates())) {
+    return { x: 0, y: 0 };
+  }
+  const read = async () => {
+    const [outer, inner] = await Promise.all([
+      appWindow.outerPosition().catch(() => null),
+      appWindow.innerPosition().catch(() => null),
+    ]);
+    if (!outer || !inner) return null;
+    const offset = {
+      x: Math.round(inner.x - outer.x),
+      y: Math.round(inner.y - outer.y),
+    };
+    return offset;
+  };
+  const first = await read();
+  if (first && (first.x !== 0 || first.y !== 0)) return first;
+  for (let i = 0; i < 10; i += 1) {
+    await new Promise((resolve) => window.setTimeout(resolve, 150));
+    const offset = await read();
+    if (offset && (offset.x !== 0 || offset.y !== 0)) return offset;
+  }
+  return first || { x: 0, y: 0 };
+}
+
 async function floatingPlacement(api, mode, logicalSize, contentScale) {
+  if (isLinuxPlatform() && !(await supportsGlobalWindowCoordinates())) {
+    return { position: null, monitor: null };
+  }
   const stored = readStoredPosition(mode);
   const requested = lastPositions[mode] || stored;
   if (!requested) return { position: null, monitor: null };
@@ -291,10 +343,13 @@ async function floatingPlacement(api, mode, logicalSize, contentScale) {
     contentScale,
   );
   if (!monitor) return { position: null, monitor: null };
+  const offset = isLinuxPlatform()
+    ? await positionRestoreOffset(api, api.getCurrentWindow())
+    : { x: 0, y: 0 };
   return {
     position: new api.PhysicalPosition(
-      Math.round(requested.x),
-      Math.round(requested.y),
+      Math.round(requested.x + offset.x),
+      Math.round(requested.y + offset.y),
     ),
     monitor,
   };
@@ -476,6 +531,7 @@ function readStoredPosition(mode) {
 /// 记住窗口的物理坐标（按形态分开记）；边缘挂靠把窗口滑出屏幕时不记，
 /// 避免下次开机在屏外。
 async function rememberWindowPosition(api, appWindow, mode) {
+  if (isLinuxPlatform() && !(await supportsGlobalWindowCoordinates())) return;
   const key = POSITION_KEYS[mode];
   if (!key) return;
   const [pos, monitor, monitors] = await Promise.all([
@@ -516,12 +572,26 @@ async function rememberWindowPosition(api, appWindow, mode) {
   }
   lastPositions[mode] = pos;
   localStorage.setItem(key, JSON.stringify({ x: pos.x, y: pos.y }));
+  if (isLinuxPlatform()) {
+    const inner = await appWindow.innerPosition().catch(() => null);
+    const offsetX = inner ? Math.round(inner.x - pos.x) : 0;
+    const offsetY = inner ? Math.round(inner.y - pos.y) : 0;
+    await invoke("persist_linux_startup_position", {
+      x: Math.round(pos.x),
+      y: Math.round(pos.y),
+      offsetX,
+      offsetY,
+    }).catch((error) => {
+      console.warn("Unable to persist the Linux startup position.", error);
+    });
+  }
 }
 
 /// 启动时把窗口放回该形态上次的位置；坐标已不在任何显示器上（拔了扩展屏等）时居中。
 async function restoreWindowPosition(mode = "compact") {
-  // macOS 面板永远贴着菜单栏图标，没有"上次的位置"这回事。
-  if (isMacPlatform()) return;
+  // macOS 面板永远贴着菜单栏图标，没有"上次的位置"这回事。Linux 在 X11
+  // 会话恢复坐标；Wayland 协议不暴露全局坐标，由能力探测自动跳过。
+  if (isMacPlatform() || (isLinuxPlatform() && !(await supportsGlobalWindowCoordinates()))) return;
   const api = await windowApi();
   if (!api) return;
   const stored = readStoredPosition(mode);
@@ -549,7 +619,15 @@ async function restoreWindowPosition(mode = "compact") {
   if (!onScreen) return;
 
   lastPositions[mode] = new api.PhysicalPosition(stored.x, stored.y);
-  await appWindow.setPosition(lastPositions[mode]).catch(() => {});
+  const offset = isLinuxPlatform()
+    ? await positionRestoreOffset(api, appWindow)
+    : { x: 0, y: 0 };
+  await appWindow
+    .setPosition(new api.PhysicalPosition(
+      Math.round(stored.x + offset.x),
+      Math.round(stored.y + offset.y),
+    ))
+    .catch(() => {});
 }
 
 /// 托盘右键"显示完整视图"：让用户从胶囊/卡片直达完整视图，不必先弹出卡片
@@ -603,7 +681,9 @@ async function onMacAgentSelection(handler) {
 
 /// 拖动结束后持久化窗口位置（compact 与 strip 各记各的；expanded 不记）。
 async function startPositionMemory(getMode) {
-  if (isMacPlatform()) return () => {};
+  if (isMacPlatform() || (isLinuxPlatform() && !(await supportsGlobalWindowCoordinates()))) {
+    return () => {};
+  }
   const api = await windowApi();
   if (!api) return () => {};
   const appWindow = api.getCurrentWindow();
@@ -625,6 +705,28 @@ async function startPositionMemory(getMode) {
 
 function isWindowsPlatform() {
   return runtimePlatform() === "windows";
+}
+
+/// Ubuntu 24.04 的受支持 Linux 壳层以 Wayland 为基线。不能把 Linux 当成
+/// Windows 来承诺全局坐标、DWM 材质或任务栏原生样式。
+function isLinuxPlatform() {
+  return runtimePlatform() === "linux";
+}
+
+let globalWindowCoordinatesPromise = null;
+
+/// Windows 始终支持全局窗口坐标；Linux 只在 X11 启用。结果按 WebView 生命周期
+/// 缓存，避免拖动与内容尺寸观察器反复跨 IPC 查询环境。
+async function supportsGlobalWindowCoordinates() {
+  if (isMacPlatform()) return false;
+  if (!isLinuxPlatform()) return true;
+  if (!isDesktop()) return false;
+  if (!globalWindowCoordinatesPromise) {
+    globalWindowCoordinatesPromise = invoke("linux_supports_global_window_coordinates")
+      .then(Boolean)
+      .catch(() => false);
+  }
+  return globalWindowCoordinatesPromise;
 }
 
 /// macOS 上小插件是菜单栏面板（NSPanel）：位置由托盘图标决定；零占地摘要直接
@@ -723,7 +825,10 @@ async function applyWindowMode(mode, options = {}) {
   // （以前无条件写 lastPositions.compact，从胶囊条进大视图会把小插件的
   // 记忆污染成胶囊条坐标，回来时就"复位"了）。同形态重入（启动恢复、
   // 自检重断言）不是变形，不记。
-  if (POSITION_KEYS[options.fromPositionMode] && options.fromPositionMode !== options.positionMode) {
+  if (
+    POSITION_KEYS[options.fromPositionMode]
+    && options.fromPositionMode !== options.positionMode
+  ) {
     await rememberWindowPosition(api, appWindow, options.fromPositionMode);
   }
 
@@ -731,6 +836,7 @@ async function applyWindowMode(mode, options = {}) {
     // 完整视图是常规窗口：一律解除置顶。固定（置顶 + 锁位置）只属于
     // compact/strip 悬浮形态，否则 1120x760 的大窗口盖住所有应用切不走。
     await appWindow.setAlwaysOnTop(false).catch(() => {});
+    if (isLinuxPlatform()) await setPinnedHoverBehavior(false);
     // 小插件不占任务栏；完整视图是常规窗口，要出现在任务栏里。
     // 无边框窗口的任务栏按钮由 WS_EX_APPWINDOW 决定，setSkipTaskbar 补不上它，
     // 所以走后端改窗口样式；样式必须在隐藏状态下改，重新显示后 shell 才重读。
@@ -751,7 +857,8 @@ async function applyWindowMode(mode, options = {}) {
     await appWindow.setMaximizable(true);
     await appWindow.setMinSize(new api.LogicalSize(minWidth, minHeight));
     await appWindow.setSize(new api.LogicalSize(targetWidth, targetHeight));
-    await appWindow.center();
+    if (isLinuxPlatform()) await appWindow.center().catch(() => {});
+    else await appWindow.center();
     await appWindow.show().catch(() => {});
     await appWindow.setFocus().catch(() => {});
     return;
@@ -789,16 +896,25 @@ async function applyWindowMode(mode, options = {}) {
       stripScale,
       placement.monitor?.scaleFactor,
     );
+    // tauri.conf 的初始 resizable:false 会让 GTK 把启动尺寸写成固定约束，必须
+    // 先解除才能收成短边 40px 的胶囊。Linux 下此后保持 resizable:true：Tao
+    // 文档明确指出再次切回 false 会附带至少 100px 的限制，实机会被 Mutter
+    // 撑成 200×200 大框。内容观察器会把任何意外的手动尺寸变化立即校正回
+    // 设计值，页面也不提供缩放控件。
+    if (isLinuxPlatform()) await appWindow.setResizable(true).catch(() => {});
     await appWindow.setSize(physical).catch((error) => {
       console.warn("Unable to apply the strip window size.", error);
     });
     // 缩放只走设置页滑杆：原生无边框窗口的 resize 命中区覆盖所有边，
     // 限制不到四角（0.11.0–0.11.1 的拖拽缩放因此移除）。
-    await appWindow.setResizable(false);
+    if (!isLinuxPlatform()) await appWindow.setResizable(false);
     // 伸出屏幕的部分钳回工作区（挂靠残留、方向切换变宽等）；
     // 完全不在任何屏幕上（拔了扩展屏等）时居中，胶囊条永远看得见、够得着。
     const clamped = await clampIntoWorkArea(api, appWindow, physical);
-    if (!clamped) await appWindow.center().catch(() => {});
+    if (!clamped) {
+      if (isLinuxPlatform()) await appWindow.center().catch(() => {});
+      else await appWindow.center();
+    }
     // 钳位/居中后的最终坐标是显示后校验的基准。
     const stripFinal = await appWindow.outerPosition().catch(() => null);
     await appWindow.show().catch(() => {});
@@ -842,13 +958,17 @@ async function applyWindowMode(mode, options = {}) {
     console.warn("Unable to apply the compact window size.", error);
   }
   // 缩放只走设置页滑杆（同胶囊条，拖拽缩放在 0.11.0–0.11.1 后移除）。
-  await appWindow.setResizable(false);
+  if (!isLinuxPlatform()) {
+    await appWindow.setResizable(false);
+  }
 
   if (placement.position) {
     // 缩放系数调大后，记忆位置 + 新尺寸可能伸出屏幕，钳回工作区。
     await clampIntoWorkArea(api, appWindow, compactPhysical);
   } else {
-    await appWindow.center();
+    // Wayland 可以拒绝客户端指定位置；尺寸仍然有效，摆放交给合成器即可。
+    if (isLinuxPlatform()) await appWindow.center().catch(() => {});
+    else await appWindow.center();
   }
   // 钳位/居中后的最终坐标是显示后校验的基准。
   const compactFinal = await appWindow.outerPosition().catch(() => null);
@@ -862,6 +982,7 @@ async function applyWindowMode(mode, options = {}) {
     uiScale,
     compactPhysical,
   );
+  if (isLinuxPlatform()) await appWindow.setResizable(false).catch(() => {});
   await appWindow.setFocus().catch(() => {});
 }
 
@@ -878,6 +999,7 @@ async function resizeStripWindow({ width, height }) {
   const targetHeight = Math.max(size.minHeight, Math.round(height || size.height));
   // 变形前记下贴边状态：用户把条贴在屏幕右/下缘时，方向切换或格数变化
   // 只改尺寸会把它从边缘"撕"下来（只保左上角），必须按原贴边重新锚定。
+  const coordinateAware = !isLinuxPlatform() || await supportsGlobalWindowCoordinates();
   const [pos, outer, monitor] = await Promise.all([
     appWindow.outerPosition().catch(() => null),
     appWindow.outerSize().catch(() => null),
@@ -885,7 +1007,7 @@ async function resizeStripWindow({ width, height }) {
   ]);
   const workArea = monitor?.workArea;
   const anchor = { right: false, bottom: false };
-  if (pos && outer && workArea) {
+  if (coordinateAware && pos && outer && workArea) {
     const workRight = workArea.position.x + workArea.size.width;
     const workBottom = workArea.position.y + workArea.size.height;
     anchor.right = Math.abs(pos.x + outer.width - workRight) <= 8;
@@ -912,6 +1034,7 @@ async function resizeStripWindow({ width, height }) {
   );
   // 测量收敛出的尺寸记作下次变形的首帧（否则首帧永远是常量估计）。
   rememberStripSize(targetWidth, targetHeight);
+  if (!coordinateAware) return;
   if ((anchor.right || anchor.bottom) && pos && workArea) {
     // 新尺寸必须用自己算出的 physical：setSize 是异步生效的，紧接着读
     // outerSize 会拿到旧值（Windows 实测拿到过 ~0），把窗口锚出屏幕。
@@ -968,6 +1091,7 @@ async function resizeCompactWindow({ height }) {
   );
   // 高度收敛值记作下次变形的首帧。
   rememberCompactHeight(targetHeight);
+  if (isLinuxPlatform() && !(await supportsGlobalWindowCoordinates())) return;
   // 变高可能把窗口底边顶出屏幕；钳位用刚算出的 physical（setSize 异步生效，
   // 此刻读 outerSize 是旧值）；完全掉出所有屏幕时居中找回。
   const clamped = await clampIntoWorkArea(api, appWindow, physical);
@@ -1086,6 +1210,16 @@ async function setWindowGlass(enabled, radius = 12, tintStyle = "dark") {
     // external backdrop-filter sampling into an opaque white capture surface.
     return resolveWindowsGlassComposition({ enabled, tintStyle }).mode;
   }
+  if (isLinuxPlatform()) {
+    // WebKitGTK/Wayland 没有跨 GNOME、KDE 和 X11 都一致的原生 blur 协议。
+    // 明确使用 CSS 表面，避免 setEffects 看似成功却渲染成不透明/黑底。
+    return resolveGlassMode({
+      enabled,
+      tintStyle,
+      nativeAvailable: false,
+      trueAlphaAvailable: false,
+    });
+  }
   const api = await windowApi();
   if (!api) return enabled ? "css" : "off";
   const appWindow = api.getCurrentWindow();
@@ -1119,10 +1253,92 @@ const DOCK_PEEK_PX = 6;
 const DOCK_HIDE_DELAY_MS = 900;
 const DOCK_POLL_MS = 250;
 
+let pinnedHoverBehaviorQueue = Promise.resolve();
+let pinnedHoverEnabled = false;
+let pinnedHoverNative = false;
+let pinnedHoverInputsInstalled = false;
+let pinnedHoverTargetOpacity = 0;
+
+function applyPinnedHoverAppearance(inside) {
+  const root = document.documentElement;
+  root.dataset.pinnedHoverActive = pinnedHoverEnabled && inside ? "true" : "false";
+}
+
+/// Wayland/浏览器预览没有全局坐标，只能在窗口仍能收到的本地边界事件上回落。
+/// X11 的主通道直接改 GTK 顶层窗口 opacity，不经过这里或 WebKit 事件。
+function ensurePinnedHoverInputs() {
+  if (pinnedHoverInputsInstalled) return;
+  pinnedHoverInputsInstalled = true;
+  const onPointerOver = () => {
+    if (pinnedHoverEnabled && !pinnedHoverNative) applyPinnedHoverAppearance(true);
+  };
+  const onPointerOut = (event) => {
+    if (pinnedHoverEnabled && !pinnedHoverNative && !event.relatedTarget) {
+      applyPinnedHoverAppearance(false);
+    }
+  };
+  window.addEventListener("pointerover", onPointerOver, true);
+  window.addEventListener("pointerout", onPointerOut, true);
+}
+
+/// 串行同步置顶悬停监视器。窗口变形和 React StrictMode 都可能连续重断言
+/// 置顶状态；若让这些 IPC 并发，迟到的旧请求会覆盖最终配置。
+function setPinnedHoverBehavior(enabled) {
+  // 置顶悬停（含原生 X11 与 Wayland 本地回落）是 Linux shell 专属能力。
+  // Windows 继续保留原有的置顶窗口交互，不加载状态、事件或 CSS 回落。
+  if (!isLinuxPlatform()) return Promise.resolve();
+  const requested = Boolean(enabled);
+  const requestedOpacity = pinnedHoverTargetOpacity;
+  pinnedHoverBehaviorQueue = pinnedHoverBehaviorQueue
+    .catch(() => {})
+    .then(async () => {
+      ensurePinnedHoverInputs();
+      pinnedHoverEnabled = requested;
+      // Linux 先按原生通道处理，避免 IPC 返回前的 pointerover 把 CSS opacity
+      // 置零；命令若确认是 Wayland/连接失败，再切到本地回落。
+      pinnedHoverNative = requested && isDesktop() && isLinuxPlatform();
+      applyPinnedHoverAppearance(false);
+
+      let native = false;
+      if (isDesktop()) {
+        native = await invoke("configure_pinned_hover", {
+          enabled: requested,
+          targetOpacity: requestedOpacity,
+        })
+          .then(Boolean)
+          .catch((error) => {
+            console.warn("Unable to configure pinned hover behavior.", error);
+            return false;
+          });
+      }
+      pinnedHoverNative = requested && native;
+      document.documentElement.dataset.pinnedHoverDriver = pinnedHoverNative
+        ? "native-x11"
+        : "local";
+      if (!pinnedHoverNative && requested) {
+        const hovered = document.querySelector(".widget-shell:hover, .strip-shell:hover");
+        applyPinnedHoverAppearance(Boolean(hovered));
+      }
+    });
+  return pinnedHoverBehaviorQueue;
+}
+
+function setPinnedHoverTargetOpacity(opacity) {
+  if (!isLinuxPlatform()) return;
+  const parsed = Number(opacity);
+  pinnedHoverTargetOpacity = Number.isFinite(parsed)
+    ? Math.min(1, Math.max(0, parsed))
+    : 0;
+  if (pinnedHoverEnabled) setPinnedHoverBehavior(true);
+}
+
 /// 边缘挂靠：未固定的卡片和胶囊条可贴四边自动收起，只留一条细边。
 /// 细边落在窗口的非客户区，webview 收不到 hover，因此以全局光标位置判断显示。
 async function startEdgeDock({ getMode, getPinned }) {
-  if (isMacPlatform()) return () => {};
+  // Wayland 不提供全局指针与窗口坐标；Linux 的 X11 会话可以正常启用。
+  if (isMacPlatform() || (isLinuxPlatform() && !(await supportsGlobalWindowCoordinates()))) {
+    return () => {};
+  }
   const api = await windowApi();
   if (!api) return () => {};
   const win = api.getCurrentWindow();
@@ -1284,6 +1500,23 @@ async function setWindowPinned(pinned) {
   const api = await windowApi();
   if (!api) return;
   await api.getCurrentWindow().setAlwaysOnTop(pinned);
+  // 悬停监视器与原生置顶状态共用同一条已串行化的窗口动作链，避免 React
+  // effect 的严格模式清理晚到一步、把已经置顶的监视器再次关掉。
+  if (isLinuxPlatform()) await setPinnedHoverBehavior(pinned);
+}
+
+/// Linux 托盘菜单的“置顶/取消置顶”请求。其 payload 是后端已经切换过的目标值，
+/// 前端只负责把窗口与持久化状态同步到该值。
+async function onTrayPinnedChange(handler) {
+  if (!isDesktop() || !isLinuxPlatform()) return () => {};
+  const { listen } = await import("@tauri-apps/api/event");
+  return listen("tray://set-pinned", (event) => handler(Boolean(event.payload)));
+}
+
+/// 从设置页变更置顶后刷新 Linux 托盘项的文字；其它平台没有该菜单。
+async function syncLinuxTrayPinned(pinned) {
+  if (!isDesktop() || !isLinuxPlatform()) return;
+  await invoke("sync_linux_tray_pinned", { pinned: Boolean(pinned) }).catch(() => {});
 }
 
 async function autostartApi() {
@@ -1363,6 +1596,7 @@ export {
   getMacAgentSelection,
   installUpdate,
   isDesktop,
+  isLinuxPlatform,
   isMacPlatform,
   isWindowsPlatform,
   minimizeWindow,
@@ -1370,6 +1604,7 @@ export {
   onMacAgentSelection,
   onMacAppearance,
   onScaleFactorChanged,
+  onTrayPinnedChange,
   onTrayShowExpanded,
   openExpandedWindow,
   readStripScale,
@@ -1386,10 +1621,13 @@ export {
   updateTrayQuotaBadge,
   setStripScale,
   setWindowGlass,
+  setPinnedHoverBehavior,
+  setPinnedHoverTargetOpacity,
   setWindowPinned,
   setWindowUiScale,
   startEdgeDock,
   startPositionMemory,
+  syncLinuxTrayPinned,
   stripContentSize,
   toggleMaximizeWindow,
 };


### PR DESCRIPTION
## Scope

Linux shell and Linux CI only. The application version is unchanged in this feature branch. Windows and macOS runtime behavior is intentionally preserved.

## What changed

- Adds Ubuntu 24.04 x86_64 build and package smoke checks for deb and AppImage.
- Adds Linux-native widget startup-position restoration, tray pin/unpin controls, and responsive pinned-hover fade/hide behavior.
- Uses compile-time Linux guards for native window behavior and the Tauri compile-time platform signal for frontend selection.
- Records the Linux platform boundaries and acceptance expectations.

## Assumptions and boundaries

- The affected shell is Ubuntu 24.04 x86_64.
- Linux-specific GTK/X11 integration is target-gated; it is not linked into Windows or macOS builds.
- Release preparation and version bumps remain outside this feature PR.

## Verification

- npm test: passed locally (40 tests).
- PR CI: Windows, macOS, and Ubuntu 24.04 x86_64 checks passed.
- Ubuntu package smoke check builds both deb and AppImage.
- Native Linux widget behavior was smoke-tested on Ubuntu before packaging.

## Follow-up

The release workflow and v0.16.4 tag are maintained separately from this feature PR.