### PR TITLE
Windows 托盘余量徽标：任务栏图标显示最上方 Agent 的官方余量

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,7 +125,7 @@ Where a source reports its own total, `TokenVector::disagrees_with_reported_tota
 
 ## Runtime boundary
 
-- Compact mode refreshes every five minutes while visible; expanded mode refreshes every minute. While `indexing.pending > 0` the UI polls every 400 ms instead, so each snapshot spends another `PARSE_BUDGET` on the backlog until it is drained. Returning to the window triggers a refresh.
+- Compact mode refreshes every five minutes while visible; expanded mode refreshes every minute. While `indexing.pending > 0` the UI polls every 400 ms instead, so each snapshot spends another `PARSE_BUDGET` on the backlog until it is drained. Returning to the window triggers a refresh. A hidden window also keeps the five-minute cadence while the Windows tray quota badge is enabled, because the taskbar number must not freeze.
 - One in-flight request is allowed from the UI; duplicate period requests are coalesced. The Rust scan remains serialized by one lock.
 - A desktop single-instance guard focuses the existing window instead of starting a second scanner.
 - Unchanged files are cheap metadata checks. A changed file is still reparsed from the beginning, so very large active logs remain the main CPU and disk bottleneck until an append cursor with durable parser state is implemented. The budget bounds a snapshot between files, not within one, so a single very large file can still overrun it.

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -95,6 +95,13 @@ change.
   drift and verify the full design viewport rather than trusting HWND size alone.
 - Strip window size is measured from rendered content. Constants may seed the
   first frame but are not the source of truth.
+- The notification-area icon can become a quota badge: while the setting is on,
+  the tray icon shows the remaining percentage of the first agent in the widget
+  list instead of the app mark. The number follows the compact-row rule
+  (tightest window), shows `--` when no reliable quota exists, colors stale
+  readings, and the tooltip names the agent and exact value. A hidden window
+  keeps refreshing at the compact cadence so the badge never freezes; turning
+  the setting off restores the default app icon.
 - Compact and strip have independent continuous UI scales in the range
   0.75–2.0, applied on the next entry into that form. Expanded mode is freely
   resizable and keeps webview zoom at 1.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "node --test src/platformDetection.test.js src/windowGeometry.test.js src/glassAppearance.test.js src/quotaWindows.test.js src/macosWidgetBundle.test.js",
+    "test": "node --test src/platformDetection.test.js src/windowGeometry.test.js src/glassAppearance.test.js src/quotaWindows.test.js src/macosWidgetBundle.test.js src/trayBadge.test.js",
     "preview": "vite preview",
     "pricing:update": "node --use-env-proxy scripts/update-pricing.mjs",
     "tauri": "tauri",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -918,6 +918,89 @@ async fn set_taskbar_button(window: tauri::WebviewWindow, visible: bool) -> Resu
     Ok(())
 }
 
+/// Windows 托盘余量徽标：把前端渲染好的 RGBA 位图换成任务栏托盘图标。
+/// 隐藏窗口后任务栏按钮本身就没了，能常驻显示数字的只有通知区域的托盘图标；
+/// 位图由 webview 里的 canvas 画出（渲染权威在前端，与悬浮窗尺寸同一套哲学），
+/// 后端只做校验和登记。icon 为 None 时恢复应用默认图标。
+#[derive(Debug, serde::Deserialize)]
+struct TrayQuotaIcon {
+    rgba: Vec<u8>,
+    width: u32,
+    height: u32,
+}
+
+/// 托盘图标尺寸上限：徽标实际是 32×32，这里只拦离谱的输入，不当作配置项。
+const TRAY_ICON_MAX_EDGE: u32 = 256;
+
+/// 负载校验：尺寸有界且 RGBA 长度与宽高一致。独立成函数供单测，不依赖平台。
+fn validate_tray_quota_icon(icon: &TrayQuotaIcon) -> Result<(), String> {
+    if icon.width == 0
+        || icon.height == 0
+        || icon.width > TRAY_ICON_MAX_EDGE
+        || icon.height > TRAY_ICON_MAX_EDGE
+    {
+        return Err(format!(
+            "托盘图标尺寸超出范围：{}×{}",
+            icon.width, icon.height
+        ));
+    }
+    let expected = icon.width as usize * icon.height as usize * 4;
+    if icon.rgba.len() != expected {
+        return Err(format!(
+            "托盘图标像素数据长度不匹配：{} ≠ {expected}",
+            icon.rgba.len()
+        ));
+    }
+    Ok(())
+}
+
+/// 设置 Windows 托盘图标为余量徽标；icon 为 None 时恢复默认图标与默认提示。
+/// 其它平台没有这条路径（前端只在 Windows 调用），这里是 no-op。
+#[tauri::command]
+fn set_tray_quota_icon(
+    app: tauri::AppHandle,
+    icon: Option<TrayQuotaIcon>,
+    tooltip: Option<String>,
+) -> Result<(), String> {
+    // 校验放在平台分支之前：非 Windows 构建里也读字段、走同一契约，
+    // 否则 dead_code 会把 TrayQuotaIcon、校验函数和上限常量判成死代码。
+    if let Some(payload) = icon.as_ref() {
+        validate_tray_quota_icon(payload)?;
+    }
+    #[cfg(windows)]
+    {
+        let Some(tray) = app.tray_by_id("main") else {
+            return Err("任务栏托盘图标不存在".into());
+        };
+        match icon {
+            Some(payload) => {
+                let image =
+                    tauri::image::Image::new_owned(payload.rgba, payload.width, payload.height);
+                tray.set_icon(Some(image))
+                    .map_err(|error| error.to_string())?;
+            }
+            None => {
+                let fallback = app
+                    .default_window_icon()
+                    .cloned()
+                    .ok_or_else(|| "默认应用图标不可用".to_string())?;
+                tray.set_icon(Some(fallback))
+                    .map_err(|error| error.to_string())?;
+            }
+        }
+        // 提示文本跟着数字走（如 "Metrik · Claude 剩余 87%"）；恢复时回到默认。
+        let tooltip = tooltip.filter(|text| !text.trim().is_empty());
+        tray.set_tooltip(tooltip.as_deref().or(Some("Metrik")))
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (app, icon, tooltip);
+        Ok(())
+    }
+}
+
 #[tauri::command]
 async fn claude_hook_status() -> Result<claude_hook::ClaudeHookStatus, String> {
     tauri::async_runtime::spawn_blocking(|| {
@@ -1331,6 +1414,7 @@ pub fn run() {
             qoder_cookie_status,
             configure_qoder_cookie,
             set_taskbar_button,
+            set_tray_quota_icon,
             set_native_theme,
             open_expanded_window,
             set_macos_desktop_widget_visible,
@@ -1599,6 +1683,41 @@ mod tests {
         migrate_legacy_database(&legacy, &local).unwrap();
 
         assert!(!local.exists());
+    }
+
+    #[test]
+    fn tray_quota_icon_payloads_are_validated_before_use() {
+        let badge = TrayQuotaIcon {
+            rgba: vec![10; 32 * 32 * 4],
+            width: 32,
+            height: 32,
+        };
+        assert_eq!(validate_tray_quota_icon(&badge), Ok(()));
+
+        let truncated = TrayQuotaIcon {
+            rgba: vec![10; 100],
+            width: 32,
+            height: 32,
+        };
+        assert!(validate_tray_quota_icon(&truncated)
+            .unwrap_err()
+            .contains("长度不匹配"));
+
+        let oversize = TrayQuotaIcon {
+            rgba: vec![0; (TRAY_ICON_MAX_EDGE as usize + 1) * 4],
+            width: TRAY_ICON_MAX_EDGE + 1,
+            height: 1,
+        };
+        assert!(validate_tray_quota_icon(&oversize)
+            .unwrap_err()
+            .contains("尺寸超出范围"));
+
+        let empty = TrayQuotaIcon {
+            rgba: Vec::new(),
+            width: 0,
+            height: 0,
+        };
+        assert!(validate_tray_quota_icon(&empty).is_err());
     }
 }
 #[test]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -95,6 +95,7 @@ import {
   setNativeTheme,
   setStripScale,
   updateMacStatusItems,
+  updateTrayQuotaBadge,
   setWindowGlass,
   setWindowPinned,
   setWindowUiScale,
@@ -103,11 +104,18 @@ import {
   stripContentSize,
   toggleMaximizeWindow,
 } from "./windowClient";
+import {
+  TRAY_BADGE_HIDDEN_REFRESH_MS,
+  trayBadgeSpec,
+  trayBadgeTooltip,
+} from "./trayBadge.js";
 
 // macOS 是菜单栏应用：小插件是贴着菜单栏图标的面板（没有窗口按钮、不可拖动、
 // 材质由系统 vibrancy 承担），完整视图是独立的标准窗口（原生红绿灯）。
 // Windows 仍是"单窗口变形 + 自绘按钮"，两条路径不互相影响。
 const IS_MAC = isMacPlatform();
+// Windows 任务栏托盘可换成余量数字徽标；其它平台没有这条路径。
+const IS_WINDOWS = isWindowsPlatform();
 
 const UsagePlot = lazy(() =>
   import("./UsagePlot").then((module) => ({ default: module.UsagePlot })),
@@ -2559,7 +2567,7 @@ function AgentListColumn({ title, hint, agents, detected, onToggle, onMove }) {
   );
 }
 
-function AgentsDisplayCard({ widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, detectedAgents }) {
+function AgentsDisplayCard({ widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, detectedAgents, trayBadgeEnabled, onToggleTrayBadge }) {
   return (
     <div className="settings-card">
       <h2>显示的 Agent</h2>
@@ -2586,6 +2594,25 @@ function AgentsDisplayCard({ widgetAgents, onToggleWidgetAgent, onMoveWidgetAgen
           />
         )}
       </div>
+      {/* Windows 专属：托盘图标换成数字。取的正是上面列表最上方的 Agent，
+          与菜单栏状态项同一套数据，只是托盘只放得下一个数字。 */}
+      {IS_WINDOWS && (
+        <div className="settings-subsection">
+          <h3>任务栏图标</h3>
+          <p className="settings-muted">
+            开启后，任务栏右下角的 Metrik 图标改为显示列表最上方 Agent 的剩余百分比；
+            无可靠额度时显示 --，窗口隐藏后数字仍每 5 分钟更新一次。
+          </p>
+          <label className="settings-check">
+            <input
+              type="checkbox"
+              checked={trayBadgeEnabled}
+              onChange={(event) => onToggleTrayBadge(event.target.checked)}
+            />
+            <span>图标改为显示余量数字</span>
+          </label>
+        </div>
+      )}
     </div>
   );
 }
@@ -2734,7 +2761,7 @@ const SETTINGS_TABS = [
   },
 ];
 
-function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, detectedAgents, glassAlpha, onGlassAlpha, glassTint, onGlassTint, glassInk, onGlassInk, uiScale, onUiScale, stripScale, onStripScale, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
+function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, detectedAgents, trayBadgeEnabled, onToggleTrayBadge, glassAlpha, onGlassAlpha, glassTint, onGlassTint, glassInk, onGlassInk, uiScale, onUiScale, stripScale, onStripScale, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
   const [settings, setSettings] = useState(null);
   const [directoryInput, setDirectoryInput] = useState("");
   const [busy, setBusy] = useState(false);
@@ -2851,6 +2878,8 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
             onToggleStripAgent={onToggleStripAgent}
             onMoveStripAgent={onMoveStripAgent}
             detectedAgents={detectedAgents}
+            trayBadgeEnabled={trayBadgeEnabled}
+            onToggleTrayBadge={onToggleTrayBadge}
           />
         )}
         {activeTab.id === "sources" && (
@@ -4392,6 +4421,15 @@ export function App() {
     setAutoUpdateCheck(next);
     localStorage.setItem("metrik:autoUpdateCheck", String(next));
   }, []);
+  // Windows 专属：任务栏托盘图标改为显示 Agent 列表最上方的余量数字。默认关，
+  // 关着的人看到的一直是应用图标。
+  const [trayBadgeEnabled, setTrayBadgeEnabled] = useState(
+    () => localStorage.getItem("metrik:trayQuotaBadge") === "true",
+  );
+  const handleToggleTrayBadge = useCallback((next) => {
+    setTrayBadgeEnabled(next);
+    localStorage.setItem("metrik:trayQuotaBadge", String(next));
+  }, []);
   const [availableUpdate, setAvailableUpdate] = useState(null);
   useEffect(() => {
     if (!isDesktop() || !autoUpdateCheck) return undefined;
@@ -4512,6 +4550,12 @@ export function App() {
       timer = undefined;
       if (document.visibilityState === "visible") {
         timer = window.setInterval(() => loadSnapshot(period), refreshEvery);
+      } else if (trayBadgeEnabled) {
+        // 托盘数字还亮在任务栏上：窗口隐藏时保留慢速刷新，数字不会冻在旧值。
+        timer = window.setInterval(
+          () => loadSnapshot(period),
+          TRAY_BADGE_HIDDEN_REFRESH_MS,
+        );
       }
     };
 
@@ -4528,7 +4572,7 @@ export function App() {
       document.removeEventListener("visibilitychange", refreshWhenVisible);
       window.removeEventListener("focus", refreshWhenVisible);
     };
-  }, [loadSnapshot, period, viewMode, indexing]);
+  }, [loadSnapshot, period, viewMode, indexing, trayBadgeEnabled]);
 
   useEffect(() => {
     // macOS 面板由系统管层级和位置：不置顶、不恢复坐标。
@@ -4845,6 +4889,27 @@ export function App() {
     if (!IS_MAC) return;
     runWindowAction(() => updateMacStatusItems(macStatusItems));
   }, [macStatusItems]);
+
+  // Windows 托盘徽标与 macOS 菜单栏同源：都从 widgetAgents 的状态列表取数，
+  // 只是托盘只放得下一个数字，取列表最上方（排序最高）的那个 Agent。
+  const trayBadge = useMemo(
+    () => trayBadgeSpec(macStatusItems),
+    [macStatusItems],
+  );
+  useEffect(() => {
+    if (!IS_WINDOWS) return;
+    const spec = trayBadgeEnabled
+      ? trayBadge && {
+          ...trayBadge,
+          tooltip: trayBadgeTooltip(
+            AGENT_META[trayBadge.agent]?.label || trayBadge.agent,
+            trayBadge.percent,
+            trayBadge.stale,
+          ),
+        }
+      : null;
+    runWindowAction(() => updateTrayQuotaBadge(spec));
+  }, [trayBadge, trayBadgeEnabled]);
 
   // 勾选即追加到末尾（勾选顺序 = 显示顺序）；首次改动时以当前自动列表为基准。
   const handleToggleStripAgent = useCallback((agentId) => {
@@ -5233,6 +5298,8 @@ export function App() {
             onToggleStripAgent={handleToggleStripAgent}
             onMoveStripAgent={handleMoveStripAgent}
             detectedAgents={detectedAgents}
+            trayBadgeEnabled={trayBadgeEnabled}
+            onToggleTrayBadge={handleToggleTrayBadge}
             glassAlpha={glassAlpha}
             onGlassAlpha={handleGlassAlpha}
             glassTint={glassTint}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2466,6 +2466,14 @@ html:has(.strip-shell--glass-ink-light) #root {
   margin: 0 0 12px;
 }
 
+/* 设置页通用开关行（如 Windows 托盘余量数字）。 */
+.settings-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px;
+}
+
 .status-dot--error { background: #c96a45; }
 .status-dot--warning { background: #c79332; }
 

--- a/src/trayBadge.js
+++ b/src/trayBadge.js
@@ -1,0 +1,111 @@
+/// Windows 托盘数字徽标：把 Agent 列表最上方一行的官方余量画成任务栏图标。
+/// 决策逻辑（取哪个数字、写什么提示）与画布渲染分开：决策部分可在 Node
+/// 单测里直接跑，画布只在浏览器里被调用。
+
+/// 渲染边长（像素）。托盘图标在 100%–200% DPI 下最大显示 32px，
+/// 以 32 渲染、由系统按需缩小，三个档位都不会放大糊掉。
+export const TRAY_BADGE_EDGE = 32;
+
+/// 数字可用的最大宽度：给圆角底留出边缘余量。
+const TRAY_BADGE_TEXT_BOX = 26;
+
+/// 隐藏窗口时的徽标刷新间隔：与可见小插件同档（5 分钟）。
+/// 托盘数字常亮在任务栏上，不能随窗口隐藏而冻结。
+export const TRAY_BADGE_HIDDEN_REFRESH_MS = 300_000;
+
+/// 余量取值归一：非有限值（含 null）代表不可用，其余四舍五入并钳到 0–100。
+/// 上游（macStatusItems）已经钳过，这里再挡一层，防止未来调用方绕过。
+export function normalizeBadgePercent(value) {
+  if (!Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+/// 从菜单栏同源的状态列表里取排序最高的 Agent（列表第一项）。
+/// 列表为空或首项无效时返回 null，调用方按「无徽标」处理。
+export function trayBadgeSpec(items) {
+  if (!Array.isArray(items) || items.length === 0) return null;
+  const top = items[0];
+  if (!top || typeof top.agent !== "string") return null;
+  return {
+    agent: top.agent,
+    percent: normalizeBadgePercent(top.remaining),
+    stale: Boolean(top.stale),
+  };
+}
+
+/// 徽标文字：不可用显示 --，与菜单栏同一语法；正常只有数字，16px 的
+/// 托盘图标塞不下百分号，精确值由悬停提示给出。
+export function trayBadgeText(percent) {
+  return percent == null ? "--" : String(percent);
+}
+
+/// 悬停提示，与 macOS 状态项同一套文案。
+export function trayBadgeTooltip(agentLabel, percent, stale) {
+  const body = percent == null
+    ? `${agentLabel} 配额不可用`
+    : `${agentLabel} 剩余 ${percent}%`;
+  return stale ? `Metrik · ${body} · 数据可能已过期` : `Metrik · ${body}`;
+}
+
+/// 状态指纹：Agent、数字或过期标记任一变化才算新徽标，避免每次快照
+/// 都把同一张图标重发一遍。
+export function trayBadgeKey(spec) {
+  if (!spec) return null;
+  const percent = spec.percent == null ? "--" : String(spec.percent);
+  return `${spec.agent}:${percent}:${spec.stale ? 1 : 0}`;
+}
+
+const BADGE_COLORS = {
+  // 深色圆角底保证对比：任务栏无论明暗，白字/琥珀字都立得住。
+  background: "rgba(23, 25, 30, 0.94)",
+  border: "rgba(255, 255, 255, 0.16)",
+  fresh: "#f4f5f7",
+  // 过期用琥珀色区分，图标里塞不下 macOS 的 ~ 前缀，颜色就是过期标记。
+  stale: "#e8b04b",
+  unavailable: "#8f96a3",
+};
+
+const BADGE_FONT_STACK = '"Geist Variable", "Segoe UI", system-ui, sans-serif';
+
+/// 把徽标画成 RGBA 位图。只被浏览器端调用（windowClient），Node 单测不经过这里。
+export function renderTrayQuotaBadge(percent, stale) {
+  const size = TRAY_BADGE_EDGE;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const context = canvas.getContext("2d", { willReadFrequently: true });
+
+  // 圆角底：整幅收在 1px 边距内，四角透明，贴进托盘槽位不出硬边。
+  context.beginPath();
+  context.roundRect(1, 1, size - 2, size - 2, 9);
+  context.fillStyle = BADGE_COLORS.background;
+  context.fill();
+  context.strokeStyle = BADGE_COLORS.border;
+  context.lineWidth = 1;
+  context.stroke();
+
+  const text = trayBadgeText(percent);
+  const color = percent == null
+    ? BADGE_COLORS.unavailable
+    : stale
+      ? BADGE_COLORS.stale
+      : BADGE_COLORS.fresh;
+
+  // 从大到小收到放得下为止；两位数一般停在 19–20px，三位数（100/--）收得
+  // 更小。数字宽度由真实测量决定，不按字符数硬编码档位。
+  let fontSize = 20;
+  for (;;) {
+    context.font = `700 ${fontSize}px ${BADGE_FONT_STACK}`;
+    if (context.measureText(text).width <= TRAY_BADGE_TEXT_BOX || fontSize <= 12) break;
+    fontSize -= 1;
+  }
+
+  context.fillStyle = color;
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  // middle 基线以字面框为准，纯数字会略偏高，下移 1px 到视觉中心。
+  context.fillText(text, size / 2, size / 2 + 1);
+
+  const { data } = context.getImageData(0, 0, size, size);
+  return { rgba: data, width: size, height: size };
+}

--- a/src/trayBadge.test.js
+++ b/src/trayBadge.test.js
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  TRAY_BADGE_HIDDEN_REFRESH_MS,
+  normalizeBadgePercent,
+  trayBadgeKey,
+  trayBadgeSpec,
+  trayBadgeText,
+  trayBadgeTooltip,
+} from "./trayBadge.js";
+
+test("badge spec picks the first agent from the shared status list", () => {
+  const items = [
+    { agent: "claude", remaining: 87, stale: false },
+    { agent: "codex", remaining: 42, stale: true },
+  ];
+  assert.deepEqual(trayBadgeSpec(items), {
+    agent: "claude",
+    percent: 87,
+    stale: false,
+  });
+});
+
+test("badge spec survives empty or malformed lists", () => {
+  assert.equal(trayBadgeSpec([]), null);
+  assert.equal(trayBadgeSpec(null), null);
+  assert.equal(trayBadgeSpec([{ agent: 7 }]), null);
+});
+
+test("badge spec normalizes the percentage", () => {
+  const spec = trayBadgeSpec([{ agent: "codex", remaining: 120.4, stale: true }]);
+  assert.equal(spec.percent, 100);
+  const missing = trayBadgeSpec([{ agent: "codex", remaining: null, stale: false }]);
+  assert.equal(missing.percent, null);
+});
+
+test("percent normalization keeps only finite clamped integers", () => {
+  assert.equal(normalizeBadgePercent(94.4), 94);
+  assert.equal(normalizeBadgePercent(-3), 0);
+  assert.equal(normalizeBadgePercent(250), 100);
+  assert.equal(normalizeBadgePercent(null), null);
+  assert.equal(normalizeBadgePercent(Number.NaN), null);
+});
+
+test("badge text shows -- only when the quota is unavailable", () => {
+  assert.equal(trayBadgeText(87), "87");
+  assert.equal(trayBadgeText(0), "0");
+  assert.equal(trayBadgeText(100), "100");
+  assert.equal(trayBadgeText(null), "--");
+});
+
+test("badge tooltip reuses the menu-bar wording", () => {
+  assert.equal(trayBadgeTooltip("ChatGPT", 87, false), "Metrik · ChatGPT 剩余 87%");
+  assert.equal(
+    trayBadgeTooltip("Claude", 42, true),
+    "Metrik · Claude 剩余 42% · 数据可能已过期",
+  );
+  assert.equal(trayBadgeTooltip("GLM", null, false), "Metrik · GLM 配额不可用");
+});
+
+test("badge key changes only when agent, percent, or staleness changes", () => {
+  const key = trayBadgeKey({ agent: "kimi", percent: 66, stale: false });
+  assert.equal(trayBadgeKey({ agent: "kimi", percent: 66, stale: false }), key);
+  assert.notEqual(trayBadgeKey({ agent: "kimi", percent: 65, stale: false }), key);
+  assert.notEqual(trayBadgeKey({ agent: "kimi", percent: 66, stale: true }), key);
+  assert.notEqual(trayBadgeKey({ agent: "codex", percent: 66, stale: false }), key);
+  assert.notEqual(trayBadgeKey({ agent: "kimi", percent: null, stale: false }), key);
+  assert.equal(trayBadgeKey(null), null);
+});
+
+test("hidden refresh cadence matches the visible compact widget", () => {
+  assert.equal(TRAY_BADGE_HIDDEN_REFRESH_MS, 300_000);
+});

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -6,6 +6,10 @@ import {
 } from "./glassAppearance.js";
 import { detectRuntimePlatform } from "./platformDetection";
 import {
+  renderTrayQuotaBadge,
+  trayBadgeKey,
+} from "./trayBadge.js";
+import {
   monitorForWindowPosition,
   physicalWindowSize,
   viewportCorrectedPhysicalSize,
@@ -672,6 +676,32 @@ async function updateMacStatusItems(items) {
     ),
     stale: items.map((item) => Boolean(item.stale)),
   });
+}
+
+/// 把列表最上方 Agent 的余量画进 Windows 任务栏托盘图标。spec 为 null 时
+/// 恢复应用默认图标。同一状态只下发一次：快照每次刷新都会重跑，但数字没变
+/// 就不该再碰托盘。下发失败不记账，下一次快照会自动重试。
+let appliedTrayBadgeKey = null;
+
+async function updateTrayQuotaBadge(spec) {
+  if (!isDesktop() || !isWindowsPlatform()) return;
+  const nextKey = spec ? trayBadgeKey(spec) : null;
+  if (nextKey === appliedTrayBadgeKey) return;
+  if (!spec) {
+    await invoke("set_tray_quota_icon", { icon: null, tooltip: null });
+    appliedTrayBadgeKey = null;
+    return;
+  }
+  const rendered = renderTrayQuotaBadge(spec.percent, spec.stale);
+  await invoke("set_tray_quota_icon", {
+    icon: {
+      rgba: Array.from(rendered.rgba),
+      width: rendered.width,
+      height: rendered.height,
+    },
+    tooltip: spec.tooltip,
+  });
+  appliedTrayBadgeKey = nextKey;
 }
 
 async function applyWindowMode(mode, options = {}) {
@@ -1353,6 +1383,7 @@ export {
   setAutostart,
   setNativeTheme,
   updateMacStatusItems,
+  updateTrayQuotaBadge,
   setStripScale,
   setWindowGlass,
   setWindowPinned,


### PR DESCRIPTION
## 影响范围

Windows shell（后端命令为 Windows 实现、其它平台 no-op；前端入口仅 Windows 显示）。

## 内容

- 设置 → Agent 选择新增「任务栏图标」开关（仅 Windows）：开启后通知区托盘图标换成小组件列表最上方 Agent 的官方余量百分比。
- 数字与 macOS 菜单栏状态项同源（同一套余量取值规则：最紧窗口、低水位接管）；无可靠额度显示 `--`，过期数据用琥珀色区分，悬停提示给出 Agent 名与精确值。
- 位图由前端 canvas 渲染（32×32，深色圆角底 + 数字），后端 `set_tray_quota_icon` 命令只做负载校验与托盘登记；关闭开关恢复应用默认图标。
- 窗口隐藏时轮询原本暂停；开启徽标后隐藏状态保持每 5 分钟刷新（与可见卡片同档），托盘数字不会冻结。

## 验证

- 前端 47 项测试（新增 8 项决策逻辑单测）、Rust 192 项测试（新增负载校验单测）、clippy/fmt/vite build 全绿。
- Windows 实机冒烟：dev 构建开启开关后托盘显示真实配额数字，隐藏窗口后正常刷新，控制台无警告；渲染输出经 headless 浏览器逐场景核对（两位数/100/--/过期/单数字）。
- macOS 不受影响：入口不渲染、命令 no-op，CI 仅编译验证（与仓库现状一致）。