### PR TITLE
feat(pricing): xAI 官方价目与 grok-4.5-build 订阅别名计价

### DIFF
--- a/scripts/update-pricing.mjs
+++ b/scripts/update-pricing.mjs
@@ -19,7 +19,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 const SOURCE =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const OUT = "src-tauri/src/pricing_table.rs";
-const PROVIDERS = new Set(["openai", "anthropic", "moonshot", "zai", "gemini"]);
+const PROVIDERS = new Set(["openai", "anthropic", "moonshot", "zai", "gemini", "xai"]);
 
 const localPath = process.argv[2];
 let raw;
@@ -103,7 +103,7 @@ writeFileSync(
   OUT,
   `//! 由 scripts/update-pricing.mjs 生成，请勿手改。
 //! 来源：LiteLLM 的 model_prices_and_context_window.json
-//! （只取 openai / anthropic / moonshot / zai / gemini 官方第一方 API）。
+//! （只取 openai / anthropic / moonshot / zai / gemini / xai 官方第一方 API）。
 //! 重新生成：node scripts/update-pricing.mjs
 //!
 //! 单位：美元 / 百万 token。表按模型名有序，供 price_for 二分查找。

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -1,7 +1,7 @@
 //! 成本估算定价表（美元每百万 token）。
 //!
 //! 数据来源：LiteLLM 的公开价格表（`model_prices_and_context_window.json`），
-//! 只取 openai / anthropic / moonshot / zai / gemini 五个官方第一方 API 的
+//! 只取 openai / anthropic / moonshot / zai / gemini / xai 六个官方第一方 API 的
 //! provider，构建期由 `scripts/update-pricing.mjs` 生成 `pricing_table.rs`
 //! （`npm run pricing:update`）。运行时不联网——价格随发版更新，留在 git 里可审计。
 //!
@@ -18,7 +18,7 @@
 //!
 //! ## 覆盖范围
 //!
-//! 表内是五个第一方官方 API 的价目（生成时剥掉 LiteLLM 键的 provider 前缀，
+//! 表内是六个第一方官方 API 的价目（生成时剥掉 LiteLLM 键的 provider 前缀，
 //! 按裸模型名匹配）。OpenCode、Antigravity 等直连这些官方 API 的用量因此可以
 //! 计价（如 kimi-k2.5、glm-4.6、gemini-3-flash-preview）。
 //!
@@ -93,12 +93,20 @@ const MANUAL_PRICING: &[(&str, Pricing)] = &[
 ];
 
 /// 订阅制 coding plan 的模型 ID → 同一模型的官方第一方 API 价（估算口径）。
-/// 仅限"同一模型"：Kimi Code 订阅记的 `kimi-code/k3` 就是 kimi-k3 本身，
-/// 官方称 Extra Usage"接近开放平台官方 API 价"；成本页始终标注为估算。
+/// 仅限"同一模型"，且要有官方佐证，不是看名字像就归一：
+/// - Kimi Code 订阅记的 `kimi-code/k3` 就是 kimi-k3 本身，
+///   官方称 Extra Usage"接近开放平台官方 API 价"；成本页始终标注为估算。
+/// - ZCode coding-plan 记的 `GLM-5.2` 只是 glm-5.2 的大小写变体，同一模型。
+/// - Grok Build 订阅记的 `grok-4.5-build`：docs.x.ai 模型页里 grok-4.5 的官方
+///   别名就含 `grok-build-latest`（Build 产品线 = grok-4.5，2026-08-19 核对），
+///   故按 grok-4.5 官方 API 价估算。
+///
 /// 没有官方价的订阅 ID（kimi-for-coding 等）继续 unpriced。
-/// ZCode coding-plan 记的 `GLM-5.2` 只是 glm-5.2 的大小写变体，同一模型。
-const SUBSCRIPTION_ALIASES: &[(&str, &str)] =
-    &[("GLM-5.2", "glm-5.2"), ("kimi-code/k3", "kimi-k3")];
+const SUBSCRIPTION_ALIASES: &[(&str, &str)] = &[
+    ("GLM-5.2", "glm-5.2"),
+    ("kimi-code/k3", "kimi-k3"),
+    ("grok-4.5-build", "grok-4.5"),
+];
 
 /// 返回 `model` 的定价；表里没有则返回 `None`（调用方归入 unpriced，
 /// 不得臆造价格）。见模块文档：只精确匹配，日期快照后缀与订阅别名除外。
@@ -218,6 +226,23 @@ mod tests {
         assert_eq!(aliased.output, direct.output);
         // 其他订阅 ID 仍不得蒙混（见上一条测试）。
         assert!(price_for("kimi-code/k4").is_none());
+    }
+
+    #[test]
+    fn grok_45_build_priced_from_official_api_rates() {
+        // Grok Build 订阅记的 grok-4.5-build 按 grok-4.5 官方 API 价估算：
+        // docs.x.ai 模型页 grok-4.5 的官方别名含 grok-build-latest（Build
+        // 产品线 = grok-4.5；in $2 / cache $0.30 / out $6，2026-08-19 与
+        // LiteLLM 交叉一致）。直连 xAI API 的裸名也照表计价。
+        let aliased = price_for("grok-4.5-build").expect("alias priced");
+        assert_eq!(aliased.input, 2.0);
+        assert_eq!(aliased.cache_read, 0.3);
+        assert_eq!(aliased.output, 6.0);
+        let direct = price_for("grok-4.5").expect("api name priced");
+        assert_eq!(direct.input, aliased.input);
+        assert_eq!(direct.output, aliased.output);
+        // 未佐证的其他订阅变体不得蒙混：前缀匹配是事故，不重演。
+        assert!(price_for("grok-4.6-build").is_none());
     }
 
     #[test]

--- a/src-tauri/src/pricing_table.rs
+++ b/src-tauri/src/pricing_table.rs
@@ -1,6 +1,6 @@
 //! 由 scripts/update-pricing.mjs 生成，请勿手改。
 //! 来源：LiteLLM 的 model_prices_and_context_window.json
-//! （只取 openai / anthropic / moonshot / zai / gemini 官方第一方 API）。
+//! （只取 openai / anthropic / moonshot / zai / gemini / xai 官方第一方 API）。
 //! 重新生成：node scripts/update-pricing.mjs
 //!
 //! 单位：美元 / 百万 token。表按模型名有序，供 price_for 二分查找。
@@ -8,7 +8,7 @@
 use super::Pricing;
 
 /// 价格表的生成日期，透传给前端做"估算截至"标注。
-pub const PRICING_AS_OF: &str = "2026-08-01";
+pub const PRICING_AS_OF: &str = "2026-08-19";
 
 // 每行一个模型：rustfmt 会把它拆成每条六行（近千行），生成结果与格式化结果
 // 互相打架。这是生成文件，保持一行一条更好读也更好 diff。
@@ -23,6 +23,8 @@ pub const PRICING_TABLE: &[(&str, Pricing)] = &[
     ("claude-fable-5", Pricing { input: 10.0, cache_read: 1.0, cache_write: 12.5, output: 50.0 }),
     ("claude-haiku-4-5", Pricing { input: 1.0, cache_read: 0.1, cache_write: 1.25, output: 5.0 }),
     ("claude-haiku-4-5-20251001", Pricing { input: 1.0, cache_read: 0.1, cache_write: 1.25, output: 5.0 }),
+    ("claude-mythos-5", Pricing { input: 10.0, cache_read: 1.0, cache_write: 12.5, output: 50.0 }),
+    ("claude-mythos-preview", Pricing { input: 10.0, cache_read: 1.0, cache_write: 12.5, output: 50.0 }),
     ("claude-opus-4-1", Pricing { input: 15.0, cache_read: 1.5, cache_write: 18.75, output: 75.0 }),
     ("claude-opus-4-1-20250805", Pricing { input: 15.0, cache_read: 1.5, cache_write: 18.75, output: 75.0 }),
     ("claude-opus-4-20250514", Pricing { input: 15.0, cache_read: 1.5, cache_write: 18.75, output: 75.0 }),
@@ -77,6 +79,7 @@ pub const PRICING_TABLE: &[(&str, Pricing)] = &[
     ("gemini-3.5-flash", Pricing { input: 1.5, cache_read: 0.15, cache_write: 0.0, output: 9.0 }),
     ("gemini-3.5-flash-lite", Pricing { input: 0.3, cache_read: 0.03, cache_write: 0.0, output: 2.5 }),
     ("gemini-3.6-flash", Pricing { input: 1.5, cache_read: 0.15, cache_write: 0.0, output: 7.5 }),
+    ("gemini-3.7-flash", Pricing { input: 0.75, cache_read: 0.075, cache_write: 0.0, output: 3.75 }),
     ("gemini-exp-1114", Pricing { input: 0.0, cache_read: 0.0, cache_write: 0.0, output: 0.0 }),
     ("gemini-exp-1206", Pricing { input: 0.0, cache_read: 0.0, cache_write: 0.0, output: 0.0 }),
     ("gemini-flash-latest", Pricing { input: 0.3, cache_read: 0.075, cache_write: 0.0, output: 2.5 }),
@@ -86,6 +89,9 @@ pub const PRICING_TABLE: &[(&str, Pricing)] = &[
     ("gemini-omni-flash-preview", Pricing { input: 1.5, cache_read: 1.5, cache_write: 0.0, output: 9.0 }),
     ("gemini-pro-latest", Pricing { input: 1.25, cache_read: 0.125, cache_write: 0.0, output: 10.0 }),
     ("gemini-robotics-er-1.5-preview", Pricing { input: 0.3, cache_read: 0.0, cache_write: 0.0, output: 2.5 }),
+    ("gemini-robotics-er-1.6-preview", Pricing { input: 1.0, cache_read: 1.0, cache_write: 0.0, output: 5.0 }),
+    ("gemini-robotics-er-2-preview", Pricing { input: 2.0, cache_read: 0.2, cache_write: 0.0, output: 10.0 }),
+    ("gemini-robotics-er-2-streaming-preview", Pricing { input: 2.0, cache_read: 2.0, cache_write: 0.0, output: 10.0 }),
     ("gemma-3-27b-it", Pricing { input: 0.0, cache_read: 0.0, cache_write: 0.0, output: 0.0 }),
     ("glm-4-32b-0414-128k", Pricing { input: 0.1, cache_read: 0.1, cache_write: 0.0, output: 0.1 }),
     ("glm-4.5", Pricing { input: 0.6, cache_read: 0.6, cache_write: 0.0, output: 2.2 }),
@@ -182,6 +188,50 @@ pub const PRICING_TABLE: &[(&str, Pricing)] = &[
     ("gpt-audio-mini", Pricing { input: 0.6, cache_read: 0.6, cache_write: 0.0, output: 2.4 }),
     ("gpt-audio-mini-2025-10-06", Pricing { input: 0.6, cache_read: 0.6, cache_write: 0.0, output: 2.4 }),
     ("gpt-audio-mini-2025-12-15", Pricing { input: 0.6, cache_read: 0.6, cache_write: 0.0, output: 2.4 }),
+    ("grok-2", Pricing { input: 2.0, cache_read: 2.0, cache_write: 0.0, output: 10.0 }),
+    ("grok-2-1212", Pricing { input: 2.0, cache_read: 2.0, cache_write: 0.0, output: 10.0 }),
+    ("grok-2-latest", Pricing { input: 2.0, cache_read: 2.0, cache_write: 0.0, output: 10.0 }),
+    ("grok-2-vision", Pricing { input: 2.0, cache_read: 2.0, cache_write: 0.0, output: 10.0 }),
+    ("grok-2-vision-1212", Pricing { input: 2.0, cache_read: 2.0, cache_write: 0.0, output: 10.0 }),
+    ("grok-2-vision-latest", Pricing { input: 2.0, cache_read: 2.0, cache_write: 0.0, output: 10.0 }),
+    ("grok-3", Pricing { input: 3.0, cache_read: 0.75, cache_write: 0.0, output: 15.0 }),
+    ("grok-3-beta", Pricing { input: 3.0, cache_read: 0.75, cache_write: 0.0, output: 15.0 }),
+    ("grok-3-fast-beta", Pricing { input: 5.0, cache_read: 1.25, cache_write: 0.0, output: 25.0 }),
+    ("grok-3-fast-latest", Pricing { input: 5.0, cache_read: 1.25, cache_write: 0.0, output: 25.0 }),
+    ("grok-3-latest", Pricing { input: 3.0, cache_read: 0.75, cache_write: 0.0, output: 15.0 }),
+    ("grok-3-mini", Pricing { input: 0.3, cache_read: 0.075, cache_write: 0.0, output: 0.5 }),
+    ("grok-3-mini-beta", Pricing { input: 0.3, cache_read: 0.075, cache_write: 0.0, output: 0.5 }),
+    ("grok-3-mini-fast", Pricing { input: 0.6, cache_read: 0.15, cache_write: 0.0, output: 4.0 }),
+    ("grok-3-mini-fast-beta", Pricing { input: 0.6, cache_read: 0.15, cache_write: 0.0, output: 4.0 }),
+    ("grok-3-mini-fast-latest", Pricing { input: 0.6, cache_read: 0.15, cache_write: 0.0, output: 4.0 }),
+    ("grok-3-mini-latest", Pricing { input: 0.3, cache_read: 0.075, cache_write: 0.0, output: 0.5 }),
+    ("grok-4", Pricing { input: 3.0, cache_read: 3.0, cache_write: 0.0, output: 15.0 }),
+    ("grok-4-0709", Pricing { input: 3.0, cache_read: 3.0, cache_write: 0.0, output: 15.0 }),
+    ("grok-4-1-fast", Pricing { input: 0.2, cache_read: 0.05, cache_write: 0.0, output: 0.5 }),
+    ("grok-4-1-fast-non-reasoning", Pricing { input: 0.2, cache_read: 0.05, cache_write: 0.0, output: 0.5 }),
+    ("grok-4-1-fast-non-reasoning-latest", Pricing { input: 0.2, cache_read: 0.05, cache_write: 0.0, output: 0.5 }),
+    ("grok-4-1-fast-reasoning", Pricing { input: 0.2, cache_read: 0.05, cache_write: 0.0, output: 0.5 }),
+    ("grok-4-1-fast-reasoning-latest", Pricing { input: 0.2, cache_read: 0.05, cache_write: 0.0, output: 0.5 }),
+    ("grok-4-fast-non-reasoning", Pricing { input: 0.2, cache_read: 0.05, cache_write: 0.0, output: 0.5 }),
+    ("grok-4-fast-reasoning", Pricing { input: 0.2, cache_read: 0.05, cache_write: 0.0, output: 0.5 }),
+    ("grok-4-latest", Pricing { input: 3.0, cache_read: 3.0, cache_write: 0.0, output: 15.0 }),
+    ("grok-4.20-0309-non-reasoning", Pricing { input: 1.25, cache_read: 0.2, cache_write: 0.0, output: 2.5 }),
+    ("grok-4.20-0309-reasoning", Pricing { input: 1.25, cache_read: 0.2, cache_write: 0.0, output: 2.5 }),
+    ("grok-4.20-beta-0309-non-reasoning", Pricing { input: 1.25, cache_read: 0.2, cache_write: 0.0, output: 2.5 }),
+    ("grok-4.20-beta-0309-reasoning", Pricing { input: 1.25, cache_read: 0.2, cache_write: 0.0, output: 2.5 }),
+    ("grok-4.20-multi-agent-0309", Pricing { input: 1.25, cache_read: 0.2, cache_write: 0.0, output: 2.5 }),
+    ("grok-4.20-multi-agent-beta-0309", Pricing { input: 1.25, cache_read: 0.2, cache_write: 0.0, output: 2.5 }),
+    ("grok-4.3", Pricing { input: 1.25, cache_read: 0.2, cache_write: 0.0, output: 2.5 }),
+    ("grok-4.3-latest", Pricing { input: 1.25, cache_read: 0.2, cache_write: 0.0, output: 2.5 }),
+    ("grok-4.5", Pricing { input: 2.0, cache_read: 0.3, cache_write: 0.0, output: 6.0 }),
+    ("grok-4.5-latest", Pricing { input: 2.0, cache_read: 0.3, cache_write: 0.0, output: 6.0 }),
+    ("grok-4.6", Pricing { input: 2.0, cache_read: 0.5, cache_write: 0.0, output: 6.0 }),
+    ("grok-beta", Pricing { input: 5.0, cache_read: 5.0, cache_write: 0.0, output: 15.0 }),
+    ("grok-build-0.1", Pricing { input: 1.0, cache_read: 0.2, cache_write: 0.0, output: 2.0 }),
+    ("grok-code-fast", Pricing { input: 1.0, cache_read: 0.2, cache_write: 0.0, output: 2.0 }),
+    ("grok-code-fast-1", Pricing { input: 1.0, cache_read: 0.2, cache_write: 0.0, output: 2.0 }),
+    ("grok-code-fast-1-0825", Pricing { input: 1.0, cache_read: 0.2, cache_write: 0.0, output: 2.0 }),
+    ("grok-vision-beta", Pricing { input: 5.0, cache_read: 5.0, cache_write: 0.0, output: 15.0 }),
     ("kimi-k2-0711-preview", Pricing { input: 0.6, cache_read: 0.15, cache_write: 0.0, output: 2.5 }),
     ("kimi-k2-0905-preview", Pricing { input: 0.6, cache_read: 0.15, cache_write: 0.0, output: 2.5 }),
     ("kimi-k2-thinking", Pricing { input: 0.6, cache_read: 0.15, cache_write: 0.0, output: 2.5 }),

--- a/src/usageClient.js
+++ b/src/usageClient.js
@@ -168,11 +168,11 @@ function demoSnapshot(period = "today") {
     ],
     cost: {
       available: true,
-      // 演示值按 gpt-5.2 / claude 价目的量级粗算。
-      totalUsd: 5.62 * scale,
-      // ZCode / OpenCode / Kimi / Antigravity / WorkBuddy / Grok 未计价：演示数据也如实反映这一点。
-      unpricedTokens: zcodeTokens + opencodeTokens + kimiTokens + antigravityTokens + workbuddyTokens + grokTokens,
-      pricingAsOf: "2026-07-13",
+      // 演示值按 gpt-5.2 / claude / grok-4.5 价目的量级粗算。
+      totalUsd: 5.84 * scale,
+      // ZCode / OpenCode / Kimi / Antigravity / WorkBuddy 未计价：演示数据也如实反映这一点。
+      unpricedTokens: zcodeTokens + opencodeTokens + kimiTokens + antigravityTokens + workbuddyTokens,
+      pricingAsOf: "2026-08-19",
       byAgent: [
         { agent: "codex", usd: 2.31 * scale, unpricedTokens: 0 },
         { agent: "claude", usd: 3.31 * scale, unpricedTokens: 0 },
@@ -181,7 +181,7 @@ function demoSnapshot(period = "today") {
         { agent: "kimi", usd: 0, unpricedTokens: kimiTokens },
         { agent: "antigravity", usd: 0, unpricedTokens: antigravityTokens },
         { agent: "workbuddy", usd: 0, unpricedTokens: workbuddyTokens },
-        { agent: "grok", usd: 0, unpricedTokens: grokTokens },
+        { agent: "grok", usd: 0.22 * scale, unpricedTokens: 0 },
       ],
     },
     models: [


### PR DESCRIPTION
补上 #124 留下的缺口：Grok Build 用量此前全部落入未计价。

## 影响范围

shared（定价表与匹配规则）；无平台分支。

## 口径依据（不用竞品数据）

沿用仓库既有原则：只认官方第一方价目，同一模型才可别名归一。

- `update-pricing.mjs` 白名单加入 `xai`（xAI 官方 API），从 LiteLLM 官方源重新生成价格表；grok-4.5 = in $2.00/M、cache $0.30/M、out $6.00/M，与 docs.x.ai 模型页逐一核对一致（价格单位换算经 grok-4.5 与 grok-4-fast 双重交叉验证）。
- 订阅模型 `grok-4.5-build`（Grok Build 实际记录的 modelUsage ID）→ `grok-4.5`：**官方证据是 docs.x.ai 里 grok-4.5 的官方别名列表就包含 `grok-build-latest`**——xAI 自己把 Build 产品线指向 grok-4.5。与 kimi-code/k3 → kimi-k3 同款处理。
- 未佐证的变体（grok-4.6-build 等）不做前缀猜测，维持 unpriced（前缀匹配是本仓库明确记录过的事故，不重演）。

## 顺带

- 表重新生成同时带上 LiteLLM 新收录的 claude-mythos / gemini-3.7-flash / gemini-robotics 等条目（生成日期 2026-08-19，留在 git 可审计）。
- 演示数据：grok 从未计价改为已计价（usd 0.22 · scale），总量与 unpriced 同步更新。

## 验证

- cargo test 199 项（新增 grok 定价测试：别名价、裸名价、grok-4.6-build 仍 unpriced）、clippy/fmt、npm test 47 项、vite build 全绿。
- 数据链：docs.x.ai 模型页（官方）↔ LiteLLM 生成表（官方源）双源一致。