### PR TITLE
test(pricing): 锁死 grok-4.6 与 grok-build-0.1 的价目覆盖

### DIFF
--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -253,6 +253,14 @@ mod tests {
         assert!(price_for("glm-4.6").is_some());
         assert!(price_for("gemini-3-flash-preview").is_some());
         assert!(price_for("gemini-2.5-pro").is_some());
+        // xAI 两个易混淆的裸名都要在表：4.6 的缓存价与 4.5 不同，
+        // grok-build-0.1 是独立定价的代码快模型（别名 grok-code-fast 族）。
+        // 钉在测试里：LiteLLM 若将来掉条目，重新生成会静默失价。
+        let forty_six = price_for("grok-4.6").expect("grok-4.6 priced");
+        assert_eq!(forty_six.cache_read, 0.5);
+        let build_code = price_for("grok-build-0.1").expect("grok-build-0.1 priced");
+        assert_eq!(build_code.input, 1.0);
+        assert_eq!(build_code.output, 2.0);
     }
 
     #[test]


### PR DESCRIPTION
## 影响范围

shared（仅测试）。

## 背景

#125 重新生成的价格表已包含全部 44 条 xAI 官方条目，其中：

- `grok-4.6`：in $2 / cache **$0.50** / out $6——缓存价与 grok-4.5 的 $0.30 不同，靠生成表自然正确
- `grok-build-0.1`：in $1 / cache $0.20 / out $2，独立定价的代码快模型（docs.x.ai 官方别名为 grok-code-fast-1 一族）

本 PR 只把这两个裸名钉进 `first_party_api_models_are_priced_by_bare_name`：LiteLLM 若将来掉条目，重新生成会静默失价，测试拦住并强制显式决策（补 MANUAL_PRICING 或确认退市）。

## 未变的判断

Build 产品线官方指向未变：docs.x.ai（2026-08-19 核对）`grok-build-latest` 仍是 **grok-4.5** 的别名，未挂到 grok-4.6；因此 `grok-4.5-build` 的订阅别名维持，`grok-4.6-build` 无官方佐证继续 unpriced（已有测试锁住）。

## 验证

cargo test pricing 10 项全绿；clippy/fmt 通过。