### PR TITLE
docs: README 与架构图补上 Grok

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Metrik
 
-Metrik 是一款桌面常驻工具，统一查看本机各个 AI 编程 Agent 的官方配额余量与 Token 消耗，支持 ChatGPT、Claude、GLM、Kimi 等主流 Agent。
+Metrik 是一款桌面常驻工具，统一查看本机各个 AI 编程 Agent 的官方配额余量与 Token 消耗，支持 ChatGPT、Claude、GLM、Kimi、Grok 等主流 Agent。
 
 [![Download](https://img.shields.io/github/v/release/keros68/metrik?label=下载&color=success)](https://github.com/keros68/metrik/releases/latest)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,11 +16,13 @@ Codex JSONL ─────┐
 Claude JSONL ────┤
 ZCode SQLite ────┼─ adapter ─ normalized event ─ SQLite ledger ─ period query ─ UI
 OpenCode JSON ───┤
-Kimi wire.jsonl ─┘
+Kimi wire.jsonl ─┤
+Grok updates ────┘
 
-Codex app-server ────────┐
-Claude statusLine hook ──┼─ official quota snapshot ──────────────┘
-Claude OAuth (opt-in) ───┘
+Codex app-server ─────────┐
+Claude statusLine hook ───┼─ official quota snapshot ──────────────┘
+Claude OAuth (opt-in) ────┤
+Grok CLI billing log ─────┘
 ```
 
 The UI invokes one asynchronous Tauri command, `usage_snapshot(period)`. Blocking discovery, parsing, SQLite work, and the local quota subprocess run inside `spawn_blocking`, guarded by a single scan lock. On each request the engine:


### PR DESCRIPTION
## 影响范围

纯文档（README.md、docs/ARCHITECTURE.md）。

## 内容

- README 简介句的 Agent 举例加入 Grok（「支持的 Agent」表格行在 #124 已加，简介句漏了）。
- ARCHITECTURE.md 的数据流示意图补上 Grok 的两个源：用量 `updates.jsonl`（adapter 一侧）与 CLI billing log 配额快照（quota 一侧）——#124 合入时漏更新。