### PR TITLE
fix: widget 打包脚本资产清单回归修复 + 单测护栏

### DIFF
--- a/scripts/build-macos-widget-extension.sh
+++ b/scripts/build-macos-widget-extension.sh
@@ -86,7 +86,8 @@ for asset in \
   workbuddy-app-icon.png \
   qoder-app-icon.png \
   grok-app-icon.png \
-  pi-app-icon.png \n  qwen-app-icon.png
+  pi-app-icon.png \
+  qwen-app-icon.png
 do
   ditto "$PROJECT_DIR/src/assets/$asset" "$APPEX_RESOURCES/$asset"
 done

--- a/scripts/build-macos-widget-preview.sh
+++ b/scripts/build-macos-widget-preview.sh
@@ -70,8 +70,8 @@ for asset in \
   workbuddy-app-icon.png \
   qoder-app-icon.png \
   grok-app-icon.png \
-  pi-app-icon.png \n  qwen-app-icon.png \
-  pi-app-icon.png \n  qwen-app-icon.png
+  pi-app-icon.png \
+  qwen-app-icon.png
 do
   ditto "$PROJECT_DIR/src/assets/$asset" "$APPEX_RESOURCES/$asset"
 done

--- a/src/macosWidgetBundle.test.js
+++ b/src/macosWidgetBundle.test.js
@@ -28,6 +28,65 @@ const widgetBuildScript = fs.readFileSync(
   "scripts/build-macos-widget-extension.sh",
   "utf8",
 );
+const widgetPreviewScript = fs.readFileSync(
+  "scripts/build-macos-widget-preview.sh",
+  "utf8",
+);
+
+/// 提取 `for asset in … do` 列表并校验：名字必须是纯文件名、不重复、
+/// 且真实存在于 src/assets。这能抓住 v0.17.0 那种事故——脚本里混入了字面量
+/// `\n`，bash -n 语法上过、CI 只编译 macOS 也只在发版时才爆（ditto 找不到
+/// src/assets/n）。资产清单从此属于单测管辖。
+function assetLoopEntries(rawScript) {
+  // 检出于 Windows 时是 CRLF，先归一化；匹配与拆分都按 LF 处理。
+  const script = rawScript.replace(/\r\n/g, "\n");
+  const loop = script.match(/for asset in \\([\s\S]*?)^do$/m);
+  assert.ok(loop, "脚本里应有 for asset 循环");
+  return loop[1]
+    .split(/\\\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+test("widget 脚本的图标清单是真实存在的纯文件名且无重复", () => {
+  for (const [name, script] of [
+    ["extension", widgetBuildScript],
+    ["preview", widgetPreviewScript],
+  ]) {
+    const assets = assetLoopEntries(script);
+    assert.ok(assets.length >= 11, `${name} 清单应覆盖全部 Agent 图标`);
+    for (const asset of assets) {
+      assert.match(
+        asset,
+        /^[\w.-]+\.(png|jpg)$/,
+        `${name}: ${asset} 不是纯文件名（混入转义/空白？）`,
+      );
+      assert.ok(
+        fs.existsSync(`src/assets/${asset}`),
+        `${name}: src/assets/${asset} 不存在`,
+      );
+    }
+    assert.equal(
+      new Set(assets).size,
+      assets.length,
+      `${name} 清单里有重复项`,
+    );
+  }
+});
+
+test("Swift 的 asset 映射都被打包脚本覆盖", () => {
+  const shipped = new Set(assetLoopEntries(widgetBuildScript));
+  const referenced = [
+    ...widgetModels.matchAll(/case "\w+": \("([\w.-]+)", "(png|jpg)"\)/g),
+  ].map(([, file, ext]) => `${file}.${ext}`);
+  assert.ok(referenced.length >= 7, "Swift 映射的 case 数量异常");
+  for (const asset of referenced) {
+    assert.ok(
+      shipped.has(asset),
+      `MetrikWidgetModels 引用的 ${asset} 没进 widget 打包清单`,
+    );
+  }
+});
 
 test("macOS release embeds the native WidgetKit extension and helpers", () => {
   assert.equal(


### PR DESCRIPTION
## 事故

v0.17.0 的 macOS 发版构建失败：`build-macos-widget-extension.sh` 资产循环中混入字面量 `\n`（zsh 解释为单词 `n` → `ditto: Cannot get the real path for source '.../src/assets/n'`）。`bash -n` 对此语法合法，CI 的 macOS job 只跑编译不跑打包，因此直到发版才暴露。preview 脚本同病且重复两行。

## 修复

- 两个脚本的循环改为正确的反斜杠续行（11 项，逐行核对）
- `macosWidgetBundle.test.js` 新增护栏：提取循环清单 → 每项必须是纯文件名 + 真实存在于 `src/assets` + 无重复；Swift asset 映射引用的图标必须被清单覆盖。已用受控变异验证（注入同样的字面量 `\n` → 测试红）。

## 影响范围

shared（脚本 + 测试）。v0.17.0 tag 按协议烧毁，本修复随 v0.17.1 发版。