### PR TITLE
feat: 补齐 glm-5.3 官方定价

### DIFF
--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -115,6 +115,7 @@ struct SessionAgg {
     event_count: i64,
     model_components: HashMap<String, TokenComponents>,
     project_tokens: HashMap<String, i64>,
+    cost: CostAccrual,
 }
 
 #[derive(Default)]
@@ -126,6 +127,7 @@ struct ProjectAgg {
     agent_tokens: HashMap<String, i64>,
     sessions: HashSet<(String, String)>,
     pinned: bool,
+    cost: CostAccrual,
 }
 
 /// 项目根路径的展示名：最后一段目录名。
@@ -143,20 +145,33 @@ fn ranked_keys(totals: &HashMap<String, i64>) -> Vec<String> {
     ranked.into_iter().map(|(name, _)| name.clone()).collect()
 }
 
-/// 按模型分量求可计价成本；全部模型都没有定价时返回 None。
-fn estimate_usd(model_components: &HashMap<String, TokenComponents>) -> Option<f64> {
-    let mut total = 0.0_f64;
-    let mut priced_any = false;
-    for (model, comps) in model_components {
-        if let Some(price) = pricing::price_for(model) {
-            priced_any = true;
-            total += comps.input_uncached as f64 * price.input / 1_000_000.0
-                + comps.cache_read as f64 * price.cache_read / 1_000_000.0
-                + comps.cache_write as f64 * price.cache_write / 1_000_000.0
-                + comps.output as f64 * price.output / 1_000_000.0;
+/// 逐事件累计的成本。DeepSeek 按 UTC 时段分峰谷，先按模型汇总再乘单价会把
+/// 时段抹掉，所以计价放在事件粒度上做，汇总的只是算好的金额。
+#[derive(Default)]
+struct CostAccrual {
+    usd: f64,
+    priced_any: bool,
+    unpriced_tokens: i64,
+}
+
+impl CostAccrual {
+    fn add(&mut self, model: Option<&str>, occurred_at_ms: i64, comps: &TokenComponents) {
+        match model.and_then(|model| pricing::price_for(model, occurred_at_ms)) {
+            Some(price) => {
+                self.priced_any = true;
+                self.usd += comps.input_uncached as f64 * price.input / 1_000_000.0
+                    + comps.cache_read as f64 * price.cache_read / 1_000_000.0
+                    + comps.cache_write as f64 * price.cache_write / 1_000_000.0
+                    + comps.output as f64 * price.output / 1_000_000.0;
+            }
+            // 一个模型都没定价时对外仍报"无法估算"，不报 $0。
+            None => self.unpriced_tokens += comps.processed(),
         }
     }
-    priced_any.then_some(total)
+
+    fn usd(&self) -> Option<f64> {
+        self.priced_any.then_some(self.usd)
+    }
 }
 
 pub fn build_snapshot(
@@ -454,12 +469,13 @@ fn sessions_at(
             output: event.output,
         };
         agg.totals.add(&comps);
-        if let Some(model) = event
+        let model = event
             .model
             .as_deref()
             .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
+            .filter(|value| !value.is_empty());
+        agg.cost.add(model, event.timestamp, &comps);
+        if let Some(model) = model {
             agg.model_components
                 .entry(model.to_owned())
                 .or_default()
@@ -490,7 +506,7 @@ fn sessions_at(
             let model = model_totals.first().map(|(model, _)| model.clone());
             let models = model_totals.into_iter().map(|(model, _)| model).collect();
 
-            let usd = estimate_usd(&agg.model_components);
+            let usd = agg.cost.usd();
             let project = ranked_keys(&agg.project_tokens).into_iter().next();
             let project_label = project.as_deref().map(project_label);
 
@@ -627,12 +643,13 @@ fn projects_at(
         *agg.agent_tokens.entry((*agent).to_owned()).or_default() += comps.processed();
         agg.sessions
             .insert(((*agent).to_owned(), event.session_id.clone()));
-        if let Some(model) = event
+        let model = event
             .model
             .as_deref()
             .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
+            .filter(|value| !value.is_empty());
+        agg.cost.add(model, event.timestamp, &comps);
+        if let Some(model) = model {
             agg.model_components
                 .entry(model.to_owned())
                 .or_default()
@@ -649,7 +666,7 @@ fn projects_at(
             cache_read: agg.totals.cache_read,
             cache_write: agg.totals.cache_write,
             output: agg.totals.output,
-            usd: estimate_usd(&agg.model_components),
+            usd: agg.cost.usd(),
             session_count: agg.sessions.len() as i64,
             event_count: agg.event_count,
             last_ms: agg.last_ms,
@@ -894,7 +911,10 @@ fn query_snapshot_at(
         .map(|agent| (*agent, TokenComponents::default()))
         .collect();
     let mut model_totals: HashMap<(String, String), i64> = HashMap::new();
-    let mut model_components: HashMap<(String, String), TokenComponents> = HashMap::new();
+    let mut agent_cost: HashMap<&str, CostAccrual> = AGENT_IDS
+        .iter()
+        .map(|agent| (*agent, CostAccrual::default()))
+        .collect();
 
     for event in events {
         let Some(agent) = AGENT_IDS.iter().find(|agent| **agent == event.adapter) else {
@@ -914,25 +934,29 @@ fn query_snapshot_at(
         }
         buckets.get_mut(agent).expect("registered agent")[index] += event.tokens;
         *totals.entry(agent).or_default() += event.tokens;
-        let comps = components.get_mut(agent).expect("registered agent");
-        comps.input_uncached += event.input_uncached;
-        comps.cache_read += event.cache_read;
-        comps.cache_write += event.cache_write;
-        comps.output += event.output;
-        let model_key = event
+        let event_comps = TokenComponents {
+            input_uncached: event.input_uncached,
+            cache_read: event.cache_read,
+            cache_write: event.cache_write,
+            output: event.output,
+        };
+        components
+            .get_mut(agent)
+            .expect("registered agent")
+            .add(&event_comps);
+        let model = event
             .model
             .as_deref()
             .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("unknown")
-            .to_owned();
-        let model_map_key = ((*agent).to_owned(), model_key);
-        *model_totals.entry(model_map_key.clone()).or_insert(0) += event.tokens;
-        let model_comp = model_components.entry(model_map_key).or_default();
-        model_comp.input_uncached += event.input_uncached;
-        model_comp.cache_read += event.cache_read;
-        model_comp.cache_write += event.cache_write;
-        model_comp.output += event.output;
+            .filter(|value| !value.is_empty());
+        // 模型分布里认不出名字的记成 "unknown"，计价一侧同样归入 unpriced。
+        let model_map_key = ((*agent).to_owned(), model.unwrap_or("unknown").to_owned());
+        *model_totals.entry(model_map_key).or_insert(0) += event.tokens;
+        agent_cost.get_mut(agent).expect("registered agent").add(
+            model,
+            event.timestamp,
+            &event_comps,
+        );
     }
 
     if period == "today" {
@@ -988,44 +1012,20 @@ fn query_snapshot_at(
         }
     };
 
-    let mut agent_cost_usd: HashMap<&str, f64> =
-        AGENT_IDS.iter().map(|agent| (*agent, 0.0)).collect();
-    let mut agent_unpriced_tokens: HashMap<&str, i64> =
-        AGENT_IDS.iter().map(|agent| (*agent, 0)).collect();
-    let mut total_usd = 0.0_f64;
-    let mut unpriced_tokens = 0_i64;
-    for ((agent, model), comp) in &model_components {
-        let processed = comp.input_uncached + comp.cache_read + comp.cache_write + comp.output;
-        match pricing::price_for(model) {
-            Some(price) => {
-                let usd = comp.input_uncached as f64 * price.input / 1_000_000.0
-                    + comp.cache_read as f64 * price.cache_read / 1_000_000.0
-                    + comp.cache_write as f64 * price.cache_write / 1_000_000.0
-                    + comp.output as f64 * price.output / 1_000_000.0;
-                total_usd += usd;
-                if let Some(entry) = agent_cost_usd.get_mut(agent.as_str()) {
-                    *entry += usd;
-                }
-            }
-            None => {
-                unpriced_tokens += processed;
-                if let Some(entry) = agent_unpriced_tokens.get_mut(agent.as_str()) {
-                    *entry += processed;
-                }
-            }
-        }
-    }
     let cost = CostSummary {
         available: true,
-        total_usd,
-        unpriced_tokens,
+        total_usd: agent_cost.values().map(|accrual| accrual.usd).sum(),
+        unpriced_tokens: agent_cost
+            .values()
+            .map(|accrual| accrual.unpriced_tokens)
+            .sum(),
         pricing_as_of: pricing::PRICING_AS_OF.to_owned(),
         by_agent: AGENT_IDS
             .iter()
             .map(|agent| AgentCost {
                 agent: (*agent).to_owned(),
-                usd: agent_cost_usd[agent],
-                unpriced_tokens: agent_unpriced_tokens[agent],
+                usd: agent_cost[agent].usd,
+                unpriced_tokens: agent_cost[agent].unpriced_tokens,
             })
             .collect(),
     };
@@ -2138,6 +2138,71 @@ mod tests {
         assert_eq!(session.model, None);
         assert!(session.models.is_empty());
         assert_eq!(session.usd, None);
+    }
+
+    #[test]
+    fn deepseek_cost_follows_the_utc_peak_and_off_peak_windows() {
+        // DeepSeek 按 UTC 时段分峰谷。计价必须拿事件自己的时间戳去查价：
+        // 先按模型汇总再乘单价，两个时段的用量会被抹成一个价。
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(include_str!("../migrations/001_init.sql"))
+            .unwrap();
+        let today = Local::now().date_naive();
+        let local_now = test_local_time(today, 23);
+
+        // 本地一天覆盖 24 个 UTC 小时，峰段最长的空档也只有 15 小时，
+        // 所以 0–22 点里一定各能找到一个峰段和一个谷段时刻（与时区无关）。
+        let hour_ms = |hour: u32| -> Option<i64> {
+            Local
+                .from_local_datetime(&today.and_hms_opt(hour, 0, 0).unwrap())
+                .single()
+                .map(|time| time.timestamp_millis())
+        };
+        // 时间戳 0 是 UTC 00:00，落在谷段；谷段价是峰段的一半，比它贵就是峰段。
+        let off_peak_input = pricing::price_for("deepseek-v4-pro", 0).unwrap().input;
+        let is_peak =
+            |ms: i64| pricing::price_for("deepseek-v4-pro", ms).unwrap().input > off_peak_input;
+        let peak_ms = (0..23)
+            .filter_map(hour_ms)
+            .find(|ms| is_peak(*ms))
+            .expect("本地日里必有峰段时刻");
+        let off_peak_ms = (0..23)
+            .filter_map(hour_ms)
+            .find(|ms| !is_peak(*ms))
+            .expect("本地日里必有谷段时刻");
+
+        for (event_id, session_id, occurred_at_ms) in [
+            ("ds-peak", "sess-peak", peak_ms),
+            ("ds-off-peak", "sess-off-peak", off_peak_ms),
+        ] {
+            insert_test_session_event(
+                &connection,
+                event_id,
+                "claude",
+                session_id,
+                occurred_at_ms,
+                Some("deepseek-v4-pro"),
+                1_000_000,
+                0,
+                0,
+                1_000_000,
+            );
+        }
+
+        let result = sessions_at(&connection, "today", local_now).unwrap();
+        let usd_of = |session_id: &str| {
+            result
+                .sessions
+                .iter()
+                .find(|session| session.session_id == session_id)
+                .unwrap()
+                .usd
+                .unwrap()
+        };
+        // 官方谷段价正是峰段的一半，用量完全相同，成本就该差一倍。
+        assert!((usd_of("sess-peak") - (1.32 + 3.96)).abs() < 1e-9);
+        assert!((usd_of("sess-off-peak") - (0.66 + 1.98)).abs() < 1e-9);
     }
 
     #[test]

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -22,6 +22,15 @@
 //! 按裸模型名匹配）。OpenCode、Antigravity 等直连这些官方 API 的用量因此可以
 //! 计价（如 kimi-k2.5、glm-4.6、gemini-3-flash-preview）。
 //!
+//! 生成表覆盖不到的官方 API（DeepSeek、阿里云百炼的 Qwen）按官方定价页手动
+//! 补在 MANUAL_PRICING，规则不变：只认官方第一方价目，不借第三方转售价。
+//!
+//! ## 分时定价
+//!
+//! DeepSeek 按 UTC 时段分峰谷，谷段是峰段的 5 折。所以 `price_for` 收事件
+//! 时间戳：成本必须逐事件计价，先按模型汇总再乘单价会把时段信息抹掉。
+//! 表里存峰段（标准）价，谷段在查表时打折，见 OFF_PEAK_HALF_PRICE。
+//!
 //! 订阅制 coding plan 的专属模型 ID 一律 unpriced：Kimi Code 的 kimi-for-coding 等。
 //! 订阅额度按周期重置、不按 token 卖；
 //! LiteLLM 里那些名字的 Bedrock/Azure/Cloudflare 条目是第三方转售价，拿来当
@@ -54,6 +63,18 @@ pub struct Pricing {
     pub output: f64,
 }
 
+impl Pricing {
+    /// 谷段 5 折：四个分量同比例打折（DeepSeek 官方谷段价正是峰段的一半）。
+    fn halved(self) -> Self {
+        Self {
+            input: self.input / 2.0,
+            cache_read: self.cache_read / 2.0,
+            cache_write: self.cache_write / 2.0,
+            output: self.output / 2.0,
+        }
+    }
+}
+
 /// 手动补充的官方第一方价目（生成表之外）：模型太新、LiteLLM 尚未收录时
 /// 按官方定价页临时补齐，收录后即可删。查找时先于生成表命中。
 /// 来源：
@@ -64,7 +85,32 @@ pub struct Pricing {
 ///   佐证来源可信）。缓存写入官方标注限时免费 → 记 0。
 /// - glm-5.3：同页（2026-08-20 核对），官方定价与 glm-5.2 相同：输入 $1.4/M、
 ///   缓存命中 $0.26/M、输出 $4.4/M。同价是官方定价如此，不是沿用旧价。
+/// - deepseek-v4-pro / deepseek-v4-flash：DeepSeek 官方定价页
+///   api-docs.deepseek.com/quick_start/pricing（2026-08-20 核对）。存的是峰段
+///   标准价，谷段由 OFF_PEAK_HALF_PRICE 打 5 折。缓存写入官方不单独计费 → 记 0。
+/// - qwen3.8-max：阿里云百炼（2026-08-20 核对）。输入 $2/M、输出 $6/M 是官方
+///   公布价；缓存两项官方尚未逐模型列出，按百炼计费文档的通用规则推算——
+///   命中按输入价 10%（$0.2/M）、显式缓存写入按 125%（$2.5/M）。这两项是
+///   规则推算不是逐模型报价，官方列出后应替换。
 const MANUAL_PRICING: &[(&str, Pricing)] = &[
+    (
+        "deepseek-v4-flash",
+        Pricing {
+            input: 0.44,
+            cache_read: 0.014,
+            cache_write: 0.0,
+            output: 1.32,
+        },
+    ),
+    (
+        "deepseek-v4-pro",
+        Pricing {
+            input: 1.32,
+            cache_read: 0.044,
+            cache_write: 0.0,
+            output: 3.96,
+        },
+    ),
     (
         "glm-5-turbo",
         Pricing {
@@ -101,7 +147,21 @@ const MANUAL_PRICING: &[(&str, Pricing)] = &[
             output: 15.0,
         },
     ),
+    (
+        "qwen3.8-max",
+        Pricing {
+            input: 2.0,
+            cache_read: 0.2,
+            cache_write: 2.5,
+            output: 6.0,
+        },
+    ),
 ];
+
+/// 官方按 UTC 时段分价的模型：谷段单价 = 表内标准价 × 0.5。
+/// DeepSeek 定价页（2026-08-20 核对）：峰段 01:00–04:00 与 06:00–10:00 UTC，
+/// 其余时段为谷段、5 折。表内存峰段标准价，与其他模型「存官方标价」一致。
+const OFF_PEAK_HALF_PRICE: &[&str] = &["deepseek-v4-flash", "deepseek-v4-pro"];
 
 /// 订阅制 coding plan 的模型 ID → 同一模型的官方第一方 API 价（估算口径）。
 /// 仅限"同一模型"，且要有官方佐证，不是看名字像就归一：
@@ -112,6 +172,9 @@ const MANUAL_PRICING: &[(&str, Pricing)] = &[
 /// - Grok Build 订阅记的 `grok-4.5-build`：docs.x.ai 模型页里 grok-4.5 的官方
 ///   别名就含 `grok-build-latest`（Build 产品线 = grok-4.5，2026-08-19 核对），
 ///   故按 grok-4.5 官方 API 价估算。
+/// - Codex 自动评审记的 `codex-auto-review`：OpenAI 官方页
+///   alignment.openai.com/auto-review 明写「Auto-review uses GPT-5.4 Thinking
+///   (low reasoning)」（2026-08-20 核对），故按 gpt-5.4 官方 API 价估算。
 ///
 /// 没有官方价的订阅 ID（kimi-for-coding 等）继续 unpriced。
 const SUBSCRIPTION_ALIASES: &[(&str, &str)] = &[
@@ -119,14 +182,45 @@ const SUBSCRIPTION_ALIASES: &[(&str, &str)] = &[
     ("GLM-5.3", "glm-5.3"),
     ("kimi-code/k3", "kimi-k3"),
     ("grok-4.5-build", "grok-4.5"),
+    ("codex-auto-review", "gpt-5.4"),
 ];
 
-/// 返回 `model` 的定价；表里没有则返回 `None`（调用方归入 unpriced，
-/// 不得臆造价格）。见模块文档：只精确匹配，日期快照后缀与订阅别名除外。
-pub fn price_for(model: &str) -> Option<Pricing> {
-    exact(model)
-        .or_else(|| exact(strip_date_suffix(model)?))
-        .or_else(|| subscription_alias(model).and_then(exact))
+/// 返回 `model` 在 `occurred_at_ms` 时刻的定价；表里没有则返回 `None`
+/// （调用方归入 unpriced，不得臆造价格）。见模块文档：只精确匹配，日期快照
+/// 后缀与订阅别名除外。时间戳只对 OFF_PEAK_HALF_PRICE 里的模型有影响，
+/// 其余模型全天一价。
+pub fn price_for(model: &str, occurred_at_ms: i64) -> Option<Pricing> {
+    let (canonical, price) = resolve(model)?;
+    Some(if in_off_peak(canonical, occurred_at_ms) {
+        price.halved()
+    } else {
+        price
+    })
+}
+
+/// 归一到表里的规范名，连同标准价一起返回。规范名（而不是调用方传进来的
+/// 别名）才是查分时定价的依据。
+fn resolve(model: &str) -> Option<(&str, Pricing)> {
+    if let Some(pricing) = exact(model) {
+        return Some((model, pricing));
+    }
+    if let Some(base) = strip_date_suffix(model) {
+        if let Some(pricing) = exact(base) {
+            return Some((base, pricing));
+        }
+    }
+    let target = subscription_alias(model)?;
+    exact(target).map(|pricing| (target, pricing))
+}
+
+/// DeepSeek 峰段是 01:00–04:00 与 06:00–10:00 UTC（左闭右开），其余为谷段。
+fn in_off_peak(canonical: &str, occurred_at_ms: i64) -> bool {
+    if !OFF_PEAK_HALF_PRICE.contains(&canonical) {
+        return false;
+    }
+    // Unix 纪元起点就是 UTC 00:00，UTC 又没有夏令时，整除即可，不必引 chrono。
+    let hour = occurred_at_ms.div_euclid(3_600_000).rem_euclid(24);
+    !((1..4).contains(&hour) || (6..10).contains(&hour))
 }
 
 fn exact(model: &str) -> Option<Pricing> {
@@ -161,6 +255,10 @@ fn strip_date_suffix(model: &str) -> Option<&str> {
 mod tests {
     use super::*;
 
+    /// 峰谷之外的模型全天一价，用哪个时刻都一样；固定一个（2026-08-20 12:30
+    /// UTC）省得每条断言各写各的。
+    const ANY_TIME_MS: i64 = 1_787_229_000_000;
+
     #[test]
     fn table_is_sorted_and_nonempty_so_binary_search_is_valid() {
         assert!(PRICING_TABLE.len() > 50, "生成的价格表异常地小");
@@ -172,22 +270,25 @@ mod tests {
 
     #[test]
     fn dated_snapshot_falls_back_to_the_undated_alias() {
-        let base = price_for("claude-haiku-4-5").expect("priced");
+        let base = price_for("claude-haiku-4-5", ANY_TIME_MS).expect("priced");
         // LiteLLM 恰好也收录了这个日期版；剥后缀的回退对它未收录的新快照才关键。
-        let dated = price_for("claude-haiku-4-5-20251001").expect("priced");
+        let dated = price_for("claude-haiku-4-5-20251001", ANY_TIME_MS).expect("priced");
         assert_eq!(base.input, dated.input);
         assert_eq!(base.output, dated.output);
 
         // 表里没有的未来快照，靠剥后缀命中别名。
-        let future = price_for("claude-opus-4-8-20260401").expect("priced");
-        assert_eq!(future.input, price_for("claude-opus-4-8").unwrap().input);
+        let future = price_for("claude-opus-4-8-20260401", ANY_TIME_MS).expect("priced");
+        assert_eq!(
+            future.input,
+            price_for("claude-opus-4-8", ANY_TIME_MS).unwrap().input
+        );
     }
 
     #[test]
     fn new_generation_never_borrows_an_older_models_price() {
         // 这是回归测试：前缀匹配曾让 gpt-5.6-sol 命中 gpt-5 的价格，低估 74%。
-        let sol = price_for("gpt-5.6-sol").expect("priced");
-        let five = price_for("gpt-5").expect("priced");
+        let sol = price_for("gpt-5.6-sol", ANY_TIME_MS).expect("priced");
+        let five = price_for("gpt-5", ANY_TIME_MS).expect("priced");
         assert_ne!(
             sol.input, five.input,
             "gpt-5.6-sol 必须用自己的价格，不能退回 gpt-5",
@@ -202,35 +303,35 @@ mod tests {
     fn subscription_only_model_ids_stay_unpriced() {
         // 订阅 coding plan 的专属 ID 没有官方按 token 价目：不得借第三方
         // 转售价或同系模型的价格蒙混（Kimi Code 订阅等）。
-        assert!(price_for("kimi-code/kimi-for-coding").is_none());
-        assert!(price_for("kimi-for-coding").is_none());
+        assert!(price_for("kimi-code/kimi-for-coding", ANY_TIME_MS).is_none());
+        assert!(price_for("kimi-for-coding", ANY_TIME_MS).is_none());
         // 有 -preview 后缀的官方价也不补给稳定版名字。
-        assert!(price_for("gemini-3.1-pro").is_none());
+        assert!(price_for("gemini-3.1-pro", ANY_TIME_MS).is_none());
     }
 
     #[test]
     fn glm_priced_from_official_rates_including_case_alias() {
         // z.ai 官方定价页（2026-07-20 核对）：glm-5.2 输入 $1.4、缓存 $0.26、
         // 输出 $4.4；glm-5-turbo 输入 $1.2、缓存 $0.24、输出 $4.0。
-        let direct = price_for("glm-5.2").expect("glm-5.2 priced");
+        let direct = price_for("glm-5.2", ANY_TIME_MS).expect("glm-5.2 priced");
         assert_eq!(direct.input, 1.4);
         assert_eq!(direct.cache_read, 0.26);
         assert_eq!(direct.output, 4.4);
-        let turbo = price_for("glm-5-turbo").expect("glm-5-turbo priced");
+        let turbo = price_for("glm-5-turbo", ANY_TIME_MS).expect("glm-5-turbo priced");
         assert_eq!(turbo.input, 1.2);
         assert_eq!(turbo.output, 4.0);
         // ZCode coding-plan 记的大写 GLM-5.2 是同一模型的大小写变体，同价。
-        let aliased = price_for("GLM-5.2").expect("alias priced");
+        let aliased = price_for("GLM-5.2", ANY_TIME_MS).expect("alias priced");
         assert_eq!(aliased.input, direct.input);
         assert_eq!(aliased.output, direct.output);
 
         // glm-5.3 官方定价与 5.2 相同（2026-08-20 核对）；claude/pi 适配器记
         // 小写裸名，ZCode 记大写，两种写法都要计价。
-        let five_three = price_for("glm-5.3").expect("glm-5.3 priced");
+        let five_three = price_for("glm-5.3", ANY_TIME_MS).expect("glm-5.3 priced");
         assert_eq!(five_three.input, 1.4);
         assert_eq!(five_three.cache_read, 0.26);
         assert_eq!(five_three.output, 4.4);
-        let five_three_upper = price_for("GLM-5.3").expect("alias priced");
+        let five_three_upper = price_for("GLM-5.3", ANY_TIME_MS).expect("alias priced");
         assert_eq!(five_three_upper.input, five_three.input);
         assert_eq!(five_three_upper.output, five_three.output);
     }
@@ -239,16 +340,16 @@ mod tests {
     fn kimi_k3_priced_from_official_rates_including_subscription_alias() {
         // 手动补充的官方价（LiteLLM 未收录时临时补齐）：K3 输入 $3、
         // 缓存 $0.3、输出 $15（2026-07-18 官方定价页核对）。
-        let direct = price_for("kimi-k3").expect("kimi-k3 priced");
+        let direct = price_for("kimi-k3", ANY_TIME_MS).expect("kimi-k3 priced");
         assert_eq!(direct.input, 3.0);
         assert_eq!(direct.cache_read, 0.3);
         assert_eq!(direct.output, 15.0);
         // 窄例外：Kimi Code 订阅的 kimi-code/k3 就是 K3 本身，按同一官方价估算。
-        let aliased = price_for("kimi-code/k3").expect("alias priced");
+        let aliased = price_for("kimi-code/k3", ANY_TIME_MS).expect("alias priced");
         assert_eq!(aliased.input, direct.input);
         assert_eq!(aliased.output, direct.output);
         // 其他订阅 ID 仍不得蒙混（见上一条测试）。
-        assert!(price_for("kimi-code/k4").is_none());
+        assert!(price_for("kimi-code/k4", ANY_TIME_MS).is_none());
     }
 
     #[test]
@@ -257,40 +358,91 @@ mod tests {
         // docs.x.ai 模型页 grok-4.5 的官方别名含 grok-build-latest（Build
         // 产品线 = grok-4.5；in $2 / cache $0.30 / out $6，2026-08-19 与
         // LiteLLM 交叉一致）。直连 xAI API 的裸名也照表计价。
-        let aliased = price_for("grok-4.5-build").expect("alias priced");
+        let aliased = price_for("grok-4.5-build", ANY_TIME_MS).expect("alias priced");
         assert_eq!(aliased.input, 2.0);
         assert_eq!(aliased.cache_read, 0.3);
         assert_eq!(aliased.output, 6.0);
-        let direct = price_for("grok-4.5").expect("api name priced");
+        let direct = price_for("grok-4.5", ANY_TIME_MS).expect("api name priced");
         assert_eq!(direct.input, aliased.input);
         assert_eq!(direct.output, aliased.output);
         // 未佐证的其他订阅变体不得蒙混：前缀匹配是事故，不重演。
-        assert!(price_for("grok-4.6-build").is_none());
+        assert!(price_for("grok-4.6-build", ANY_TIME_MS).is_none());
     }
 
     #[test]
     fn first_party_api_models_are_priced_by_bare_name() {
         // OpenCode / Antigravity 等直连官方 API 的用量按第一方价目计价
         // （LiteLLM 键的 provider 前缀在生成时已剥掉）。
-        assert!(price_for("kimi-k2.5").is_some());
-        assert!(price_for("glm-4.6").is_some());
-        assert!(price_for("gemini-3-flash-preview").is_some());
-        assert!(price_for("gemini-2.5-pro").is_some());
+        assert!(price_for("kimi-k2.5", ANY_TIME_MS).is_some());
+        assert!(price_for("glm-4.6", ANY_TIME_MS).is_some());
+        assert!(price_for("gemini-3-flash-preview", ANY_TIME_MS).is_some());
+        assert!(price_for("gemini-2.5-pro", ANY_TIME_MS).is_some());
         // xAI 两个易混淆的裸名都要在表：4.6 的缓存价与 4.5 不同，
         // grok-build-0.1 是独立定价的代码快模型（别名 grok-code-fast 族）。
         // 钉在测试里：LiteLLM 若将来掉条目，重新生成会静默失价。
-        let forty_six = price_for("grok-4.6").expect("grok-4.6 priced");
+        let forty_six = price_for("grok-4.6", ANY_TIME_MS).expect("grok-4.6 priced");
         assert_eq!(forty_six.cache_read, 0.5);
-        let build_code = price_for("grok-build-0.1").expect("grok-build-0.1 priced");
+        let build_code = price_for("grok-build-0.1", ANY_TIME_MS).expect("grok-build-0.1 priced");
         assert_eq!(build_code.input, 1.0);
         assert_eq!(build_code.output, 2.0);
     }
 
     #[test]
+    fn deepseek_switches_between_peak_and_off_peak_rates() {
+        // DeepSeek 官方定价页（2026-08-20 核对）：峰段 01:00–04:00 与
+        // 06:00–10:00 UTC 是标准价，其余时段 5 折。表内存峰段价。
+        let peak = price_for("deepseek-v4-pro", 1_787_193_000_000).expect("peak priced");
+        assert_eq!(peak.input, 1.32);
+        assert_eq!(peak.cache_read, 0.044);
+        assert_eq!(peak.output, 3.96);
+        let off_peak = price_for("deepseek-v4-pro", 1_787_229_000_000).expect("off-peak priced");
+        assert_eq!(off_peak.input, 0.66);
+        assert_eq!(off_peak.cache_read, 0.022);
+        assert_eq!(off_peak.output, 1.98);
+
+        // 边界左闭右开：09:30 还在峰段，10:30 已经出峰段。
+        assert_eq!(
+            price_for("deepseek-v4-pro", 1_787_218_200_000)
+                .unwrap()
+                .input,
+            1.32,
+        );
+        assert_eq!(
+            price_for("deepseek-v4-pro", 1_787_221_800_000)
+                .unwrap()
+                .input,
+            0.66,
+        );
+
+        // 分时只对 DeepSeek 生效，别的模型全天一价。
+        let glm_peak = price_for("glm-5.3", 1_787_193_000_000).expect("priced");
+        let glm_off = price_for("glm-5.3", 1_787_229_000_000).expect("priced");
+        assert_eq!(glm_peak.input, glm_off.input);
+    }
+
+    #[test]
+    fn qwen_and_codex_auto_review_are_priced_from_official_sources() {
+        // 阿里云百炼 qwen3.8-max：输入 $2、输出 $6 是官方公布价；缓存两项按
+        // 官方计费规则推算（命中 10%、显式缓存写入 125%）。
+        let qwen = price_for("qwen3.8-max", ANY_TIME_MS).expect("qwen3.8-max priced");
+        assert_eq!(qwen.input, 2.0);
+        assert_eq!(qwen.cache_read, 0.2);
+        assert_eq!(qwen.cache_write, 2.5);
+        assert_eq!(qwen.output, 6.0);
+
+        // codex-auto-review 按 OpenAI 官方声明的 GPT-5.4 计价，不是自成一档。
+        let review = price_for("codex-auto-review", ANY_TIME_MS).expect("alias priced");
+        let gpt = price_for("gpt-5.4", ANY_TIME_MS).expect("gpt-5.4 priced");
+        assert_eq!(review.input, gpt.input);
+        assert_eq!(review.cache_read, gpt.cache_read);
+        assert_eq!(review.output, gpt.output);
+    }
+
+    #[test]
     fn unknown_model_is_unpriced() {
-        assert!(price_for("unknown").is_none());
-        assert!(price_for("").is_none());
+        assert!(price_for("unknown", ANY_TIME_MS).is_none());
+        assert!(price_for("", ANY_TIME_MS).is_none());
         // 未知模型带日期后缀也不能靠剥后缀蒙混过关。
-        assert!(price_for("totally-made-up-20260101").is_none());
+        assert!(price_for("totally-made-up-20260101", ANY_TIME_MS).is_none());
     }
 }

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -62,6 +62,8 @@ pub struct Pricing {
 /// - glm-5.2 / glm-5-turbo：z.ai 官方定价页 docs.z.ai/guides/overview/pricing
 ///   （2026-07-20 核对；同页 glm-5/glm-5.1 数值与 LiteLLM 生成表完全一致，
 ///   佐证来源可信）。缓存写入官方标注限时免费 → 记 0。
+/// - glm-5.3：同页（2026-08-20 核对），官方定价与 glm-5.2 相同：输入 $1.4/M、
+///   缓存命中 $0.26/M、输出 $4.4/M。同价是官方定价如此，不是沿用旧价。
 const MANUAL_PRICING: &[(&str, Pricing)] = &[
     (
         "glm-5-turbo",
@@ -74,6 +76,15 @@ const MANUAL_PRICING: &[(&str, Pricing)] = &[
     ),
     (
         "glm-5.2",
+        Pricing {
+            input: 1.4,
+            cache_read: 0.26,
+            cache_write: 0.0,
+            output: 4.4,
+        },
+    ),
+    (
+        "glm-5.3",
         Pricing {
             input: 1.4,
             cache_read: 0.26,
@@ -96,7 +107,8 @@ const MANUAL_PRICING: &[(&str, Pricing)] = &[
 /// 仅限"同一模型"，且要有官方佐证，不是看名字像就归一：
 /// - Kimi Code 订阅记的 `kimi-code/k3` 就是 kimi-k3 本身，
 ///   官方称 Extra Usage"接近开放平台官方 API 价"；成本页始终标注为估算。
-/// - ZCode coding-plan 记的 `GLM-5.2` 只是 glm-5.2 的大小写变体，同一模型。
+/// - ZCode coding-plan 记的 `GLM-5.2`、`GLM-5.3` 只是 glm-5.2、glm-5.3 的
+///   大小写变体，同一模型。
 /// - Grok Build 订阅记的 `grok-4.5-build`：docs.x.ai 模型页里 grok-4.5 的官方
 ///   别名就含 `grok-build-latest`（Build 产品线 = grok-4.5，2026-08-19 核对），
 ///   故按 grok-4.5 官方 API 价估算。
@@ -104,6 +116,7 @@ const MANUAL_PRICING: &[(&str, Pricing)] = &[
 /// 没有官方价的订阅 ID（kimi-for-coding 等）继续 unpriced。
 const SUBSCRIPTION_ALIASES: &[(&str, &str)] = &[
     ("GLM-5.2", "glm-5.2"),
+    ("GLM-5.3", "glm-5.3"),
     ("kimi-code/k3", "kimi-k3"),
     ("grok-4.5-build", "grok-4.5"),
 ];
@@ -210,6 +223,16 @@ mod tests {
         let aliased = price_for("GLM-5.2").expect("alias priced");
         assert_eq!(aliased.input, direct.input);
         assert_eq!(aliased.output, direct.output);
+
+        // glm-5.3 官方定价与 5.2 相同（2026-08-20 核对）；claude/pi 适配器记
+        // 小写裸名，ZCode 记大写，两种写法都要计价。
+        let five_three = price_for("glm-5.3").expect("glm-5.3 priced");
+        assert_eq!(five_three.input, 1.4);
+        assert_eq!(five_three.cache_read, 0.26);
+        assert_eq!(five_three.output, 4.4);
+        let five_three_upper = price_for("GLM-5.3").expect("alias priced");
+        assert_eq!(five_three_upper.input, five_three.input);
+        assert_eq!(five_three_upper.output, five_three.output);
     }
 
     #[test]


### PR DESCRIPTION
## 问题

GLM-5.3 上线后价目表里没有它，成本估算的 GLM 一栏显示「未计价」。

## 改动

按 z.ai 官方定价页（docs.z.ai/guides/overview/pricing，2026-08-20 核对）把
glm-5.3 补进 `MANUAL_PRICING`：

| | 输入 | 缓存命中 | 缓存写入 | 输出 |
|---|---|---|---|---|
| glm-5.3 | $1.4/M | $0.26/M | 0（官方限时免费） | $4.4/M |

与 glm-5.2 同价——官方定价如此，不是沿用旧价。VentureBeat / OpenRouter 的
GLM-5.3 条目为同一数值，交叉一致。

`claude`、`pi` 适配器记的是小写裸名 `glm-5.3`，ZCode coding-plan 记大写
`GLM-5.3`；后者按既有窄例外加进 `SUBSCRIPTION_ALIASES`（同一模型的大小写变体，
不是猜价）。

生成表 `pricing_table.rs` 未动，LiteLLM 收录后可删掉这条手动价目。

## 验证

- `cargo test pricing`：10 项全绿，新增两种写法的断言
- `cargo fmt --check`、`cargo clippy -- -D warnings`：干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)
