### PR TITLE
chore: clippy 纳入测试代码，并清掉已攒下的 10 处告警

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,10 @@ jobs:
         run: cargo fmt --check
         working-directory: src-tauri
 
+      # --all-targets 把测试代码也纳入检查：不带它时 #[cfg(test)] 里的问题
+      # 攒了一批才被发现。
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
         working-directory: src-tauri
 
       # 读取本机真实 Agent 日志的烟测标记为 ignored，CI 里跑不了也不该跑。

--- a/src-tauri/src/adapters/grok.rs
+++ b/src-tauri/src/adapters/grok.rs
@@ -504,7 +504,7 @@ mod tests {
         // processed = input + output（cache/reasoning 已含在分量内，不另加）
         assert_eq!(first.tokens.processed(), 120);
         assert_eq!(first.model.as_deref(), Some("grok-4.5-build"));
-        assert_eq!(first.occurred_at_ms, 1785935395_000);
+        assert_eq!(first.occurred_at_ms, 1_785_935_395_000);
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 

--- a/src-tauri/src/adapters/pi.rs
+++ b/src-tauri/src/adapters/pi.rs
@@ -377,9 +377,9 @@ fn fallback_identity(entry_id: &Option<String>, timestamp: Option<i64>) -> Strin
     format!("fallback:{id}")
 }
 
-/// 会话文件目录名（`--D--work-usage--`）是有损编码，不可反推项目路径；
-/// 项目归属只认 session 头里的 `cwd`（见 `project_attribution_never_comes_
-/// from_the_directory_name` 测试）。
+// 会话文件目录名（`--D--work-usage--`）是有损编码，不可反推项目路径；
+// 项目归属只认 session 头里的 `cwd`（见 `project_attribution_never_comes_
+// from_the_directory_name` 测试）。
 
 #[cfg(test)]
 mod tests {
@@ -415,7 +415,7 @@ mod tests {
         // 字段形状取自本机真实日志（zai-coding-cn / glm-5.3）。
         let path = session_file(
             "assistant",
-            &concat!(
+            concat!(
                 r#"{"type":"session","version":3,"id":"ses-1","timestamp":"2026-08-20T00:31:11.882Z","cwd":"D:\\work\\usage"}"#,
                 "\n",
                 r#"{"type":"message","id":"631fa049","parentId":"793123d5","timestamp":"2026-08-20T00:32:00.897Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"provider":"zai-coding-cn","model":"glm-5.3","responseId":"202608171505273491557405ff476a","usage":{"input":2882,"output":561,"cacheRead":1088,"cacheWrite":0,"reasoning":503,"totalTokens":4531,"cost":{"total":0}},"stopReason":"stop"}}"#,
@@ -449,7 +449,7 @@ mod tests {
         // 这次调用确实计费，照常入账。
         let path = session_file(
             "aborted",
-            &concat!(
+            concat!(
                 r#"{"type":"session","version":3,"id":"ses-1","cwd":"/tmp"}"#,
                 "\n",
                 r#"{"type":"message","id":"c6115304","timestamp":"2026-08-19T00:30:00.000Z","message":{"role":"assistant","provider":"zai-coding-cn","model":"glm-5.3","usage":{"input":100,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":120},"stopReason":"aborted"}}"#,
@@ -511,7 +511,7 @@ mod tests {
         // 摘要生成与工具内嵌 LLM 调用都是真实计费；pi 自己的会话合计也含它们。
         let path = session_file(
             "compaction",
-            &concat!(
+            concat!(
                 r#"{"type":"session","id":"ses-1","cwd":"/tmp"}"#,
                 "\n",
                 r#"{"type":"compaction","id":"f6g7h8i9","timestamp":"2026-08-20T01:00:00.000Z","summary":"…","tokensBefore":50000,"usage":{"input":8000,"output":900,"cacheRead":0,"cacheWrite":0,"totalTokens":8900}}"#,
@@ -555,7 +555,7 @@ mod tests {
     fn a_reported_total_that_disagrees_marks_the_source_partial() {
         let path = session_file(
             "mismatch",
-            &concat!(
+            concat!(
                 r#"{"type":"session","id":"ses-1","cwd":"/tmp"}"#,
                 "\n",
                 r#"{"type":"message","id":"m1","timestamp":"2026-08-20T00:32:00.000Z","message":{"role":"assistant","model":"glm-5.3","responseId":"r1","usage":{"input":100,"output":50,"totalTokens":999}}}"#,
@@ -577,7 +577,7 @@ mod tests {
     fn duplicate_identity_with_a_conflicting_model_is_rejected_keeping_other_events() {
         let path = session_file(
             "conflict",
-            &concat!(
+            concat!(
                 r#"{"type":"session","id":"ses-1","cwd":"/tmp"}"#,
                 "\n",
                 r#"{"type":"message","id":"a1","timestamp":"2026-08-20T00:32:00.000Z","message":{"role":"assistant","model":"glm-5.3","responseId":"r1","usage":{"input":100,"output":50,"totalTokens":150}}}"#,
@@ -605,7 +605,7 @@ mod tests {
         // 外来文件处理，整文件不计并标注数据不完整。
         let tolerant = session_file(
             "omp-title",
-            &concat!(
+            concat!(
                 r#"{"type":"title","v":1,"title":"Comment on GitHub issue","source":"auto"}"#,
                 "\n",
                 r#"{"type":"session","id":"ses-omp","cwd":"/tmp"}"#,
@@ -616,7 +616,7 @@ mod tests {
         );
         let foreign = session_file(
             "foreign",
-            &concat!(
+            concat!(
                 r#"{"type":"totally_unknown_thing","foo":"bar"}"#,
                 "\n",
                 r#"{"type":"session","id":"ses-x","cwd":"/tmp"}"#,
@@ -642,7 +642,7 @@ mod tests {
     fn malformed_lines_and_cutoff_respect_diagnostics() {
         let path = session_file(
             "diagnostics",
-            &concat!(
+            concat!(
                 r#"{"type":"session","id":"ses-1","cwd":"/tmp"}"#,
                 "\n",
                 "not-json\n",


### PR DESCRIPTION
## 问题

CI 跑的是 `cargo clippy -- -D warnings`，不带 `--all-targets`，所以 `#[cfg(test)]` 里的代码一直没进检查。攒到现在有 10 处：

- `pi.rs`：8 处多余取址（`&concat!(...)`），1 处 `///` 误挂到 `mod tests` 上——那段是模块说明，不是 tests 的文档
- `grok.rs`：1 处数字下划线分组不一致（`1785935395_000`）

## 改动

先清干净，再把 `--all-targets` 加进 CI，测试代码就不会再这样悄悄积累。前 8 处由 `cargo clippy --fix` 生成，后两处手改。

## 验证

- `cargo clippy --all-targets -- -D warnings`：干净
- `cargo fmt --check`、`cargo test`（218 项）：全绿

与 #132、#134 无文件重叠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
