### PR TITLE
fix: pi 是 harness 不是计量身份，用量与配额按 provider 归属

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Claude statusLine hook ───┼─ official quota snapshot ─────�
 Claude OAuth (opt-in) ────┤
 Grok CLI billing log ─────┤
 GLM/Kimi/Qoder/WorkBuddy ─┤
-Pi (GLM key from pi) ─────┘
+GLM key from pi auth ─────┘
 ```
 
 The UI invokes one asynchronous Tauri command, `usage_snapshot(period)`. Blocking discovery, parsing, SQLite work, and the local quota subprocess run inside `spawn_blocking`, guarded by a single scan lock. On each request the engine:
@@ -79,7 +79,13 @@ Quota rows are replaced wholesale, never merged, so a window a plan no longer ha
 - **Codex**: `primary` and `secondary` are slots, not window semantics — a plan may carry a weekly window in the `primary` slot and have no `secondary` at all. Windows are classified by `windowDurationMins` (≤ 1440 minutes is a session window, otherwise weekly); the slot name is only a fallback when the duration is absent. A successful `app-server` read replaces the whole Codex row set.
 - **Claude**: the statusLine hook file is the zero-credential source. Every platform handles the hook natively inside `metrik --statusline`, invoked directly by Claude Code before desktop initialization; there is no external interpreter dependency. The chained delegate and the absolute quota-file path live in `metrik-statusline.json` metadata; the delegate runs through the platform shell (`cmd.exe` on Windows, `/bin/sh` on Unix) and is force-terminated by process tree/group after a 10-second timeout. Legacy generated hook scripts (`.ps1` on Windows, `.py` on Unix) are migrated to the native entry on startup. The opt-in OAuth source (off by default) reads the token Claude Code already stores and queries the official usage endpoint; the token is never persisted, uploaded, or logged. A successful read from either source replaces the whole Claude row set; a failed OAuth read falls back to the hook file rather than to a guess. That token expires within hours and only Claude Code itself renews it — on a real Mac `claude auth status --json` exited 0 reporting a logged-in account while the keychain `expiresAt` stayed ten hours in the past, and `claude auth` exposes no refresh command. Metrik does not spend the stored refresh token, since rotation would invalidate the copy Claude Code holds and could log the user out of their own client; an expired token short-circuits to the hook instead of spending a request that would be rejected.
 - **Qoder**: Qoder, QoderWork, and Qoder CLI share one account-level Credits quota. The existing dashboard-cookie source reads that one quota only; it does not decrypt CLI credentials. Qoder CLI local telemetry with zero token counters is ignored rather than counted.
-- **Pi**: the quota reads the GLM Coding Plan through the API key pi itself stores in `~/.pi/agent/auth.json` (`zai-coding-cn` or `zai`), against the same already-verified z.ai/bigmodel response shape the GLM card uses. The key is used in memory for one request only. `qwen-token-plan*` keys in the same file belong to a different Bailian product and are not used by this source.
+- **Pi**: pi is a harness, not a quota identity — it has no coding plan of its
+  own. Its session usage is attributed per provider: GLM Coding Plan providers
+  (`zai*`) count under the GLM card, Qwen Token Plan providers under the Qwen
+  card, and direct providers (Anthropic, OpenAI, …) stay under Pi. The GLM
+  quota source additionally accepts the key pi stores in
+  `~/.pi/agent/auth.json`, so a pi-only install still shows the GLM quota on
+  the GLM card. The Pi card carries local usage only, never a quota.
 - **Qwen**: the Bailian personal Token Plan is an account-level subscription consumed by any client holding its `sk-sp-` key, but its quota is only exposed through the Bailian console login. The cookie-based source (same storage rules as Qoder) calls the console gateway verified on a real account in 2026-08: `tool/user/info.json` yields a `secToken`, then a form-encoded `BroadScopeAspnGateway` call to `bailian-cs.console.aliyun.com` returns `per5Hour*`/`per1Week*` used **ratios (0..1, not percentage points)** and millisecond reset times; a request missing `sec_token`/`region` is bounced to an error page that looks like a WAF block. Absent windows are omitted, never fabricated.
 - A window whose reset time has passed without fresh data renders as `--`, not as its last known percentage.
 

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -52,9 +52,14 @@ change.
 - Qoder Credits and the Bailian personal Token Plan (shown as `Qwen`) are
   separate account-level quotas from the same vendor group: different plans,
   accounts, and quota hosts. Never merge, sum, or cross-fill their windows or
-  cookies. Qwen is quota-only; token usage of clients spending its `sk-sp-`
-  key (for example Pi) stays attributed to those clients, never re-attributed
-  to the Qwen card.
+  cookies.
+- Pi is a harness, not a quota identity: it has no coding plan of its own.
+  Its session usage is attributed by provider — GLM Coding Plan providers to
+  the GLM card, Qwen Token Plan providers to the Qwen card, direct providers
+  (Anthropic, OpenAI, …) to the Pi card. The Pi card therefore carries local
+  usage only and never a quota; the GLM quota source additionally accepts the
+  key pi stores so a pi-only install still shows the GLM quota on the GLM
+  card.
 - Do not expose credentials or raw provider responses through UI, logs, storage,
   sync, fixtures, or diagnostics.
 

--- a/src-tauri/src/adapters/pi.rs
+++ b/src-tauri/src/adapters/pi.rs
@@ -61,6 +61,8 @@ struct PiEntry {
 struct PiMessage {
     role: Option<String>,
     model: Option<String>,
+    /// 发起这次调用的 provider id（pi 目录里的名字，如 zai-coding-cn）。
+    provider: Option<String>,
     /// provider 生成的响应标识；aborted 消息可能缺失。
     #[serde(rename = "responseId")]
     response_id: Option<String>,
@@ -107,6 +109,8 @@ struct PendingEvent {
     event_key: String,
     model: Option<String>,
     tokens: TokenVector,
+    /// 事件归属的计量 Agent（pi 是 harness，见 `pi_providers`）。
+    credited_agent: &'static str,
 }
 
 impl PiAdapter {
@@ -143,6 +147,9 @@ impl AgentAdapter for PiAdapter {
         let mut session_id: Option<String> = None;
         let mut project: Option<String> = None;
         let mut saw_content = false;
+        // 会话当前 provider（model_change 之外没有显式标记，assistant 消息的
+        // provider 即当前值；摘要生成归属跟随它）。
+        let mut session_provider: Option<String> = None;
         // 头之前出现未知记录时丢弃整个文件：那不是 Pi 的会话文件（或格式已
         // 变），读下去只会读错。
         let mut discard_file = false;
@@ -209,7 +216,7 @@ impl AgentAdapter for PiAdapter {
             };
             let session = session_id.clone().unwrap_or_default();
             let timestamp = timestamp_str_ms(entry.timestamp.as_deref());
-            let (usage, model, identity) = match entry.entry_type.as_str() {
+            let (usage, model, provider, identity) = match entry.entry_type.as_str() {
                 "message" => {
                     let Some(message) = entry.message else {
                         continue;
@@ -219,6 +226,17 @@ impl AgentAdapter for PiAdapter {
                             let Some(usage) = message.usage else {
                                 continue;
                             };
+                            let provider = message
+                                .provider
+                                .as_deref()
+                                .map(str::trim)
+                                .filter(|value| !value.is_empty())
+                                .map(str::to_owned);
+                            // 会话当前 provider 随每条 assistant 消息更新，
+                            // 供摘要生成归属使用。
+                            if provider.is_some() {
+                                session_provider = provider.clone();
+                            }
                             let identity = match message
                                 .response_id
                                 .as_deref()
@@ -228,7 +246,8 @@ impl AgentAdapter for PiAdapter {
                                 Some(response_id) => format!("response:{response_id}"),
                                 None => fallback_identity(&entry.id, timestamp),
                             };
-                            (usage, message.model, identity)
+                            let model = message.model;
+                            (usage, model, provider, identity)
                         }
                         // 工具内嵌 LLM 调用的用量：真实计费，但没有 provider
                         // 响应标识，退回事件内身份。
@@ -236,9 +255,17 @@ impl AgentAdapter for PiAdapter {
                             let Some(usage) = message.usage else {
                                 continue;
                             };
+                            let provider = message
+                                .provider
+                                .as_deref()
+                                .map(str::trim)
+                                .filter(|value| !value.is_empty())
+                                .map(str::to_owned);
+                            let model = message.model;
                             (
                                 usage,
-                                message.model,
+                                model,
+                                provider,
                                 fallback_identity(&entry.id, timestamp),
                             )
                         }
@@ -255,9 +282,12 @@ impl AgentAdapter for PiAdapter {
                         "branch"
                     };
                     // 身份同样不含会话 id：fork/clone 会连 compaction 条目一起复制。
+                    // 摘要生成沿用会话当前 provider（记录里不再重复），归属同样
+                    // 跟随该 provider；拿不到时留在 pi。
                     (
                         usage,
                         None,
+                        session_provider.clone(),
                         format!("{prefix}:{}", entry.id.as_deref().unwrap_or("?")),
                     )
                 }
@@ -287,6 +317,7 @@ impl AgentAdapter for PiAdapter {
                 event_key: identity.clone(),
                 model: model.clone(),
                 tokens: tokens.clone(),
+                credited_agent: crate::pi_providers::credited_agent(provider.as_deref()),
             };
             match events.get_mut(&identity) {
                 Some(stored) => {
@@ -297,6 +328,15 @@ impl AgentAdapter for PiAdapter {
                         _ => false,
                     };
                     if model_conflict {
+                        events.remove(&identity);
+                        rejected_keys.insert(identity);
+                        diagnostics.rejected_events += 1;
+                        continue;
+                    }
+                    // 同 key 同模型：正常只会在文件被原样复制时出现（fork/clone），
+                    // 分量取最大值即可；真异常由口径自检兜底。provider 冲突
+                    // 同样拒绝（同一响应不可能来自两家 provider）。
+                    if stored.credited_agent != candidate_event.credited_agent {
                         events.remove(&identity);
                         rejected_keys.insert(identity);
                         diagnostics.rejected_events += 1;
@@ -328,7 +368,9 @@ impl AgentAdapter for PiAdapter {
             .into_values()
             .map(|event| {
                 UsageEvent::new(
-                    self.id(),
+                    // 归属在 adapter 层落库：pi 是 harness，GLM/Qwen 等 coding
+                    // plan 的用量记到对应计量 Agent（见 `pi_providers`）。
+                    event.credited_agent,
                     event.event_key,
                     event.timestamp,
                     event.session_id,
@@ -410,6 +452,76 @@ mod tests {
 
     const HEADER: &str = r#"{"type":"session","version":3,"id":"01a01c94-3c09-7714-b020-f054ef4540aa","timestamp":"2026-08-20T00:31:11.882Z","cwd":"D:\\work\\usage"}"#;
 
+    /// pi 会话里混用多家 provider 时，各事件归属各自的计量 Agent；
+    /// 摘要生成跟随会话当前 provider；直连 provider 留在 pi。
+    #[test]
+    fn provider_determines_the_credited_agent_per_event() {
+        let path = session_file(
+            "providers",
+            &concat!(
+                r#"{"type":"session","id":"ses-mixed","cwd":"/tmp"}"#,
+                "\n",
+                r#"{"type":"message","id":"m1","timestamp":"2026-08-20T00:32:00.000Z","message":{"role":"assistant","provider":"zai-coding-cn","model":"glm-5.3","responseId":"r-glm","usage":{"input":100,"output":10,"totalTokens":110}}}"#,
+                "\n",
+                r#"{"type":"message","id":"m2","timestamp":"2026-08-20T00:33:00.000Z","message":{"role":"assistant","provider":"qwen-token-plan-cn","model":"qwen3.8-max","responseId":"r-qwen","usage":{"input":200,"output":20,"totalTokens":220}}}"#,
+                "\n",
+                r#"{"type":"message","id":"m3","timestamp":"2026-08-20T00:34:00.000Z","message":{"role":"assistant","provider":"anthropic","model":"claude-sonnet-5","responseId":"r-direct","usage":{"input":50,"output":5,"totalTokens":55}}}"#,
+                "\n",
+                // 摘要生成发生在最后一条 assistant 之后：会话当前 provider 是 anthropic，
+                // 但摘要本身计费跟随它——这里断言它留在 pi（直连不经过既有额度）。
+                // 换成 GLM 在前的会话时，compaction 会归 zcode（见下一个测试）。
+                r#"{"type":"compaction","id":"c1","timestamp":"2026-08-20T00:35:00.000Z","summary":"…","tokensBefore":50000,"usage":{"input":80,"output":8,"totalTokens":88}}"#,
+                "\n",
+            ),
+        );
+
+        let parsed = PiAdapter::with_roots(vec![])
+            .parse(&candidate_for(&path), i64::MIN)
+            .unwrap();
+
+        let by_key = |key: &str| {
+            parsed
+                .source
+                .events
+                .iter()
+                .find(|event| event.event_key == key)
+                .unwrap_or_else(|| panic!("missing {key}"))
+        };
+        assert_eq!(by_key("response:r-glm").adapter_id, "zcode");
+        assert_eq!(by_key("response:r-qwen").adapter_id, "qwen");
+        assert_eq!(by_key("response:r-direct").adapter_id, "pi");
+        assert_eq!(by_key("compaction:c1").adapter_id, "pi");
+        std::fs::remove_file(path).ok();
+    }
+
+    /// compaction 前最后一条 assistant 是 GLM 时，摘要生成的用量归属 zcode。
+    #[test]
+    fn compaction_follows_the_session_provider() {
+        let path = session_file(
+            "compaction-provider",
+            &concat!(
+                r#"{"type":"session","id":"ses-glm","cwd":"/tmp"}"#,
+                "\n",
+                r#"{"type":"message","id":"m1","timestamp":"2026-08-20T00:32:00.000Z","message":{"role":"assistant","provider":"zai-coding-cn","model":"glm-5.3","responseId":"r-glm","usage":{"input":100,"output":10,"totalTokens":110}}}"#,
+                "\n",
+                r#"{"type":"compaction","id":"c1","timestamp":"2026-08-20T00:35:00.000Z","summary":"…","tokensBefore":50000,"usage":{"input":80,"output":8,"totalTokens":88}}"#,
+                "\n",
+            ),
+        );
+
+        let parsed = PiAdapter::with_roots(vec![])
+            .parse(&candidate_for(&path), i64::MIN)
+            .unwrap();
+        let compaction = parsed
+            .source
+            .events
+            .iter()
+            .find(|event| event.event_key == "compaction:c1")
+            .unwrap();
+        assert_eq!(compaction.adapter_id, "zcode");
+        std::fs::remove_file(path).ok();
+    }
+
     #[test]
     fn assistant_usage_is_counted_with_response_identity_and_header_cwd() {
         // 字段形状取自本机真实日志（zai-coding-cn / glm-5.3）。
@@ -430,6 +542,8 @@ mod tests {
         assert_eq!(parsed.source.events.len(), 1);
         let event = &parsed.source.events[0];
         assert_eq!(event.event_key, "response:202608171505273491557405ff476a");
+        // pi 是 harness：zai-coding-cn 的用量归属 GLM（zcode）卡片。
+        assert_eq!(event.adapter_id, "zcode");
         assert_eq!(event.tokens.input_uncached, 2_882);
         assert_eq!(event.tokens.cache_read, 1_088);
         assert_eq!(event.tokens.output, 561);
@@ -452,7 +566,7 @@ mod tests {
             &concat!(
                 r#"{"type":"session","version":3,"id":"ses-1","cwd":"/tmp"}"#,
                 "\n",
-                r#"{"type":"message","id":"c6115304","timestamp":"2026-08-19T00:30:00.000Z","message":{"role":"assistant","provider":"zai-coding-cn","model":"glm-5.3","usage":{"input":100,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":120},"stopReason":"aborted"}}"#,
+                r#"{"type":"message","id":"c6115304","timestamp":"2026-08-19T00:30:00.000Z","message":{"role":"assistant","model":"glm-5.3","usage":{"input":100,"output":20,"cacheRead":0,"cacheWrite":0,"totalTokens":120},"stopReason":"aborted"}}"#,
                 "\n",
             ),
         );
@@ -463,6 +577,8 @@ mod tests {
 
         assert_eq!(parsed.source.events.len(), 1);
         assert_eq!(parsed.source.events[0].event_key, "fallback:c6115304");
+        // 无 provider 的 aborted 消息留在 pi 名下。
+        assert_eq!(parsed.source.events[0].adapter_id, "pi");
         assert_eq!(parsed.source.events[0].tokens.processed(), 120);
         std::fs::remove_file(path).ok();
     }

--- a/src-tauri/src/coding_quota.rs
+++ b/src-tauri/src/coding_quota.rs
@@ -79,33 +79,12 @@ const KIMIWORK_STATS_URL: &str =
 pub fn fetch_zcode_quota(timeout: Duration) -> Result<Vec<QuotaSample>> {
     let candidates = resolve_glm_credentials();
     if candidates.is_empty() {
-        bail!("未找到 GLM/ZCode 的 API key（zcode 配置、环境变量或 OpenCode auth.json）");
+        bail!("未找到 GLM/ZCode 的 API key（zcode 配置、环境变量、OpenCode auth.json 或 pi auth.json）");
     }
     let agent = ureq::AgentBuilder::new().timeout(timeout).build();
     let mut last_error = None;
     for cred in candidates {
         match fetch_glm_once(&agent, &cred, "zcode") {
-            Ok(samples) => return Ok(samples),
-            Err(error) => last_error = Some(error),
-        }
-    }
-    Err(last_error.expect("candidates 非空则必有错误"))
-}
-
-/// pi 的 GLM Coding Plan 配额。key 存在 pi 自己的 auth.json 里（明文、与
-/// OpenCode auth.json 同形），仅在内存里用于一次请求。响应形状与 zcode 用的
-/// 同一套（已在真机核验），只是落库身份换成 pi 卡片。
-/// qwen-token-plan* 同在这份文件里，但那是百炼的另一产品，不打这套端点，
-/// 不逐把试。
-pub fn fetch_pi_quota(timeout: Duration) -> Result<Vec<QuotaSample>> {
-    let candidates = resolve_pi_glm_credentials();
-    if candidates.is_empty() {
-        bail!("未找到 pi 的 GLM Coding Plan key（~/.pi/agent/auth.json）");
-    }
-    let agent = ureq::AgentBuilder::new().timeout(timeout).build();
-    let mut last_error = None;
-    for cred in candidates {
-        match fetch_glm_once(&agent, &cred, "pi") {
             Ok(samples) => return Ok(samples),
             Err(error) => last_error = Some(error),
         }
@@ -965,6 +944,11 @@ fn resolve_glm_credentials() -> Vec<GlmCredential> {
     if let Some(token) = nonempty(opencode.get("zhipuai-coding-plan")) {
         push(token, GlmRegion::Bigmodel);
     }
+    // pi 是 harness 不是配额身份：它 auth.json 里的 GLM key 与 zcode 桌面端
+    // 是同一套餐，配额读数同样归 GLM 卡片（与用量归属一致）。
+    for cred in resolve_pi_glm_credentials() {
+        push(cred.token, cred.region);
+    }
     if let Some(token) = nonempty(opencode.get("zai-coding-plan")) {
         push(token, GlmRegion::Zai);
     }
@@ -1006,6 +990,11 @@ fn pi_auth_paths() -> Vec<PathBuf> {
     ]
 }
 
+/// pi 是 harness，不是配额身份：它 auth.json 里的 GLM key 与 zcode 桌面端
+/// 是同一套餐，配额读数归 GLM 卡片（与用量归属一致）。这里只作为
+/// resolve_glm_credentials 的一个凭据来源。
+/// qwen-token-plan* 同在这份文件里，但那是百炼的另一产品，不打这套端点，
+/// 不逐把试。
 fn resolve_pi_glm_credentials() -> Vec<GlmCredential> {
     for path in pi_auth_paths() {
         let Ok(raw) = std::fs::read_to_string(&path) else {
@@ -1611,23 +1600,6 @@ mod tests {
                 sample.window_key, sample.remaining_percent, sample.resets_at_ms
             );
             assert_eq!(sample.adapter_id, "zcode");
-            assert!((0.0..=100.0).contains(&sample.remaining_percent));
-        }
-    }
-
-    /// 打真实 bigmodel/z.ai 接口的 pi 卡片烟测：需要本机 pi 登录过 GLM Coding
-    /// Plan（~/.pi/agent/auth.json 里有 zai-coding-cn 或 zai key）。
-    #[test]
-    #[ignore = "reads local pi credentials and calls the live quota API"]
-    fn live_pi_quota_smoke_test() {
-        let samples = fetch_pi_quota(Duration::from_secs(15)).expect("fetch pi glm quota");
-        assert!(!samples.is_empty(), "配额响应里没有可用窗口");
-        for sample in &samples {
-            println!(
-                "pi quota: window={} remaining={:.1}% resets_at={:?}",
-                sample.window_key, sample.remaining_percent, sample.resets_at_ms
-            );
-            assert_eq!(sample.adapter_id, "pi");
             assert!((0.0..=100.0).contains(&sample.remaining_percent));
         }
     }

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -1531,7 +1531,7 @@ fn source_views(report: ScanReport, sync_status: Option<SyncView>) -> Vec<Source
             kind: "local".into(),
             label: "Pi 本地 Token".into(),
             detail: format!(
-                "发现 {} 个会话文件，本次更新 {} 个。{}逐请求计数按 provider 响应标识去重，fork/clone 复制不重复入账；摘要生成与工具内嵌调用的用量一并计入；项目归属只取会话头里的工作目录。",
+                "发现 {} 个会话文件，本次更新 {} 个。{}pi 是 harness，自身没有 coding plan：逐请求计数按 provider 响应标识去重，并按 provider 归属到对应计量卡片（GLM Coding Plan 记入 GLM、Qwen Token Plan 记入 Qwen、其余留在 Pi）；fork/clone 复制不重复入账，摘要生成与工具内嵌调用的用量一并计入，项目归属只取会话头里的工作目录。",
                 discovered("pi"),
                 refreshed("pi"),
                 coverage_detail(&diagnostics("pi"), errors("pi"))
@@ -1548,14 +1548,6 @@ fn source_views(report: ScanReport, sync_status: Option<SyncView>) -> Vec<Source
                 "精确解析"
             }
             .into(),
-        },
-        SourceView {
-            id: "pi-quota".into(),
-            kind: "official".into(),
-            label: "Pi 官方配额".into(),
-            detail: "用 pi 自己存储的 GLM Coding Plan key（~/.pi/agent/auth.json）直查官方接口，得 5 小时与每周滚动窗；key 仅在内存中用于一次请求，不入库不同步。同一账户的额度与 GLM 卡片读数同源。".into(),
-            quality: "official".into(),
-            quality_label: "官方".into(),
         },
         SourceView {
             id: "qwen-quota".into(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod domain;
 mod engine;
 #[cfg(target_os = "macos")]
 mod macos;
+mod pi_providers;
 mod pricing;
 mod projects;
 mod quota;

--- a/src-tauri/src/pi_providers.rs
+++ b/src-tauri/src/pi_providers.rs
@@ -1,0 +1,53 @@
+//! pi（badlogic/pi-mono）是 harness，不是计量身份：它没有自己的 coding plan，
+//! 用量计费发生在它调用的 provider 上。本模块把 pi 会话日志里的 provider id
+//! 映射到 Metrik 的计量 Agent。
+//!
+//! 映射依据 pi 内置目录（models-store.json 的 provider 名单，2026-08 提取）：
+//! GLM Coding Plan（z.ai / BigModel CN）→ `zcode`（GLM 卡片，与 zcode 桌面端
+//! 同一账户额度）；Qwen Token Plan 各变体 → `qwen`；其余 provider（Anthropic、
+//! OpenAI 等）由 pi 自带凭据直连计费，不经过既有客户端的额度，留在 `pi` 名下。
+//!
+//! 归属发生在 adapter 层（写入 `usage_event.adapter_id`），一次入库、处处一致：
+//! 图表、模型榜、会话流、成本估算与同步导出自动跟随，无需各查询点单独判断。
+//!
+//! GLM 配额同样如此：`resolve_glm_credentials` 把 pi auth.json 里的 GLM key
+//! 并入候选，读数归 GLM 卡片——与用量归属对齐。
+
+/// 把 pi 的 provider id 映射到计量 Agent id。
+pub fn credited_agent(pi_provider: Option<&str>) -> &'static str {
+    let Some(provider) = pi_provider.map(str::trim).filter(|value| !value.is_empty()) else {
+        // 无 provider 的记录（旧格式/工具内嵌调用）：无法归户，留在 pi。
+        return "pi";
+    };
+    match provider {
+        // GLM Coding Plan：z.ai 国际端与 BigModel 国内端是同一套餐的两个区域。
+        "zai" | "zai-coding" | "zai-coding-cn" => "zcode",
+        // 百炼个人 Token Plan：pi 目录里的三个变体打同一个套餐额度。
+        "qwen-token-plan" | "qwen-token-plan-cn" | "qwen-token-plan-individual" => "qwen",
+        _ => "pi",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glm_and_qwen_coding_plans_credit_their_own_cards() {
+        assert_eq!(credited_agent(Some("zai")), "zcode");
+        assert_eq!(credited_agent(Some("zai-coding")), "zcode");
+        assert_eq!(credited_agent(Some("zai-coding-cn")), "zcode");
+        assert_eq!(credited_agent(Some("qwen-token-plan")), "qwen");
+        assert_eq!(credited_agent(Some("qwen-token-plan-cn")), "qwen");
+        assert_eq!(credited_agent(Some("qwen-token-plan-individual")), "qwen");
+    }
+
+    #[test]
+    fn unknown_providers_and_missing_values_stay_on_pi() {
+        // pi 直连的 Anthropic/OpenAI 等不经过既有客户端的额度，留在 pi 名下。
+        assert_eq!(credited_agent(Some("anthropic")), "pi");
+        assert_eq!(credited_agent(Some("openai")), "pi");
+        assert_eq!(credited_agent(Some("  ")), "pi");
+        assert_eq!(credited_agent(None), "pi");
+    }
+}

--- a/src-tauri/src/quota.rs
+++ b/src-tauri/src/quota.rs
@@ -132,7 +132,6 @@ pub fn registry() -> Vec<Box<dyn QuotaProvider>> {
         ("kimiwork", coding_quota::fetch_kimiwork_quota),
         ("qoder", coding_quota::fetch_qoder_quota),
         ("workbuddy", coding_quota::fetch_workbuddy_quota),
-        ("pi", coding_quota::fetch_pi_quota),
         ("qwen", coding_quota::fetch_qwen_quota),
     ] {
         providers.push(Box::new(HttpQuota { adapter_id, fetch }));
@@ -349,7 +348,6 @@ mod tests {
                 "grok",
                 "kimi",
                 "kimiwork",
-                "pi",
                 "qoder",
                 "qwen",
                 "workbuddy",

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -12,7 +12,9 @@ use std::path::{Path, PathBuf};
 // double-counting the parent thread's usage (and stop showing as unknown model).
 // Version 5 rebuilds every source so already-ledgered events pick up the project
 // working directory their adapters now report.
-pub const PARSER_VERSION: i64 = 5;
+// Version 6 rebuilds every source so pi events re-attribute to their provider's
+// metering card (GLM/Qwen/Pi) instead of all landing under pi.
+pub const PARSER_VERSION: i64 = 6;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ReplaceSourceOutcome {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -204,8 +204,8 @@ const AGENT_META = {
     iconClass: "agent-icon--grok",
   },
   pi: {
-    // pi（badlogic/pi-mono）：会话日志覆盖 pi 内配置的全部 provider，
-    // 配额源是其中的 GLM Coding Plan key。
+    // pi（badlogic/pi-mono）是 harness：本地会话用量按 provider 归属到
+    // 对应计量卡片（GLM / Qwen / 其余留 Pi）；pi 自身没有独立套餐，不显示配额。
     label: "Pi",
     // 自制 π 字母牌（同 Grok 字母牌规格）；深红与 Claude 的珊瑚橙拉开明暗。
     accent: "#c1121f",


### PR DESCRIPTION
## 问题（用户截图实锤）

pi 自身没有 coding plan，但此前 pi 走 glm-5.3 的用量全记在 Pi 卡片、GLM 配额也挂在 Pi 卡片，GLM 卡片看不到这部分消耗，Pi 卡片还显示「未计价」。正确语义：**pi 是 harness，用量与配额都应按它调用的 provider 归属**。

## 改动

- 新增 `pi_providers.rs`：provider id → 计量 Agent 映射（`zai*`→zcode、`qwen-token-plan*`→qwen、其余留 pi）。归属在 adapter 层写入 `usage_event.adapter_id`，所有下游（图表/模型榜/会话流/成本/同步）自动一致。
- GLM 配额凭据并入 pi `auth.json` 的 key（与 zcode 同套餐，读数归 GLM 卡片）；删除 `fetch_pi_quota`，Pi 卡片不再自带配额。
- `PARSER_VERSION` 5→6 强制全量对账，改记既有 pi 事件。
- 文档记录 pi harness 归属约束（ARCHITECTURE / PRODUCT-CONSTRAINTS）。

## 验证

- 27 个 pi 单测含逐事件归属断言（zai→zcode、qwen→qwen、直连→pi、compaction 跟随会话 provider）。
- 真机：已重扫的 pi 源事件改记 zcode（407 条）/qwen（38 条），其余源按 PARSE_BUDGET 增量重建（既有机制）。
- 222 Rust + 49 JS 单测、fmt/clippy/build 全绿。

## 与定价线程的协调

本分支只动 `engine.rs` 来源抽屉、`storage.rs` 版本号与 pi 归属，不碰 `pricing.rs`；与 #134（定价）无重叠区域。建议先合 #134，本分支 rebase 后合入，再走 v0.17.2 发版。