### PR TITLE
ci: publish Ubuntu 24.04 packages with releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,24 @@ jobs:
             args: ""
             rust-targets: ""
             widget-archs: ""
+            updater-json: "true"
           # Intel + Apple Silicon 通用包。macOS 尚未实机验收，Release 说明里
           # 必须标明这一点。
           - platform: macos-latest
             args: "--target universal-apple-darwin"
             rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
             widget-archs: "arm64 x86_64"
+            updater-json: "true"
+          # Linux 发布基线与 CI 一致：Ubuntu 24.04 x86_64，只发 deb 与 AppImage。
+          # Linux 安装包暂不走应用内更新（deb 由包管理器接管，AppImage 更新
+          # 未验收），不产出更新器工件，也不参与 latest.json。
+          - platform: ubuntu-24.04
+            args: >-
+              --bundles deb,appimage
+              --config '{"bundle":{"createUpdaterArtifacts":false}}'
+            rust-targets: ""
+            widget-archs: ""
+            updater-json: "false"
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -44,6 +56,19 @@ jobs:
       # 发布不频繁，且通用构建的 target 布局会让缓存的路径校验在 post 步骤
       # 报错、把已成功的构建标红。发布流程不缓存，换取稳定的绿。
 
+      # 与 ci.yml 的 Linux job 保持同一份依赖清单；改动时两边一起改。
+      - name: Install Linux desktop dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            patchelf
+
       - name: Install frontend dependencies
         run: npm ci
 
@@ -57,12 +82,14 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           METRIK_WIDGET_ARCHS: ${{ matrix.widget-archs }}
+          # Ubuntu 24.04 镜像没有 FUSE，linuxdeploy 需解包运行（同 ci.yml）。
+          APPIMAGE_EXTRACT_AND_RUN: "1"
         with:
           tagName: ${{ github.ref_name }}
           releaseName: Metrik ${{ github.ref_name }}
           releaseDraft: true
           prerelease: false
-          includeUpdaterJson: true
+          includeUpdaterJson: ${{ matrix.updater-json }}
           args: ${{ matrix.args }}
 
       - name: Verify WidgetKit extension is embedded
@@ -85,3 +112,12 @@ jobs:
           test "$widget_build" = "$host_build"
           test "$widget_release" = "$host_release"
           codesign --verify --deep --strict --verbose=2 "$app_path"
+
+      # 打包步骤成功不代表两个分发格式都产出了；缺失时直接判红，避免
+      # Release 页只有其中一种包。
+      - name: Verify Linux packages were built
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          find src-tauri/target -path '*/release/bundle/deb/*.deb' | grep -q .
+          find src-tauri/target -path '*/release/bundle/appimage/*.AppImage' | grep -q .

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Metrik 是一款桌面常驻工具，统一查看本机各个 AI 编程 Agent �
 [![Tauri](https://img.shields.io/badge/Tauri-2-24C8DB.svg)](https://tauri.app/)
 [![Platform](https://img.shields.io/badge/Windows%20%7C%20macOS%20%7C%20Ubuntu%20CI-0078D6.svg)](#平台支持)
 
-[下载最新版](https://github.com/keros68/metrik/releases/latest)：Windows `.exe`、macOS 通用 `.dmg`。Ubuntu 24.04 x86_64 的 `.deb` / `.AppImage` 已由 PR CI 构建验证，但在上游 Release 工作流加入 Linux 发布任务前不会出现在 Release 页。安装包未签名，首次运行需手动放行系统安全校验；Release 页附 SHA256 校验值。
+[下载最新版](https://github.com/keros68/metrik/releases/latest)：Windows `.exe`、macOS 通用 `.dmg`；Ubuntu 24.04 x86_64 的 `.deb` / `.AppImage` 自下一个 Release 起随发布页提供，更早的版本不含 Linux 包。安装包未签名，首次运行需手动放行系统安全校验；Release 页附 SHA256 校验值。
 
 <p align="center">
   <img src="design/shot-glass.jpg" alt="Metrik 桌面小组件与配额胶囊条 · 透明档">
@@ -106,7 +106,7 @@ cargo test live_snapshot_smoke_test -- --ignored --nocapture  # 读本机真实�
 ## 已知限制
 
 1. 安装包未做数字签名，首次运行需手动放行；Windows 未预装 WebView2 时安装程序需联网获取运行时。
-2. 上游 Release 当前仅发布 Windows 与 macOS 安装包；Ubuntu 24.04 x86_64 的 `.deb` / `.AppImage` 生成流程已通过 CI 构建与冒烟测试，但目前仍需自行构建。其它发行版与架构尚未验证。AppImage 若无法显示托盘，请确认桌面环境已启用 StatusNotifier/AppIndicator 支持。
+2. Linux 仅覆盖 Ubuntu 24.04 x86_64（`.deb` / `.AppImage` 自下一个 Release 起随发布页提供），其它发行版与架构尚未验证，需自行构建。AppImage 若无法显示托盘，请确认桌面环境已启用 StatusNotifier/AppIndicator 支持。
 3. Antigravity 需对应 IDE 处于运行状态才有数据。
 4. 首次索引大体量日志会占用一段 CPU 与磁盘，界面可正常操作，未覆盖完整历史的数值会标注说明。
 

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -222,9 +222,9 @@ change.
   application. Hover appearance and restoration are driven by a dedicated
   native `XQueryPointer` connection and physical window bounds, independent of
   WebKit input delivery after the surface becomes transparent and click-through.
-  Wayland deliberately
-  withholds global pointer coordinates, so it uses local window-boundary events
-  and retains a visually imperceptible input surface for complete hiding.
+  Wayland deliberately withholds global pointer coordinates, so it uses local
+  window-boundary events and retains a visually imperceptible input surface for
+  complete hiding.
 - Linux pinning is a read-only presentation surface: its controls and drag
   regions are inactive, and only Linux Settings or the Linux tray menu can
   cancel pinning. The native window retains pointer input solely to drive


### PR DESCRIPTION
## Scope

Release workflow and documentation only. No version bump, no runtime change.

## What changed

- `release.yml` gains an `ubuntu-24.04` job that builds and attaches `.deb` and `.AppImage` on the next tag, fulfilling the follow-up promised in #119.
- The Linux job uses the same dependency list and `APPIMAGE_EXTRACT_AND_RUN` workaround as the proven CI job, builds with `--bundles deb,appimage`, and opts out of updater artifacts / `latest.json` (Linux in-app updates are not yet accepted).
- A verify step fails the job if either package format is missing, so a release cannot ship half the Linux artifacts.
- README now says Ubuntu packages ship from the next release instead of claiming they stay CI-only; `ACCEPTANCE.md` keeps Linux release artifacts as not-yet-delivered until a tag actually ships them.
- Also fixes a broken sentence reflow in `docs/PRODUCT-CONSTRAINTS.md` left over from #119.

## Verification

- YAML parses cleanly; matrix `updater-json` flag keeps `includeUpdaterJson` behavior unchanged for Windows/macOS.
- The release job itself only runs on tags; its Linux steps mirror the CI job that is green on #119.

## Follow-up

- On the next release tag, confirm the draft release contains both Linux packages before publishing.