### PR TITLE
refactor(quota): remove Bailian Token Plan console-cookie quota source

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,7 +86,12 @@ Quota rows are replaced wholesale, never merged, so a window a plan no longer ha
   quota source additionally accepts the key pi stores in
   `~/.pi/agent/auth.json`, so a pi-only install still shows the GLM quota on
   the GLM card. The Pi card carries local usage only, never a quota.
-- **Qwen**: the Bailian personal Token Plan is an account-level subscription consumed by any client holding its `sk-sp-` key, but its quota is only exposed through the Bailian console login. The cookie-based source (same storage rules as Qoder) calls the console gateway verified on a real account in 2026-08: `tool/user/info.json` yields a `secToken`, then a form-encoded `BroadScopeAspnGateway` call to `bailian-cs.console.aliyun.com` returns `per5Hour*`/`per1Week*` used **ratios (0..1, not percentage points)** and millisecond reset times; a request missing `sec_token`/`region` is bounced to an error page that looks like a WAF block. Absent windows are omitted, never fabricated.
+- **Qwen**: removed. The Bailian personal Token Plan exposes its quota only
+  behind the console's interactive login; its cookie stopped working within
+  days on a real account, and the product has no programmable quota API
+  (official OpenAPI surface checked 2026-08). The Qwen card carries local
+  usage attributed from pi sessions only; rows written by older versions are
+  cleaned up by the unmanaged-row prune.
 - A window whose reset time has passed without fresh data renders as `--`, not as its last known percentage.
 
 ## Storage

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -49,10 +49,14 @@ change.
   Their account-level Credits are shared, so they must never create separate
   agent counters or be summed. Qoder CLI's local telemetry is not a token
   source when it reports zero counters.
-- Qoder Credits and the Bailian personal Token Plan (shown as `Qwen`) are
-  separate account-level quotas from the same vendor group: different plans,
-  accounts, and quota hosts. Never merge, sum, or cross-fill their windows or
-  cookies.
+- Qoder Credits and the Bailian personal Token Plan are separate
+  account-level products from the same vendor group: different plans,
+  accounts, and hosts. Never merge, sum, or cross-fill their windows or
+  credentials. Metrik does not fetch a quota for the Bailian personal Token
+  Plan (shown as `Qwen`): its only source is the console's interactive login
+  state, whose cookies stopped working within days on a real account, and the
+  product exposes no programmable quota API. The Qwen card carries locally
+  attributed usage only, like the Pi card.
 - Pi is a harness, not a quota identity: it has no coding plan of its own.
   Its session usage is attributed by provider — GLM Coding Plan providers to
   the GLM card, Qwen Token Plan providers to the Qwen card, direct providers

--- a/src-tauri/src/coding_quota.rs
+++ b/src-tauri/src/coding_quota.rs
@@ -202,7 +202,7 @@ fn env_cookie(name: &str) -> Option<String> {
 }
 
 /// cookie 文件与应用数据库同目录（identifier 与 tauri.conf.json 一致）。
-/// 写与读走同一个 helper，路径自洽。各 provider 一份文件（qoder/qwen）。
+/// 写与读走同一个 helper，路径自洽。各 provider 一份文件（当前只有 qoder）。
 fn provider_cookie_file(name: &str) -> Option<PathBuf> {
     Some(
         dirs::data_local_dir()?
@@ -219,10 +219,6 @@ fn read_provider_cookie_file(name: &str) -> Option<String> {
 
 pub fn read_qoder_cookie_file() -> Option<String> {
     read_provider_cookie_file("qoder")
-}
-
-pub fn read_qwen_cookie_file() -> Option<String> {
-    read_provider_cookie_file("qwen")
 }
 
 /// 宽容解析用户粘贴的内容：接受裸 cookie 值、带 `Cookie:` 前缀的单行、
@@ -300,7 +296,7 @@ pub fn normalize_qoder_cookie_input(raw: &str) -> Option<String> {
 }
 
 /// 保存（Some 且非空）或清除（None/空）本地 cookie 文件；返回保存后是否存在。
-/// 各 provider 共用同一套文件读写（qoder / qwen）。
+/// 各 provider 共用同一套文件读写（当前只有 qoder）。
 pub fn write_provider_cookie_file(name: &str, cookie: Option<&str>) -> Result<bool> {
     let path = provider_cookie_file(name).context("无法定位本地数据目录")?;
     match cookie.map(str::trim).filter(|value| !value.is_empty()) {
@@ -326,26 +322,12 @@ pub fn write_qoder_cookie_file(cookie: Option<&str>) -> Result<bool> {
     write_provider_cookie_file("qoder", cookie)
 }
 
-pub fn write_qwen_cookie_file(cookie: Option<&str>) -> Result<bool> {
-    write_provider_cookie_file("qwen", cookie)
-}
-
 /// 当前生效的 cookie 来源（设置页展示用）；None = 未配置。
 pub fn qoder_cookie_source() -> Option<&'static str> {
     if read_qoder_cookie_file().is_some() {
         return Some("file");
     }
     ["QODER_COOKIE", "METRIK_QODER_COOKIE"]
-        .iter()
-        .any(|name| env_cookie(name).is_some())
-        .then_some("env")
-}
-
-pub fn qwen_cookie_source() -> Option<&'static str> {
-    if read_qwen_cookie_file().is_some() {
-        return Some("file");
-    }
-    ["QWEN_COOKIE", "METRIK_QWEN_COOKIE"]
         .iter()
         .any(|name| env_cookie(name).is_some())
         .then_some("env")
@@ -416,158 +398,6 @@ fn qoder_summary(payload: &Value, camel: &str, snake: &str) -> Option<(f64, f64)
     let used = number("usedValue", "used_value")?;
     let limit = number("limitValue", "limit_value")?;
     (used >= 0.0 && limit >= 0.0).then_some((used, limit))
-}
-
-// ── Qwen Token Plan（阿里百炼个人版）──────────────────────────
-// 唯一可用来源是百炼控制台的登录态（cookie），API key 查不到套餐额度。
-// 请求形状 2026-08 按真实账号核验（无头 Edge 抓包 + curl 复现）：
-//   1) GET bailian.console.aliyun.com/tool/user/info.json → data.secToken；
-//   2) POST bailian-cs.console.aliyun.com/data/api.json
-//      ?action=BroadScopeAspnGateway&product=sfm_bailian&api=<urlencoded API 名>
-//      body: params={"Api":…,"V":"1.0","Data":{"cornerstoneParam":{…}}}
-//            &region=cn-beijing&sec_token=…（表单编码，ureq send_form 即可）
-// 少了 sec_token/region 会被网关弹到 err.taobao.com 错误页，看起来像 WAF。
-// usage 响应里窗口字段是 0..1 的**已用比例**（CodexBar 的解析同此：clamp 到
-// [0,1] 再乘 100），重置时间是毫秒时间戳。5 小时窗与周窗都可能缺席
-// （未活跃/套餐没有），缺哪个就不出哪个窗口。
-const QWEN_INFO_URL: &str = "https://bailian.console.aliyun.com/tool/user/info.json";
-const QWEN_GATEWAY_URL: &str = "https://bailian-cs.console.aliyun.com/data/api.json";
-const QWEN_USAGE_API: &str = "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage";
-const QWEN_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36";
-
-fn resolve_qwen_cookie() -> Option<String> {
-    if let Some(cookie) = read_qwen_cookie_file() {
-        return Some(cookie);
-    }
-    ["QWEN_COOKIE", "METRIK_QWEN_COOKIE"]
-        .iter()
-        .find_map(|name| env_cookie(name))
-}
-
-pub fn fetch_qwen_quota(timeout: Duration) -> Result<Vec<QuotaSample>> {
-    let cookie = resolve_qwen_cookie()
-        .context("未找到 Qwen Token Plan 的 cookie（设置页保存，或设置 QWEN_COOKIE 环境变量）")?;
-    let agent = ureq::AgentBuilder::new().timeout(timeout).build();
-
-    // 1. sec_token：拿不到时照发（尽力而为，个别账号无 sec_token 也能过）。
-    let info = agent
-        .get(QWEN_INFO_URL)
-        .set("Cookie", &cookie)
-        .set("User-Agent", QWEN_UA)
-        .set("Accept", "application/json")
-        .set("Referer", "https://bailian.console.aliyun.com/")
-        .call()
-        .map_err(|error| map_ureq_error("Qwen", error))?;
-    let info_body = info.into_string().context("读取 Qwen 会话信息失败")?;
-    if info_body.trim_start().starts_with('<') {
-        bail!("Qwen cookie 已失效（返回登录页），请重新获取");
-    }
-    let sec_token = serde_json::from_str::<Value>(&info_body)
-        .ok()
-        .and_then(|json| {
-            json.pointer("/data/secToken")
-                .and_then(Value::as_str)
-                .map(str::to_owned)
-        })
-        .unwrap_or_default();
-
-    // 2. usage：控制台网关调用，表单编码。
-    let payload = serde_json::json!({
-        "Api": QWEN_USAGE_API,
-        "V": "1.0",
-        "Data": {
-            "cornerstoneParam": {
-                "feURL": "https://bailian.console.aliyun.com/cn-beijing?tab=plan",
-                "protocol": "V2",
-                "console": "ONE_CONSOLE",
-                "productCode": "p_efm",
-                "switchUserType": 3,
-                "domain": "bailian.console.aliyun.com",
-                "consoleSite": "BAILIAN_ALIYUN",
-                "xsp_lang": "zh-CN"
-            }
-        }
-    });
-    let response = agent
-        .post(&format!(
-            "{QWEN_GATEWAY_URL}?action=BroadScopeAspnGateway&product=sfm_bailian&api={}&_v=undefined",
-            QWEN_USAGE_API.replace('/', "%2F")
-        ))
-        .set("Cookie", &cookie)
-        .set("User-Agent", QWEN_UA)
-        .set("Accept", "application/json")
-        .set("Content-Type", "application/x-www-form-urlencoded")
-        .set("Origin", "https://bailian.console.aliyun.com")
-        .set("Referer", "https://bailian.console.aliyun.com/cn-beijing?tab=plan")
-        .send_form(&[
-            ("params", payload.to_string().as_str()),
-            ("region", "cn-beijing"),
-            ("sec_token", sec_token.as_str()),
-        ])
-        .map_err(|error| map_ureq_error("Qwen", error))?;
-    let body = response.into_string().context("读取 Qwen 配额响应失败")?;
-    if body.trim_start().starts_with('<') {
-        bail!("Qwen cookie 已失效（网关返回错误页），请重新获取");
-    }
-    let json: Value = serde_json::from_str(&body).context("Qwen 配额响应不是预期的 JSON")?;
-    let samples = parse_qwen_quota(&json, chrono::Utc::now().timestamp_millis());
-    if samples.is_empty() {
-        bail!("Qwen 配额响应缺少可用窗口");
-    }
-    Ok(samples)
-}
-
-/// 深度寻找带窗口字段的对象：信封嵌套（data.DataV2.data.data）可能随网关
-/// 版本变，字段名才是稳定契约；拿到任何一个含窗口字段的对象即可。
-fn qwen_find_usage_object<'a>(value: &'a Value, names: &[&str]) -> Option<&'a Value> {
-    let object = value.as_object()?;
-    if names.iter().any(|name| object.contains_key(*name)) {
-        return Some(value);
-    }
-    object
-        .values()
-        .find_map(|child| qwen_find_usage_object(child, names))
-}
-
-fn parse_qwen_quota(value: &Value, now: i64) -> Vec<QuotaSample> {
-    // 网关把业务错误放在 HTTP 200 的 body 里（code 非 200 / success=false）。
-    if let Some(code) = value.get("code").and_then(Value::as_str) {
-        if code != "200" {
-            return Vec::new();
-        }
-    }
-    let Some(usage) = qwen_find_usage_object(value, &["per5HourPercentage", "per1WeekPercentage"])
-    else {
-        return Vec::new();
-    };
-    let number = |name: &str| -> Option<f64> {
-        usage
-            .get(name)
-            .and_then(|raw| raw.as_f64().or_else(|| raw.as_str()?.trim().parse().ok()))
-    };
-    let mut samples = Vec::new();
-    for (percent_field, reset_field, key) in [
-        ("per5HourPercentage", "per5HourResetTime", "five_hour"),
-        ("per1WeekPercentage", "per1WeekResetTime", "seven_day"),
-    ] {
-        let Some(ratio) = number(percent_field) else {
-            continue;
-        };
-        // 0..1 已用比例 → 剩余百分比。越界值 clamp，不猜。
-        let used = ratio.clamp(0.0, 1.0);
-        let resets_at_ms = number(reset_field).map(|ms| ms as i64);
-        samples.push(QuotaSample {
-            adapter_id: "qwen",
-            window_key: key.to_owned(),
-            remaining_percent: ((1.0 - used) * 100.0).clamp(0.0, 100.0),
-            resets_at_ms: resets_at_ms
-                .and_then(|ms| crate::domain::sane_resets_at_ms(key, ms, now)),
-            collected_at_ms: now,
-            source_label: "Qwen Token Plan 官方配额".into(),
-            quality: "official_live",
-        });
-    }
-    samples
 }
 
 pub fn fetch_kimi_quota(timeout: Duration) -> Result<Vec<QuotaSample>> {
@@ -988,6 +818,23 @@ fn pi_auth_paths() -> Vec<PathBuf> {
         home.join(".pi").join("agent").join("auth.json"),
         home.join(".omp").join("agent").join("auth.json"),
     ]
+}
+
+/// 百炼 Token Plan 的官方额度入口已移除：控制台网关只认交互式登录态，
+/// cookie 实测只能活几天，百炼也没有可编程查询该额度的官方接口（2026-08 核
+/// 对官方 SDK 全部接口无相关端点）。Qwen 卡片从此只承载 pi 归属过来的本地用
+/// 量；安装探针降级为“pi auth.json 里是否配置了百炼 Token Plan 的 key”。
+pub fn pi_auth_has_qwen_token_plan() -> bool {
+    pi_auth_paths()
+        .iter()
+        .filter_map(|path| std::fs::read_to_string(path).ok())
+        .any(|raw| auth_json_has_qwen_token_plan(&raw))
+}
+
+fn auth_json_has_qwen_token_plan(raw: &str) -> bool {
+    parse_provider_key_map(raw)
+        .keys()
+        .any(|provider| crate::pi_providers::credited_agent(Some(provider.as_str())) == "qwen")
 }
 
 /// pi 是 harness，不是配额身份：它 auth.json 里的 GLM key 与 zcode 桌面端
@@ -1629,6 +1476,21 @@ mod tests {
         assert!(pi_glm_credentials_from_auth_json("not json").is_empty());
     }
 
+    /// Qwen 探针只看百炼 Token Plan 的 provider；GLM 与直连 key 不算。
+    #[test]
+    fn qwen_probe_matches_only_token_plan_providers() {
+        assert!(auth_json_has_qwen_token_plan(
+            r#"{"qwen-token-plan-cn": {"type": "api_key", "key": "sk-sp-x"}}"#
+        ));
+        assert!(auth_json_has_qwen_token_plan(
+            r#"{"qwen-token-plan-individual": {"type": "api_key", "key": "k"}}"#
+        ));
+        assert!(!auth_json_has_qwen_token_plan(
+            r#"{"zai-coding-cn": {"type": "api_key", "key": "k"}, "anthropic": {"type": "api_key", "key": "k"}}"#
+        ));
+        assert!(!auth_json_has_qwen_token_plan("not json"));
+    }
+
     /// 同一份 GLM 响应解析后，样本落在各自卡片的 adapter_id 下。
     #[test]
     fn glm_quota_parsing_keeps_the_requested_adapter_identity() {
@@ -1636,92 +1498,6 @@ mod tests {
         let samples = parse_glm_quota(&json, "pi");
         assert_eq!(samples.len(), 2);
         assert!(samples.iter().all(|sample| sample.adapter_id == "pi"));
-    }
-
-    /// 真机抓包（2026-08，百炼个人 Token Plan）：信封嵌套 data.DataV2.data.data，
-    /// 字段是 0..1 的已用比例；该账号当时只有周窗（1.0 = 已用完，约 2.6 小时后重置）。
-    const QWEN_LIVE_RESPONSE: &str = r#"{
-        "code": "200",
-        "data": {
-            "DataV2": {
-                "ret": ["SUCCESS::接口调用成功"],
-                "data": {
-                    "msg": "Success.",
-                    "code": "SUCCESS",
-                    "data": {
-                        "per1WeekResetTime": 1787202720000,
-                        "per1WeekPercentage": 1.0
-                    },
-                    "requestId": "75667df2-d953-9dbc-8e56-8bf7a38a73f8",
-                    "success": true
-                }
-            },
-            "success": true,
-            "httpStatus": 200,
-            "errorCode": "",
-            "api": "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage",
-            "errorMsg": ""
-        },
-        "httpStatusCode": "200",
-        "requestId": "75667df2-d953-4dbc-8e56-8bf7a38a73f8",
-        "successResponse": true
-    }"#;
-
-    #[test]
-    fn qwen_quota_reads_ratios_and_only_present_windows() {
-        let json: Value = serde_json::from_str(QWEN_LIVE_RESPONSE).unwrap();
-        let samples = parse_qwen_quota(&json, 1_787_193_340_000);
-
-        // 只有周窗：1.0 已用比例 → 剩余 0%，重置时刻原样保留（在周窗合理范围内）。
-        assert_eq!(samples.len(), 1);
-        assert_eq!(samples[0].adapter_id, "qwen");
-        assert_eq!(samples[0].window_key, "seven_day");
-        assert_eq!(samples[0].remaining_percent, 0.0);
-        assert_eq!(samples[0].resets_at_ms, Some(1_787_202_720_000));
-    }
-
-    #[test]
-    fn qwen_quota_handles_both_windows_and_ratio_scale() {
-        // 5h 窗 0.25 已用 → 剩 75%；周窗 0.05 → 剩 95%；百分比字符串也认。
-        let json: Value = serde_json::json!({
-            "code": "200",
-            "data": {"DataV2": {"data": {"data": {
-                "per5HourPercentage": 0.25,
-                "per5HourResetTime": 1787196940000_i64,
-                "per1WeekPercentage": "0.05",
-                "per1WeekResetTime": 1787202720000_i64
-            }}}}
-        });
-        let samples = parse_qwen_quota(&json, 1_787_193_340_000);
-        assert_eq!(samples.len(), 2);
-        assert_eq!(samples[0].window_key, "five_hour");
-        assert_eq!(samples[0].remaining_percent, 75.0);
-        assert_eq!(samples[1].window_key, "seven_day");
-        assert_eq!(samples[1].remaining_percent, 95.0);
-    }
-
-    #[test]
-    fn qwen_quota_rejects_business_errors_and_windowless_payloads() {
-        let error = serde_json::json!({"code": "500", "errorMsg": "系统异常"});
-        assert!(parse_qwen_quota(&error, 0).is_empty());
-        let no_windows = serde_json::json!({"code": "200", "data": {"foo": 1}});
-        assert!(parse_qwen_quota(&no_windows, 0).is_empty());
-    }
-
-    /// 打真实百炼接口的烟测：需要设置页保存或 QWEN_COOKIE 里有控制台 cookie。
-    #[test]
-    #[ignore = "reads local Qwen console cookie and calls the live quota API"]
-    fn live_qwen_quota_smoke_test() {
-        let samples = fetch_qwen_quota(Duration::from_secs(15)).expect("fetch qwen quota");
-        assert!(!samples.is_empty(), "配额响应里没有可用窗口");
-        for sample in &samples {
-            println!(
-                "qwen quota: window={} remaining={:.1}% resets_at={:?}",
-                sample.window_key, sample.remaining_percent, sample.resets_at_ms
-            );
-            assert_eq!(sample.adapter_id, "qwen");
-            assert!((0.0..=100.0).contains(&sample.remaining_percent));
-        }
     }
 
     /// 真机抓包（2026-07，Kimi Code + OAuth 登录），只把 userId 换成占位符。

--- a/src-tauri/src/detect.rs
+++ b/src-tauri/src/detect.rs
@@ -18,7 +18,8 @@ use std::path::PathBuf;
 pub enum Probe {
     /// 任一路径存在即算装了。路径已按平台解析成绝对路径。
     Paths(Vec<PathBuf>),
-    /// 由用户配置的凭据提供（Qoder 只有账户级 Credits，没有本地日志）。
+    /// 由用户配置的凭据提供（Qoder 只有账户级 Credits，没有本地日志；Qwen 看
+    /// pi auth.json 里有没有百炼 Token Plan 的 key）。
     Credential(fn() -> bool),
     /// 没有便宜且可靠的安装痕迹。此类 Agent 只能靠"本周期有用量"反推，
     /// 由调用方补上，这里如实返回"未知"而不是猜一个路径。
@@ -117,9 +118,11 @@ pub fn table() -> Vec<AgentProbe> {
             ]),
         },
         AgentProbe {
-            // 配额-only：百炼 Token Plan 只有控制台 cookie 能查（同 Qoder 模式）。
+            // 百炼 Token Plan 没有可编程的额度接口，控制台 cookie 只能活几天，
+            // 官方额度源已移除；卡片只承载 pi 归属过来的用量，探针看 pi 配了没配
+            // 百炼 Token Plan 的 key。
             id: "qwen",
-            probe: Probe::Credential(|| coding_quota::qwen_cookie_source().is_some()),
+            probe: Probe::Credential(coding_quota::pi_auth_has_qwen_token_plan),
         },
     ]
 }

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 /// qoder 是配额-only：Qoder、QoderWork 与 Qoder CLI 共用同一账户级 Credits
 /// 配额来源。Qoder CLI 的本地遥测 token 字段实测为 0，不能作为用量账本来源。
 /// kimiwork 只保留为内部配额来源，窗口合并到 kimi，不作为独立可见 Agent。
-/// qwen 同为配额-only：百炼个人 Token Plan 是账户级套餐，被 pi 等客户端的
-/// qwen-token-plan key 消费，但额度只能在百炼控制台查。
+/// qwen 只有本地用量：pi 的 qwen-token-plan key 用量归属到这张卡；百炼 Token
+/// Plan 没有可编程的官方额度接口，不拉官方配额。
 pub const AGENT_IDS: [&str; 11] = [
     "codex",
     "claude",

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -2140,11 +2140,13 @@ mod tests {
         connection
             .execute_batch(include_str!("../migrations/001_init.sql"))
             .unwrap();
-        let today = Local::now().date_naive();
+        // 日期固定在周三：北京周末全天谷段的规则生效后，周末的本地日里根本
+        // 没有峰段时刻，取“今天”会让这个测试在北京时间周末必挂。
+        let today = NaiveDate::from_ymd_opt(2026, 8, 26).unwrap();
         let local_now = test_local_time(today, 23);
 
         // 本地一天覆盖 24 个 UTC 小时，峰段最长的空档也只有 15 小时，
-        // 所以 0–22 点里一定各能找到一个峰段和一个谷段时刻（与时区无关）。
+        // 所以工作日里 0–22 点一定各能找到一个峰段和一个谷段时刻（与时区无关）。
         let hour_ms = |hour: u32| -> Option<i64> {
             Local
                 .from_local_datetime(&today.and_hms_opt(hour, 0, 0).unwrap())

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -1549,14 +1549,6 @@ fn source_views(report: ScanReport, sync_status: Option<SyncView>) -> Vec<Source
             }
             .into(),
         },
-        SourceView {
-            id: "qwen-quota".into(),
-            kind: "official".into(),
-            label: "Qwen Token Plan 官方配额".into(),
-            detail: "阿里百炼个人 Token Plan 是账户级套餐（pi 等客户端用它的 sk-sp- key 消耗），额度只能从百炼控制台读取：用你提供的登录 cookie 查询 5 小时与每周滚动窗，cookie 仅明文保存在本机、不入账本不同步，可随时清除。".into(),
-            quality: "official".into(),
-            quality_label: "官方".into(),
-        },
     ];
 
     if let Some(sync_status) = sync_status.filter(|status| status.enabled) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -822,71 +822,6 @@ async fn configure_qoder_cookie(cookie: Option<String>) -> Result<QoderCookieVie
     .map_err(|error| format!("qoder cookie task failed: {error}"))?
 }
 
-/// Qwen cookie 状态/配置视图与 Qoder 同构，设置页共用样式。
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct QwenCookieView {
-    configured: bool,
-    source: Option<&'static str>,
-    message: Option<String>,
-}
-
-#[tauri::command]
-async fn qwen_cookie_status() -> Result<QwenCookieView, String> {
-    let source = coding_quota::qwen_cookie_source();
-    Ok(QwenCookieView {
-        configured: source.is_some(),
-        source,
-        message: None,
-    })
-}
-
-/// 保存/清除 Qwen（百炼）控制台 cookie，保存后立即拉一次官方额度验证。
-#[tauri::command]
-async fn configure_qwen_cookie(cookie: Option<String>) -> Result<QwenCookieView, String> {
-    tauri::async_runtime::spawn_blocking(move || {
-        let normalized = match cookie.as_deref() {
-            Some(raw) => Some(
-                coding_quota::normalize_qoder_cookie_input(raw)
-                    .ok_or_else(|| "粘贴内容里没有找到 Cookie 行".to_owned())?,
-            ),
-            None => None,
-        };
-        let saved = coding_quota::write_qwen_cookie_file(normalized.as_deref())
-            .map_err(|error| error.to_string())?;
-        let source = coding_quota::qwen_cookie_source();
-        if !saved {
-            return Ok(QwenCookieView {
-                configured: source.is_some(),
-                source,
-                message: Some("已清除本地保存的 cookie。".to_owned()),
-            });
-        }
-        let message = match coding_quota::fetch_qwen_quota(std::time::Duration::from_secs(10)) {
-            Ok(samples) => {
-                let mut parts = Vec::new();
-                for sample in &samples {
-                    let label = if sample.window_key == "five_hour" {
-                        "5 小时"
-                    } else {
-                        "每周"
-                    };
-                    parts.push(format!("{label}剩余 {:.0}%", sample.remaining_percent));
-                }
-                format!("已保存并验证成功：{}。", parts.join("，"))
-            }
-            Err(error) => format!("已保存，但验证失败：{error}"),
-        };
-        Ok(QwenCookieView {
-            configured: true,
-            source,
-            message: Some(message),
-        })
-    })
-    .await
-    .map_err(|error| format!("qwen cookie task failed: {error}"))?
-}
-
 #[tauri::command]
 async fn sync_settings(state: State<'_, AppState>) -> Result<domain::SyncView, String> {
     let database_path = state.database_path.clone();
@@ -1661,8 +1596,6 @@ pub fn run() {
             set_claude_oauth,
             qoder_cookie_status,
             configure_qoder_cookie,
-            qwen_cookie_status,
-            configure_qwen_cookie,
             set_taskbar_button,
             set_tray_quota_icon,
             #[cfg(target_os = "linux")]

--- a/src-tauri/src/quota.rs
+++ b/src-tauri/src/quota.rs
@@ -132,7 +132,6 @@ pub fn registry() -> Vec<Box<dyn QuotaProvider>> {
         ("kimiwork", coding_quota::fetch_kimiwork_quota),
         ("qoder", coding_quota::fetch_qoder_quota),
         ("workbuddy", coding_quota::fetch_workbuddy_quota),
-        ("qwen", coding_quota::fetch_qwen_quota),
     ] {
         providers.push(Box::new(HttpQuota { adapter_id, fetch }));
     }
@@ -200,8 +199,8 @@ pub fn refresh_all(connection: &Connection, cache: &QuotaCache, force: bool) -> 
     Ok(())
 }
 
-/// 清除注册表已不存在的 adapter 的残留配额行。0.17.2 把 pi 配额源移除后，
-/// 0.17.1 写入的 pi 行若不清理，卡片/胶囊会继续显示一个不再有来源的配额。
+/// 清除注册表已不存在的 adapter 的残留配额行。来源被移除后（如 pi 额度源、
+/// Qwen Token Plan 的控制台 cookie 源），旧版本写入的行若不清理，卡片/胶囊会继续显示一个不再有来源的配额。
 /// 只删“不再有 provider”的 adapter；仍在注册表里的（含 kimiwork 这类内部源）
 /// 即使本轮拉空也保留旧行（陈旧展示由展示层负责）。
 pub fn prune_unmanaged_quota_rows(connection: &Connection) -> Result<()> {
@@ -348,8 +347,9 @@ mod tests {
     fn prune_removes_rows_of_removed_quota_sources_only() {
         use crate::domain::QuotaSample;
         let connection = memory_ledger();
-        // pi 曾是配额源（0.17.1），0.17.2 移除；kimiwork 仍在注册表。
-        for adapter in ["pi", "kimiwork"] {
+        // pi 曾是配额源（0.17.1）、Qwen 控制台 cookie 源后来也移除；
+        // kimiwork 仍在注册表。
+        for adapter in ["pi", "qwen", "kimiwork"] {
             storage::upsert_quota(
                 &connection,
                 &QuotaSample {
@@ -377,7 +377,7 @@ mod tests {
         assert_eq!(
             left,
             vec!["kimiwork".to_string()],
-            "pi 残留应被清除、kimiwork 保留"
+            "pi 与 qwen 残留应被清除、kimiwork 保留"
         );
     }
 
@@ -400,7 +400,6 @@ mod tests {
                 "kimi",
                 "kimiwork",
                 "qoder",
-                "qwen",
                 "workbuddy",
                 "zcode"
             ]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,8 +60,6 @@ import {
   getUsageSessions,
   getUsageProjects,
   getProjectRules,
-  getQwenCookieStatus,
-  configureQwenCookie,
   setProjectRules,
   getUsageSnapshot,
   rebuildLocalLedger,
@@ -219,8 +217,8 @@ const AGENT_META = {
     iconClass: "agent-icon--pi",
   },
   qwen: {
-    // 配额-only：百炼个人 Token Plan 是账户级套餐，由 pi 等客户端的
-    // qwen-token-plan key 消耗；额度只能在百炼控制台查。
+    // 百炼个人 Token Plan 是账户级套餐，由 pi 等客户端的 qwen-token-plan key
+    // 消耗；额度没有可编程的官方接口，这张卡只记本地归属用量。
     label: "Qwen",
     // 千问 App 官方图标；紫与 GLM 的 #6a5ae0 同系不同值，亮度更高。
     accent: "#7b5cd6",
@@ -2881,106 +2879,6 @@ const SETTINGS_TABS = [
   },
 ];
 
-function QwenQuotaCard({ onSnapshotRefresh }) {
-  const [status, setStatus] = useState(null);
-  const [cookieInput, setCookieInput] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [feedback, setFeedback] = useState(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    getQwenCookieStatus()
-      .then((value) => {
-        if (!cancelled) setStatus(value);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const apply = async (cookie) => {
-    setBusy(true);
-    setFeedback(null);
-    try {
-      const next = await configureQwenCookie(cookie);
-      setStatus(next);
-      setCookieInput("");
-      // 验证失败也已保存：如实转述后端的结果，不粉饰。
-      setFeedback({
-        tone: next.message?.includes("失败") ? "error" : "success",
-        message: next.message || "已更新。",
-      });
-      if (cookie && !next.message?.includes("失败")) onSnapshotRefresh();
-    } catch (error) {
-      setFeedback({ tone: "error", message: `操作失败：${error}` });
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  return (
-    <div className="settings-card">
-      <h2>Qwen Token Plan 官方额度</h2>
-      <p className="settings-muted">
-        阿里百炼个人 Token Plan 是账户级套餐，pi 等客户端用它的订阅 key 消耗额度；额度只能在百炼控制台查询，需要你提供一次
-        登录 cookie。cookie 仅明文保存在本机（不入账本、不进同步导出），可随时清除。
-      </p>
-      <details className="settings-guide">
-        <summary>如何获取 cookie</summary>
-        <ol>
-          <li>浏览器登录 bailian.console.aliyun.com，打开「资源食用 → Token 管理」下的 Token Plan 页；</li>
-          <li>按 F12 打开开发者工具 → 网络（Network）标签，点过滤器里的 Fetch/XHR；</li>
-          <li>刷新页面，右键任意 aliyun.com 域名的请求 → 复制 →「以 cURL 格式复制」，把整段粘贴到下面——会自动提取其中的 Cookie。</li>
-        </ol>
-      </details>
-      {status?.demo ? (
-        <p className="settings-muted">浏览器演示模式：仅桌面应用可配置。</p>
-      ) : (
-        <>
-          <div className="settings-directory-row">
-            <input
-              type="password"
-              value={cookieInput}
-              placeholder="粘贴 Cookie 值 / 整段请求标头 / cURL 命令"
-              spellCheck={false}
-              disabled={busy}
-              aria-label="Qwen cookie"
-              onChange={(event) => setCookieInput(event.target.value)}
-            />
-            <button
-              type="button"
-              className="ledger-button ledger-button--primary"
-              disabled={busy || !cookieInput.trim()}
-              onClick={() => apply(cookieInput.trim())}
-            >
-              保存并验证
-            </button>
-          </div>
-          {status?.source === "file" && (
-            <button
-              type="button"
-              className="ledger-button ledger-button--secondary"
-              disabled={busy}
-              onClick={() => apply(null)}
-            >
-              清除已保存的 cookie
-            </button>
-          )}
-          {feedback && (
-            <p
-              className={`settings-feedback settings-feedback--${feedback.tone}`}
-              role={feedback.tone === "error" ? "alert" : "status"}
-            >
-              {feedback.message}
-            </p>
-          )}
-        </>
-      )}
-    </div>
-  );
-}
-
 function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent, onMoveWidgetAgent, stripAgents, onToggleStripAgent, onMoveStripAgent, detectedAgents, trayBadgeEnabled, onToggleTrayBadge, glassAlpha, onGlassAlpha, glassTint, onGlassTint, glassInk, onGlassInk, uiScale, onUiScale, stripScale, onStripScale, pinned, onPinnedChange, pinnedHoverMode, onPinnedHoverMode, pinnedHoverOpacity, onPinnedHoverOpacity, theme, onThemeChange, autoUpdateCheck, onAutoUpdateCheck, availableUpdate }) {
   const [settings, setSettings] = useState(null);
   const [directoryInput, setDirectoryInput] = useState("");
@@ -3112,7 +3010,6 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
           <>
             <ClaudeHookCard onSnapshotRefresh={onSnapshotRefresh} />
             <QoderQuotaCard onSnapshotRefresh={onSnapshotRefresh} />
-            <QwenQuotaCard onSnapshotRefresh={onSnapshotRefresh} />
           </>
         )}
 

--- a/src/usageClient.js
+++ b/src/usageClient.js
@@ -635,20 +635,6 @@ async function configureQoderCookie(cookie) {
   return invoke("configure_qoder_cookie", { cookie });
 }
 
-async function getQwenCookieStatus() {
-  if (!isTauriRuntime()) {
-    return { demo: true, configured: false, source: null, message: null };
-  }
-  return invoke("qwen_cookie_status");
-}
-
-async function configureQwenCookie(cookie) {
-  if (!isTauriRuntime()) {
-    throw new Error("浏览器演示模式不能配置 cookie");
-  }
-  return invoke("configure_qwen_cookie", { cookie });
-}
-
 async function getClaudeOauthStatus() {
   if (!isTauriRuntime()) {
     return {
@@ -692,6 +678,4 @@ export {
   setClaudeOauth,
   getQoderCookieStatus,
   configureQoderCookie,
-  getQwenCookieStatus,
-  configureQwenCookie,
 };


### PR DESCRIPTION
## 影响范围

`shared`（额度取数层、设置页；不涉及平台壳行为）。

## 为什么

百炼个人 Token Plan 的额度只暴露在控制台交互式登录态后面。真机实测：

- 保存的控制台 cookie 约两天即失效（08-20 保存，08-22 后抓取失败，网关返回 `BailianGateway.Login.NotLogined`）；
- cookie 里带的长期 SSO cookie（`hssid`/`hsite`）同时失效，两条续期路径实测都停在登录页，无法静默换新票据；
- 官方 OpenAPI（`@alicloud/bailian20231229` 2.14.3，246 个接口）没有任何额度相关端点，AK/SK 路线不存在。

每两天要求用户重新粘贴一次 cookie，成本与收益不成比例，整体移除该来源。

## 改动

- 删除控制台网关抓取/解析、cookie 文件与环境变量读写、`qwen_cookie_status`/`configure_qwen_cookie` 命令、设置页卡片、注册表条目
- Qwen 卡片保留：只承载 pi 会话归属过来的本地用量（与 Pi 卡同语义）；检测探针改为检查 `~/.pi/agent/auth.json` 是否配置了百炼 Token Plan 的 key
- 旧版本写入的残留额度行由既有 prune 逻辑清理（测试补了 qwen 用例）
- 顺带修复 `deepseek_cost_follows_the_utc_peak_and_off_peak_windows`：北京周末全天谷段规则（#142）生效后该测试取「今天」在北京时间周末必挂，锚定到固定工作日
- 决策记入 `docs/PRODUCT-CONSTRAINTS.md`，`docs/ARCHITECTURE.md` Quota 一节同步

## 已验证（Windows）

- `cargo fmt --check`、`cargo clippy -- -D warnings` 通过
- `cargo test`：226 过、0 挂、6 忽略（忽略项均为需真机凭据的 live 烟测）
- `npm test`：50 全过；`npm run build` 成功

## 仍需其他平台

无壳层改动；CI 三平台矩阵为准，macOS/Linux 无原生烟测项。