### PR TITLE
chore: release v0.18.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.18.2",
+      "version": "0.18.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.18.2"
+version = "0.18.3"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- Bump version to 0.18.3 for release. Contains #150 (download docs + daily update-check cadence) and #151 (formal UI copy sweep).

## Impact

Version metadata only; no code changes on top of #150/#151.

## Verification

- Version files match the 0.18.2 bump commit layout (package.json, package-lock.json, tauri.conf.json, Cargo.toml, Cargo.lock metrik entry).