### PR TITLE
feat(linux): add vertical strip hover details

### DIFF
--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -114,6 +114,14 @@ change.
   pointer exit, and reveal from that edge's remaining visible sliver. Pinning
   immediately keeps the complete form visible. Horizontal and vertical strip
   placements are remembered independently.
+- On Windows and Linux, hovering an Agent in the unpinned vertical strip opens
+  its complete official-quota windows in a pointer-anchored detail bubble. The temporary
+  transparent berth expands away from the nearest screen edge when global
+  coordinates are available, while the strip itself remains fixed in place.
+  On Wayland it expands toward the window-local right and leaves placement to
+  the compositor. Leaving the berth restores the exact prior window size and,
+  when the platform exposes it, position. Linux pinned read-only hover behavior
+  remains authoritative and never opens the detail bubble.
 - Floating-form size uses the destination monitor's DPI. Compact and strip
   reassert size from native DPI-change payloads, and window mutations are
   serialized so stale resizes cannot overwrite corrections.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,8 +74,10 @@ import {
   broadcastMacAgentSelection,
   broadcastMacAppearance,
   checkForUpdate,
+  collapseVerticalStripHover,
   closeWindow,
   getMacAgentSelection,
+  expandVerticalStripHover,
   getAutostart,
   installUpdate,
   isDesktop,
@@ -271,6 +273,8 @@ const STRIP_BAR_HEIGHT = 28;
 // 竖条宽度由 26px 控件槽 + 外壳 padding 定死下限（32px）；42 留 10px 呼吸，
 // 再宽图标和百分比周围就空得发肥。
 const STRIP_VERTICAL_WIDTH = 42;
+const STRIP_DETAIL_WINDOW_WIDTH = 392;
+const STRIP_DETAIL_CARD_MARGIN = 16;
 const STRIP_VCELL_HEIGHT = 46;
 // 横条宽度的收缩迟滞。一格 54px，所以 6px 远低于「真的少了一个 Agent」，
 // 又高于 DPI/zoom 取整带来的亚像素噪声。
@@ -545,6 +549,50 @@ function quotaSeverity(view) {
   // 与 bindingWindow 的"告急"同一条线：越过它，这个窗口才会顶到行首。
   if (used >= 100 - QUOTA_LOW_REMAINING) return "warn";
   return "";
+}
+
+function StripDetailCard({ agentId, cell, cardRef }) {
+  const meta = AGENT_META[agentId];
+  const firstView = cell?.windows?.[0]?.view;
+  const stale = firstView && (firstView.stale || firstView.quality === "official_snapshot");
+  return (
+    <aside ref={cardRef} className="strip-detail-card" role="tooltip" aria-label={`${meta.label} 用量详情`}>
+      <header className="strip-detail-header">
+        <img src={meta.iconSrc} className={meta.iconClass || ""} alt="" draggable={false} />
+        <strong>{meta.label} 用量</strong>
+      </header>
+      {cell?.windows?.length ? (
+        <div className="strip-detail-metrics">
+          {cell.windows.map((window) => {
+            const view = window.view;
+            const used = Math.round(quotaUsedPercent(view));
+            const severity = quotaSeverity(view);
+            const reset = Number.isFinite(view.resetsInMinutes)
+              ? `${formatReset(view.resetsInMinutes)}后重置`
+              : "重置时间不可用";
+            return (
+              <section className="strip-detail-metric" key={window.key}>
+                <span>{window.label || shortWindowLabel(window.key)}</span>
+                <div className="strip-detail-track" aria-hidden="true">
+                  <i
+                    className={severity ? `strip-detail-fill--${severity}` : ""}
+                    style={{ width: `${used}%`, backgroundColor: severity ? undefined : meta.accent }}
+                  />
+                </div>
+                <p>
+                  <strong>已用 {used}%</strong>
+                  <small>{reset}</small>
+                </p>
+              </section>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="strip-detail-empty">官方配额暂不可用</p>
+      )}
+      {stale && <footer>官方快照 · {formatQuotaAge(firstView.ageMinutes)}</footer>}
+    </aside>
+  );
 }
 
 // 消耗节奏（仅长窗口有意义）：已用占比对比窗口已经过时间占比，
@@ -1231,7 +1279,19 @@ function StripBar({
   // 透明档的真实桌面背景变化很大，控制图标加粗以稳定识别。
   const buttonWeight = transparent && glassTint === "clear" ? "bold" : "regular";
   const shellRef = useRef(null);
+  const railRef = useRef(null);
+  const detailCardRef = useRef(null);
   const OrientationIcon = vertical ? ArrowsLeftRight : ArrowsDownUp;
+  const detailEnabled = (IS_WINDOWS || IS_LINUX) && vertical && !(pinned && IS_LINUX);
+  const [hoveredDetail, setHoveredDetail] = useState(null);
+  const [detailLayout, setDetailLayout] = useState({
+    side: IS_LINUX ? "left" : "right",
+    railOffsetY: 0,
+  });
+  const detailCell = detailEnabled && hoveredDetail
+    ? cells.find(({ agentId }) => agentId === hoveredDetail.agentId) ?? null
+    : null;
+  const detailOpen = Boolean(detailCell);
   // 控制按钮不再常驻：四个 26px 的槽在竖条上要吃掉 130px，比三个格子还高。
   // 改成按需就地展开——点状态灯位上浮出的 … 把它们放出来，条身随之变长，
   // 指针离开自动收回。窗口尺寸本来就跟着内容测量走，这里不用另外调窗。
@@ -1241,6 +1301,9 @@ function StripBar({
   useEffect(() => {
     if (pinned && IS_LINUX) setControlsOpen(false);
   }, [pinned]);
+  useEffect(() => {
+    if (!detailEnabled) setHoveredDetail(null);
+  }, [detailEnabled]);
   const shellAppearance = glassShellAppearance("strip", {
     transparent,
     glassMode,
@@ -1250,6 +1313,64 @@ function StripBar({
     isMac: IS_MAC,
     vertical,
   });
+  useLayoutEffect(() => {
+    if (!detailOpen) {
+      latestWindowCorrection += 1;
+      if (isDesktop() && (IS_WINDOWS || IS_LINUX)) {
+        runWindowAction(collapseVerticalStripHover);
+      }
+      return;
+    }
+    const rail = railRef.current;
+    const card = detailCardRef.current;
+    if (!rail || !card) return;
+    const railRect = rail.getBoundingClientRect();
+    const cardRect = card.getBoundingClientRect();
+    const targetHeight = Math.max(
+      Math.ceil(railRect.height),
+      Math.ceil(cardRect.height + STRIP_DETAIL_CARD_MARGIN * 2),
+    );
+    if (!isDesktop()) {
+      const shellHeight = shellRef.current?.clientHeight || window.innerHeight;
+      const halfCard = cardRect.height / 2;
+      const cardCenterY = Math.min(
+        Math.max(hoveredDetail.anchorY, halfCard + STRIP_DETAIL_CARD_MARGIN),
+        Math.max(shellHeight - halfCard - STRIP_DETAIL_CARD_MARGIN, halfCard + STRIP_DETAIL_CARD_MARGIN),
+      );
+      const pointerY = Math.min(
+        Math.max(hoveredDetail.anchorY - cardCenterY + halfCard, 22),
+        Math.max(cardRect.height - 22, 22),
+      );
+      setDetailLayout({
+        side: IS_LINUX ? "left" : "right",
+        railOffsetY: 0,
+        cardCenterY,
+        pointerY,
+      });
+      return;
+    }
+    runLatestWindowCorrection(async () => {
+      const layout = await expandVerticalStripHover({
+        width: STRIP_DETAIL_WINDOW_WIDTH,
+        height: targetHeight,
+        railWidth: STRIP_VERTICAL_WIDTH,
+        railHeight: Math.ceil(railRect.height),
+        anchorY: hoveredDetail.anchorY,
+        cardHeight: Math.ceil(cardRect.height),
+      });
+      if (layout) {
+        setDetailLayout(layout);
+      } else {
+        setHoveredDetail((current) =>
+          current?.agentId === hoveredDetail.agentId ? null : current,
+        );
+      }
+    });
+  }, [detailOpen, hoveredDetail?.agentId, hoveredDetail?.anchorY]);
+  useEffect(() => () => {
+    latestWindowCorrection += 1;
+    if (IS_WINDOWS || IS_LINUX) runWindowAction(collapseVerticalStripHover);
+  }, []);
   // 窗口尺寸跟随真实内容（通用方案，替代手写常量）：每次渲染后与视口变化时
   // 复核目标尺寸，差 ≥1px 才调窗；量的是 CSS px，resizeStripWindow 内部统一
   // 乘缩放系数与 DPI。任何字体/DPI/缩放/更新点组合都收敛，不再裁按钮。
@@ -1260,6 +1381,7 @@ function StripBar({
     let timer = null;
     const fit = () => {
       timer = null;
+      if (detailOpen) return;
       const isVertical = shell.classList.contains("strip-shell--vertical");
       if (isVertical) {
         const targetHeight = measureStripVerticalContent(shell);
@@ -1328,12 +1450,28 @@ function StripBar({
   // 展开态跟着指针走：移出条身就收回，省得用户忘了收，条一直长着。
   const handlePointerLeave = (event) => {
     glassProps.onPointerLeave?.(event);
+    setHoveredDetail(null);
     setControlsOpen(false);
   };
+  const showDetail = (event, agentId) => {
+    if (!detailEnabled) return;
+    const railBounds = railRef.current?.getBoundingClientRect();
+    const cellBounds = event.currentTarget.getBoundingClientRect();
+    if (!railBounds) return;
+    setHoveredDetail({
+      agentId,
+      anchorY: cellBounds.top - railBounds.top + cellBounds.height / 2,
+    });
+  };
+  const shellClassName = [
+    shellAppearance.className,
+    detailOpen ? "strip-shell--detail-open" : "",
+    detailOpen ? `strip-shell--detail-${detailLayout.side}` : "",
+  ].filter(Boolean).join(" ");
   return (
     <main
       ref={shellRef}
-      className={shellAppearance.className}
+      className={shellClassName}
       data-glass-surface={shellAppearance.trueAlpha ? "true-alpha" : undefined}
       data-pinned={pinned && IS_LINUX ? "true" : undefined}
       inert={pinned && IS_LINUX ? true : undefined}
@@ -1342,10 +1480,16 @@ function StripBar({
       onPointerLeave={handlePointerLeave}
       style={{
         ...shellAppearance.style,
+        "--strip-rail-offset-y": `${detailLayout.railOffsetY}px`,
+        "--strip-detail-card-center-y": `${detailLayout.cardCenterY ?? ((hoveredDetail?.anchorY || 0) + detailLayout.railOffsetY)}px`,
+        "--strip-detail-pointer-y": Number.isFinite(detailLayout.pointerY)
+          ? `${detailLayout.pointerY}px`
+          : "50%",
         ...(pinned ? { cursor: "default" } : {}),
       }}
     >
       <h1 className="sr-only">Metrik 官方配额胶囊条</h1>
+      <div ref={railRef} className="strip-rail">
       {cells.length ? (
         cells.map(({ agentId, cell }) => {
           const meta = AGENT_META[agentId];
@@ -1355,6 +1499,7 @@ function StripBar({
                 key={agentId}
                 className="strip-cell strip-cell--unavailable"
                 title={`${meta.label}：官方配额不可用`}
+                onPointerEnter={(event) => showDetail(event, agentId)}
                 {...dragProps}
               >
                 <img
@@ -1375,7 +1520,8 @@ function StripBar({
             <div
               key={agentId}
               className={`strip-cell ${severity ? `strip-cell--${severity}` : ""}`}
-              title={stripTooltip(agentId, cell.windows)}
+              title={detailEnabled ? undefined : stripTooltip(agentId, cell.windows)}
+              onPointerEnter={(event) => showDetail(event, agentId)}
               {...dragProps}
             >
               <img
@@ -1474,6 +1620,14 @@ function StripBar({
           </>
         )}
       </div>
+      </div>
+      {detailOpen && detailCell && (
+        <StripDetailCard
+          agentId={detailCell.agentId}
+          cell={detailCell.cell}
+          cardRef={detailCardRef}
+        />
+      )}
     </main>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1315,6 +1315,9 @@ html:has(.strip-shell) #root {
 }
 
 .strip-shell {
+  --strip-detail-surface: rgba(248, 248, 247, 0.98);
+  --strip-detail-ink: rgba(29, 31, 35, 0.94);
+  --strip-detail-muted: rgba(48, 51, 57, 0.48);
   display: flex;
   align-items: center;
   width: 100vw;
@@ -1331,6 +1334,14 @@ html:has(.strip-shell) #root {
   user-select: none;
 }
 
+.strip-rail {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  gap: 2px;
+}
+
 .strip-shell--vertical {
   flex-direction: column;
   align-items: stretch;
@@ -1338,11 +1349,199 @@ html:has(.strip-shell) #root {
   gap: 4px;
 }
 
+.strip-shell--vertical .strip-rail {
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+  gap: 4px;
+}
+
+/* Windows 竖条悬停详情：透明主窗口只提供承载区，原条身和气泡各自画表面。
+   条身按原坐标留在屏幕上，详情从指向当前 Agent 的尖角位置展开。 */
+.strip-shell--vertical.strip-shell--detail-open {
+  position: relative;
+  display: block;
+  padding: 0;
+  overflow: hidden;
+  background: transparent;
+  box-shadow: none;
+}
+
+.strip-shell--detail-open .strip-rail {
+  position: absolute;
+  z-index: 2;
+  top: var(--strip-rail-offset-y, 0px);
+  display: flex;
+  flex: none;
+  width: 42px;
+  height: max-content;
+  padding: 6px 3px 4px;
+  gap: 4px;
+  border-radius: 8px;
+  background:
+    radial-gradient(140% 180% at 14% 0%, rgba(255, 255, 255, 0.9), transparent 60%),
+    linear-gradient(165deg, #fbfbfa, #f0efeb);
+  box-shadow: inset 0 0 0 1px rgba(31, 33, 36, 0.08);
+}
+
+.strip-shell--detail-right .strip-rail { right: 0; }
+.strip-shell--detail-left .strip-rail { left: 0; }
+
+.strip-detail-card {
+  position: absolute;
+  z-index: 4;
+  top: var(--strip-detail-card-center-y, 50%);
+  width: 310px;
+  padding: 18px;
+  color: var(--strip-detail-ink);
+  background: var(--strip-detail-surface);
+  border: 1px solid rgba(31, 33, 36, 0.075);
+  border-radius: 20px;
+  box-shadow:
+    0 24px 56px rgba(10, 12, 16, 0.2),
+    0 6px 18px rgba(10, 12, 16, 0.12),
+    inset 0 1px rgba(255, 255, 255, 0.45);
+  pointer-events: none;
+  transform: translateY(-50%);
+  transform-origin: right var(--strip-detail-pointer-y, 50%);
+  animation: strip-detail-reveal-right 220ms cubic-bezier(0.2, 0.82, 0.22, 1) both;
+}
+
+.strip-shell--detail-right .strip-detail-card { right: 68px; }
+.strip-shell--detail-left .strip-detail-card {
+  left: 68px;
+  transform-origin: left var(--strip-detail-pointer-y, 50%);
+  animation-name: strip-detail-reveal-left;
+}
+
+.strip-detail-card::after {
+  content: "";
+  position: absolute;
+  top: var(--strip-detail-pointer-y, 50%);
+  width: 19px;
+  height: 38px;
+  background: var(--strip-detail-surface);
+  clip-path: polygon(0 0, 100% 50%, 0 100%, 16% 72%, 22% 50%, 16% 28%);
+  transform: translateY(-50%);
+}
+
+.strip-shell--detail-right .strip-detail-card::after { right: -18px; }
+.strip-shell--detail-left .strip-detail-card::after {
+  left: -18px;
+  transform: translateY(-50%) scaleX(-1);
+}
+
+.strip-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.strip-detail-header img {
+  width: 17px;
+  height: 17px;
+  border-radius: 4px;
+}
+
+.strip-detail-header strong {
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 19px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.strip-detail-metrics {
+  display: grid;
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.strip-detail-metric { display: grid; gap: 7px; }
+.strip-detail-metric > span {
+  overflow: hidden;
+  font-size: 11.5px;
+  line-height: 14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.strip-detail-track {
+  height: 6px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--strip-detail-ink) 15%, transparent);
+  border-radius: 999px;
+}
+
+.strip-detail-track i {
+  display: block;
+  min-width: 3px;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.strip-detail-track .strip-detail-fill--warn { background: #e8b04a; }
+.strip-detail-track .strip-detail-fill--critical { background: #ec7a63; }
+
+.strip-detail-metric p {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 14px;
+}
+
+.strip-detail-metric p strong { font-weight: 580; }
+.strip-detail-metric p small {
+  overflow: hidden;
+  color: var(--strip-detail-muted);
+  font-size: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.strip-detail-empty,
+.strip-detail-card footer {
+  margin: 14px 0 0;
+  color: var(--strip-detail-muted);
+  font-size: 11px;
+  line-height: 15px;
+}
+
+@keyframes strip-detail-reveal-right {
+  from { opacity: 0; transform: translate(8px, -50%) scale(0.97); }
+  to { opacity: 1; transform: translate(0, -50%) scale(1); }
+}
+
+@keyframes strip-detail-reveal-left {
+  from { opacity: 0; transform: translate(-8px, -50%) scale(0.97); }
+  to { opacity: 1; transform: translate(0, -50%) scale(1); }
+}
+
 /* 玻璃模式与小卡片同一条稳定 Alpha 管线；不在条带变形时切换 DWM 材质。 */
 .strip-shell--transparent {
   --glass-alpha: 0.82;
   border-radius: 8px;
   color: rgba(255, 255, 255, 0.92);
+  background:
+    radial-gradient(120% 160% at 12% 0%, rgba(178, 200, 255, 0.07), transparent 55%),
+    rgba(21, 23, 28, var(--glass-alpha));
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.09),
+    inset 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.strip-shell--detail-open.strip-shell--transparent {
+  --strip-detail-surface: rgba(9, 10, 12, 0.96);
+  --strip-detail-ink: rgba(255, 255, 255, 0.94);
+  --strip-detail-muted: rgba(255, 255, 255, 0.46);
+}
+
+.strip-shell--detail-open.strip-shell--transparent .strip-rail {
   background:
     radial-gradient(120% 160% at 12% 0%, rgba(178, 200, 255, 0.07), transparent 55%),
     rgba(21, 23, 28, var(--glass-alpha));
@@ -1974,6 +2173,23 @@ html[data-pinned-hover-driver="local"][data-pinned-hover-mode="hide"][data-pinne
   color: var(--blue);
 }
 
+.strip-shell--vertical.strip-shell--detail-open.strip-shell--glass-light {
+  --strip-detail-surface: rgba(248, 249, 250, 0.97);
+  --strip-detail-ink: rgba(24, 26, 30, 0.94);
+  --strip-detail-muted: rgba(48, 51, 57, 0.5);
+  background: transparent;
+  box-shadow: none;
+}
+
+.strip-shell--detail-open.strip-shell--glass-light .strip-rail {
+  background:
+    radial-gradient(120% 160% at 12% 0%, rgba(255, 255, 255, 0.42), transparent 55%),
+    linear-gradient(168deg, rgb(252 253 255 / calc(var(--glass-alpha) + 0.06)), rgb(236 240 247 / calc(var(--glass-alpha) - 0.02)));
+  box-shadow:
+    inset 0 0 0 1px rgba(31, 33, 36, 0.1),
+    inset 0 1px rgba(255, 255, 255, 0.68);
+}
+
 /* ============ 透明配色（--glass-clear，Windows 卡片与胶囊） ============
    Coffee 式单合成管线：透明 HWND/WebView2 始终不切换 DWM 材质，只承载一层
    罩层 + backdrop-filter，因此桌面、图标和后方窗口都是真实取样，卡片/胶囊
@@ -2277,6 +2493,30 @@ html:has(.strip-shell--glass-ink-light) #root {
   html:has(.strip-shell--glass-clear) #root::after {
     transition: none;
   }
+}
+
+/* 清透档原本把霜层画在整个 #root 上；详情打开后根节点已经是透明承载区，
+   霜层只画在条身与气泡本身，避免出现一整块矩形玻璃。 */
+html:has(.strip-shell--detail-open.strip-shell--glass-clear) #root {
+  background: transparent;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.strip-shell--detail-open.strip-shell--glass-clear:not(.strip-shell--glass-ink-light) {
+  --strip-detail-surface: rgba(239, 244, 249, 0.92);
+}
+
+.strip-shell--detail-open.strip-shell--glass-clear.strip-shell--glass-ink-light {
+  --strip-detail-surface: rgba(16, 20, 27, 0.9);
+}
+
+.strip-shell--detail-open.strip-shell--glass-clear .strip-detail-card,
+.strip-shell--detail-open.strip-shell--glass-clear .strip-rail {
+  -webkit-backdrop-filter: blur(18px) saturate(145%);
+  backdrop-filter: blur(18px) saturate(145%);
 }
 
 .sr-only {

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -12,6 +12,8 @@ import {
 import {
   monitorForWindowPosition,
   physicalWindowSize,
+  verticalStripHoverLocalLayout,
+  verticalStripHoverLayout,
   viewportCorrectedPhysicalSize,
   viewportCorrectedZoom,
 } from "./windowGeometry";
@@ -80,6 +82,7 @@ function readStoredStripScale() {
 }
 
 let stripScale = readStoredStripScale();
+let stripHoverRestore = null;
 
 /// 设置胶囊条缩放系数（钳到 0.75–2.0）并持久化；返回实际生效值。
 /// 生效在形态切换里（进入胶囊条时应用），这里只管存储。
@@ -1053,6 +1056,107 @@ async function resizeStripWindow({ width, height }) {
   if (!clamped) await appWindow.center().catch(() => {});
 }
 
+/// Windows 与 Linux 竖向胶囊悬停时临时扩出一个透明画布承载详情卡。
+/// Windows/X11 用全局坐标保持原条身位置；Wayland 只改变本地尺寸，向右展开，
+/// 最终摆放交给合成器。关闭时恢复悬停前的尺寸以及可用时的全局位置。
+async function expandVerticalStripHover({ width, height, railWidth, railHeight, anchorY, cardHeight }) {
+  if (!isWindowsPlatform() && !isLinuxPlatform()) return null;
+  const api = await windowApi();
+  if (!api) return null;
+  const appWindow = api.getCurrentWindow();
+  const coordinateAware = !isLinuxPlatform() || await supportsGlobalWindowCoordinates();
+  const [currentPosition, currentSize, monitor, factor] = await Promise.all([
+    coordinateAware ? appWindow.outerPosition().catch(() => null) : null,
+    appWindow.outerSize().catch(() => null),
+    api.currentMonitor().catch(() => null),
+    appWindow.scaleFactor().catch(() => 1),
+  ]);
+  const workArea = monitor?.workArea;
+  if (!currentSize || (coordinateAware && (!currentPosition || !workArea))) return null;
+  if (!stripHoverRestore) {
+    stripHoverRestore = {
+      position: currentPosition,
+      size: currentSize,
+      width: railWidth,
+      height: railHeight,
+    };
+  }
+  const base = stripHoverRestore;
+  const scale = stripScale * factor;
+  let physical = await scaledPhysicalSize(api, appWindow, width, height, stripScale, factor);
+  await appWindow.setSize(physical).catch((error) => {
+    console.warn("Unable to expand the strip hover window.", error);
+  });
+  physical = await reconcileFloatingSizeAfterShow(
+    api,
+    appWindow,
+    width,
+    height,
+    stripScale,
+    physical,
+  );
+  if (!coordinateAware) {
+    const local = verticalStripHoverLocalLayout({
+      targetHeight: physical.height / scale,
+      anchorY,
+      cardHeight,
+      margin: 8,
+      pointerMargin: 22,
+    });
+    if (!local) return null;
+    return {
+      // Wayland cannot reveal the screen side. Growing toward the local right
+      // keeps the rail at the window origin and lets the compositor constrain it.
+      side: "left",
+      cardCenterY: local.cardCenter,
+      pointerY: local.pointerY,
+      railOffsetY: 0,
+    };
+  }
+  const layout = verticalStripHoverLayout({
+    railPosition: base.position,
+    railSize: base.size,
+    workArea: {
+      x: workArea.position.x,
+      y: workArea.position.y,
+      width: workArea.size.width,
+      height: workArea.size.height,
+    },
+    targetSize: physical,
+    anchorY: anchorY * scale,
+    cardHeight: cardHeight * scale,
+    margin: 8 * scale,
+  });
+  if (!layout) return null;
+  await appWindow
+    .setPosition(new api.PhysicalPosition(Math.round(layout.x), Math.round(layout.y)))
+    .catch(() => {});
+  const cardCenterY = layout.cardCenter / scale;
+  const railOffsetY = layout.railOffsetY / scale;
+  const pointerY = Math.min(
+    Math.max(anchorY + railOffsetY - cardCenterY + cardHeight / 2, 22),
+    Math.max(cardHeight - 22, 22),
+  );
+  return {
+    side: layout.side,
+    cardCenterY,
+    pointerY,
+    railOffsetY,
+  };
+}
+
+async function collapseVerticalStripHover() {
+  if ((!isWindowsPlatform() && !isLinuxPlatform()) || !stripHoverRestore) return;
+  const restore = stripHoverRestore;
+  stripHoverRestore = null;
+  const api = await windowApi();
+  if (!api) return;
+  const appWindow = api.getCurrentWindow();
+  await appWindow.setSize(restore.size).catch(() => {});
+  if (restore.position) await appWindow.setPosition(restore.position).catch(() => {});
+  rememberStripSize(restore.width, restore.height);
+}
+
 /// 小组件内容（Agent 行数）变化时只调高度，宽度恒为 320，不走 hide/show。
 /// 上限取工作区高度留 48px 呼吸位（CSS px），超出部分由列表内部滚动承担。
 async function resizeCompactWindow({ height }) {
@@ -1591,9 +1695,11 @@ export {
   broadcastMacAgentSelection,
   broadcastMacAppearance,
   checkForUpdate,
+  collapseVerticalStripHover,
   closeWindow,
   getAutostart,
   getMacAgentSelection,
+  expandVerticalStripHover,
   installUpdate,
   isDesktop,
   isLinuxPlatform,

--- a/src/windowGeometry.js
+++ b/src/windowGeometry.js
@@ -126,6 +126,69 @@ function horizontalStripTargetWidth({
   );
 }
 
+/// 竖向胶囊的悬停卡片需要临时放大透明窗口。窗口扩展方向取胶囊所在的
+/// 半屏，原胶囊的屏幕坐标保持不动；纵向只移动到足够容纳卡片的位置。
+function verticalStripHoverLocalLayout({ targetHeight, anchorY, cardHeight, margin = 8, pointerMargin = 22 }) {
+  if ([targetHeight, anchorY, cardHeight, margin, pointerMargin].some((value) => !Number.isFinite(value))) {
+    return null;
+  }
+  const halfCard = cardHeight / 2;
+  const cardCenter = Math.min(
+    Math.max(anchorY, halfCard + margin),
+    Math.max(targetHeight - halfCard - margin, halfCard + margin),
+  );
+  const pointerY = Math.min(
+    Math.max(anchorY - cardCenter + halfCard, pointerMargin),
+    Math.max(cardHeight - pointerMargin, pointerMargin),
+  );
+  return { cardCenter, pointerY };
+}
+
+function verticalStripHoverLayout({ railPosition, railSize, workArea, targetSize, anchorY, cardHeight, margin = 8 }) {
+  const values = [
+    railPosition?.x,
+    railPosition?.y,
+    railSize?.width,
+    railSize?.height,
+    workArea?.x,
+    workArea?.y,
+    workArea?.width,
+    workArea?.height,
+    targetSize?.width,
+    targetSize?.height,
+    anchorY,
+    cardHeight,
+  ];
+  if (values.some((value) => !Number.isFinite(value))) return null;
+
+  const workRight = workArea.x + workArea.width;
+  const workBottom = workArea.y + workArea.height;
+  const railCenterX = railPosition.x + railSize.width / 2;
+  const side = railCenterX < workArea.x + workArea.width / 2 ? "left" : "right";
+  const local = verticalStripHoverLocalLayout({
+    targetHeight: targetSize.height,
+    anchorY,
+    cardHeight,
+    margin,
+  });
+  if (!local) return null;
+  const { cardCenter } = local;
+  const desiredX = side === "left"
+    ? railPosition.x
+    : railPosition.x + railSize.width - targetSize.width;
+  const desiredY = railPosition.y - (cardCenter - anchorY);
+  const x = Math.min(Math.max(desiredX, workArea.x), Math.max(workRight - targetSize.width, workArea.x));
+  const y = Math.min(Math.max(desiredY, workArea.y), Math.max(workBottom - targetSize.height, workArea.y));
+
+  return {
+    side,
+    x,
+    y,
+    cardCenter,
+    railOffsetY: railPosition.y - y,
+  };
+}
+
 /// 记忆坐标是物理像素；用每台显示器自己的 DPI 推导候选窗口大小，再选与工作区
 /// 重叠最多的显示器。不能先读当前窗口 DPI——窗口随后可能恢复到另一台屏幕。
 function monitorForWindowPosition(
@@ -172,6 +235,8 @@ export {
   horizontalStripTargetWidth,
   monitorForWindowPosition,
   physicalWindowSize,
+  verticalStripHoverLocalLayout,
+  verticalStripHoverLayout,
   viewportCorrectedPhysicalSize,
   viewportCorrectedZoom,
 };

--- a/src/windowGeometry.test.js
+++ b/src/windowGeometry.test.js
@@ -5,6 +5,8 @@ import {
   horizontalStripTargetWidth,
   monitorForWindowPosition,
   physicalWindowSize,
+  verticalStripHoverLocalLayout,
+  verticalStripHoverLayout,
   viewportCorrectedPhysicalSize,
   viewportCorrectedZoom,
 } from "./windowGeometry.js";
@@ -92,6 +94,53 @@ test("horizontal strip width includes every outer flex gap", () => {
       gap: 4,
     }),
     230,
+  );
+});
+
+test("vertical strip hover expands away from the nearest screen edge", () => {
+  assert.deepEqual(
+    verticalStripHoverLayout({
+      railPosition: { x: 1878, y: 300 },
+      railSize: { width: 42, height: 260 },
+      workArea: { x: 0, y: 0, width: 1920, height: 1040 },
+      targetSize: { width: 392, height: 320 },
+      anchorY: 69,
+      cardHeight: 280,
+    }),
+    { side: "right", x: 1528, y: 221, cardCenter: 148, railOffsetY: 79 },
+  );
+});
+
+test("vertical strip hover stays inside the work area near the top-left", () => {
+  assert.deepEqual(
+    verticalStripHoverLayout({
+      railPosition: { x: 0, y: 0 },
+      railSize: { width: 42, height: 90 },
+      workArea: { x: 0, y: 0, width: 1920, height: 1040 },
+      targetSize: { width: 392, height: 300 },
+      anchorY: 23,
+      cardHeight: 270,
+    }),
+    { side: "left", x: 0, y: 0, cardCenter: 143, railOffsetY: 0 },
+  );
+});
+
+test("Wayland-local strip hover clamps the card and pointer without global coordinates", () => {
+  assert.deepEqual(
+    verticalStripHoverLocalLayout({
+      targetHeight: 300,
+      anchorY: 23,
+      cardHeight: 270,
+    }),
+    { cardCenter: 143, pointerY: 22 },
+  );
+  assert.deepEqual(
+    verticalStripHoverLocalLayout({
+      targetHeight: 300,
+      anchorY: 277,
+      cardHeight: 270,
+    }),
+    { cardCenter: 157, pointerY: 248 },
   );
 });
 


### PR DESCRIPTION
## Scope

- Linux shell
- shared compact-strip presentation and geometry helpers

## Changes

- show the quota detail card when hovering an unpinned vertical strip on Linux
- use global-coordinate placement on X11 and compositor-safe local expansion on Wayland
- keep pinned Linux strips read-only until native panel behavior is implemented
- preserve the existing Windows interaction

## Verification

- 
pm test
- 
pm run build
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
- Windows/browser visual comparison

Native Ubuntu 24.04 Wayland smoke was not run because this machine has no Linux runtime.