### PR TITLE
chore: release v0.18.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.18.5",
+      "version": "0.18.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.18.5"
+version = "0.18.6"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Scope

Release metadata only.

## Changes

Bump the five synchronized application version files from 0.18.5 to 0.18.6.

## Included feature

- Linux vertical strip hover detail card, with X11 placement and Wayland-safe local expansion
- hover-state recovery fixes from PR review

## Verification

The feature PR passed Windows, macOS, and Ubuntu 24.04 CI, including the Linux bundle smoke check. This release PR must pass the same protected checks before tagging.

Native Ubuntu desktop visual smoke was not run because no Linux desktop is available on the maintainer machine.