### PR TITLE
fix: stabilize compact strip hover cards

### DIFF
--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -115,13 +115,16 @@ change.
   immediately keeps the complete form visible. Horizontal and vertical strip
   placements are remembered independently.
 - On Windows and Linux, hovering an Agent in the unpinned vertical strip opens
-  its complete official-quota windows in a pointer-anchored detail bubble. The temporary
-  transparent berth expands away from the nearest screen edge when global
-  coordinates are available, while the strip itself remains fixed in place.
+  its complete official-quota windows in a compact pointer-anchored detail
+  bubble that uses the strip's current glass surface. The temporary transparent
+  berth expands away from the nearest screen edge when global coordinates are
+  available, while the complete strip itself remains fixed and visible.
   On Wayland it expands toward the window-local right and leaves placement to
-  the compositor. Leaving the berth restores the exact prior window size and,
-  when the platform exposes it, position. Linux pinned read-only hover behavior
-  remains authoritative and never opens the detail bubble.
+  the compositor. Transient boundary events caused by the native resize must
+  not collapse the bubble; leaving the settled berth restores the exact prior
+  window size and, when the platform exposes it, position. Linux pinned
+  read-only hover behavior remains authoritative and never opens the detail
+  bubble.
 - Floating-form size uses the destination monitor's DPI. Compact and strip
   reassert size from native DPI-change payloads, and window mutations are
   serialized so stale resizes cannot overwrite corrections.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -273,8 +273,9 @@ const STRIP_BAR_HEIGHT = 28;
 // 竖条宽度由 26px 控件槽 + 外壳 padding 定死下限（32px）；42 留 10px 呼吸，
 // 再宽图标和百分比周围就空得发肥。
 const STRIP_VERTICAL_WIDTH = 42;
-const STRIP_DETAIL_WINDOW_WIDTH = 392;
-const STRIP_DETAIL_CARD_MARGIN = 16;
+const STRIP_DETAIL_WINDOW_WIDTH = 312;
+const STRIP_DETAIL_CARD_MARGIN = 12;
+const STRIP_DETAIL_LEAVE_DELAY = 180;
 const STRIP_VCELL_HEIGHT = 46;
 // 横条宽度的收缩迟滞。一格 54px，所以 6px 远低于「真的少了一个 Agent」，
 // 又高于 DPI/zoom 取整带来的亚像素噪声。
@@ -1049,7 +1050,7 @@ function runLatestWindowCorrection(action) {
   const correction = ++latestWindowCorrection;
   return runWindowAction(() => {
     if (correction !== latestWindowCorrection) return undefined;
-    return action();
+    return action(() => correction === latestWindowCorrection);
   });
 }
 
@@ -1281,6 +1282,7 @@ function StripBar({
   const shellRef = useRef(null);
   const railRef = useRef(null);
   const detailCardRef = useRef(null);
+  const pointerLeaveTimerRef = useRef(null);
   const OrientationIcon = vertical ? ArrowsLeftRight : ArrowsDownUp;
   const detailEnabled = (IS_WINDOWS || IS_LINUX) && vertical && !(pinned && IS_LINUX);
   const [hoveredDetail, setHoveredDetail] = useState(null);
@@ -1326,8 +1328,9 @@ function StripBar({
     if (!rail || !card) return;
     const railRect = rail.getBoundingClientRect();
     const cardRect = card.getBoundingClientRect();
+    const railHeight = Math.ceil(Math.max(railRect.height, rail.scrollHeight));
     const targetHeight = Math.max(
-      Math.ceil(railRect.height),
+      railHeight,
       Math.ceil(cardRect.height + STRIP_DETAIL_CARD_MARGIN * 2),
     );
     if (!isDesktop()) {
@@ -1349,15 +1352,16 @@ function StripBar({
       });
       return;
     }
-    runLatestWindowCorrection(async () => {
+    runLatestWindowCorrection(async (isLatest) => {
       const layout = await expandVerticalStripHover({
         width: STRIP_DETAIL_WINDOW_WIDTH,
         height: targetHeight,
         railWidth: STRIP_VERTICAL_WIDTH,
-        railHeight: Math.ceil(railRect.height),
+        railHeight,
         anchorY: hoveredDetail.anchorY,
         cardHeight: Math.ceil(cardRect.height),
       });
+      if (!isLatest()) return;
       if (layout) {
         setDetailLayout(layout);
       } else {
@@ -1368,6 +1372,7 @@ function StripBar({
     });
   }, [detailOpen, hoveredDetail?.agentId, hoveredDetail?.anchorY]);
   useEffect(() => () => {
+    window.clearTimeout(pointerLeaveTimerRef.current);
     latestWindowCorrection += 1;
     if (IS_WINDOWS || IS_LINUX) runWindowAction(collapseVerticalStripHover);
   }, []);
@@ -1447,14 +1452,25 @@ function StripBar({
     };
   });
   const glassProps = glassPointerProps(shellAppearance.edgeInteractive);
-  // 展开态跟着指针走：移出条身就收回，省得用户忘了收，条一直长着。
+  const cancelPointerLeave = () => {
+    window.clearTimeout(pointerLeaveTimerRef.current);
+    pointerLeaveTimerRef.current = null;
+  };
+  // Windows 扩宽并重定位原生窗口时，WebView 会短暂收到 pointerleave；立即收回
+  // 会与仍停在胶囊上的指针形成展开/收起循环。短缓冲只跨过这次原生事务，
+  // 真正离开整个透明承载区后仍会自动收回。
   const handlePointerLeave = (event) => {
     glassProps.onPointerLeave?.(event);
-    setHoveredDetail(null);
-    setControlsOpen(false);
+    cancelPointerLeave();
+    pointerLeaveTimerRef.current = window.setTimeout(() => {
+      pointerLeaveTimerRef.current = null;
+      setHoveredDetail(null);
+      setControlsOpen(false);
+    }, STRIP_DETAIL_LEAVE_DELAY);
   };
   const showDetail = (event, agentId) => {
     if (!detailEnabled) return;
+    cancelPointerLeave();
     const railBounds = railRef.current?.getBoundingClientRect();
     const cellBounds = event.currentTarget.getBoundingClientRect();
     if (!railBounds) return;
@@ -1477,6 +1493,7 @@ function StripBar({
       inert={pinned && IS_LINUX ? true : undefined}
       {...dragProps}
       {...glassProps}
+      onPointerEnter={cancelPointerLeave}
       onPointerLeave={handlePointerLeave}
       style={{
         ...shellAppearance.style,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1316,6 +1316,9 @@ html:has(.strip-shell) #root {
 
 .strip-shell {
   --strip-detail-surface: rgba(248, 248, 247, 0.98);
+  --strip-detail-background:
+    radial-gradient(140% 180% at 14% 0%, rgba(255, 255, 255, 0.9), transparent 60%),
+    linear-gradient(165deg, #fbfbfa, #f0efeb);
   --strip-detail-ink: rgba(29, 31, 35, 0.94);
   --strip-detail-muted: rgba(48, 51, 57, 0.48);
   display: flex;
@@ -1378,9 +1381,7 @@ html:has(.strip-shell) #root {
   padding: 6px 3px 4px;
   gap: 4px;
   border-radius: 8px;
-  background:
-    radial-gradient(140% 180% at 14% 0%, rgba(255, 255, 255, 0.9), transparent 60%),
-    linear-gradient(165deg, #fbfbfa, #f0efeb);
+  background: var(--strip-detail-background);
   box-shadow: inset 0 0 0 1px rgba(31, 33, 36, 0.08);
 }
 
@@ -1391,25 +1392,26 @@ html:has(.strip-shell) #root {
   position: absolute;
   z-index: 4;
   top: var(--strip-detail-card-center-y, 50%);
-  width: 310px;
-  padding: 18px;
+  width: 232px;
+  padding: 12px;
   color: var(--strip-detail-ink);
-  background: var(--strip-detail-surface);
-  border: 1px solid rgba(31, 33, 36, 0.075);
-  border-radius: 20px;
+  background: var(--strip-detail-background);
+  border: 1px solid color-mix(in srgb, var(--strip-detail-ink) 9%, transparent);
+  border-radius: 14px;
   box-shadow:
-    0 24px 56px rgba(10, 12, 16, 0.2),
-    0 6px 18px rgba(10, 12, 16, 0.12),
-    inset 0 1px rgba(255, 255, 255, 0.45);
+    0 12px 26px rgba(10, 12, 16, 0.15),
+    0 3px 10px rgba(10, 12, 16, 0.09),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    inset 0 1px rgba(255, 255, 255, 0.16);
   pointer-events: none;
   transform: translateY(-50%);
   transform-origin: right var(--strip-detail-pointer-y, 50%);
-  animation: strip-detail-reveal-right 220ms cubic-bezier(0.2, 0.82, 0.22, 1) both;
+  animation: strip-detail-reveal-right 160ms cubic-bezier(0.2, 0.82, 0.22, 1) both;
 }
 
-.strip-shell--detail-right .strip-detail-card { right: 68px; }
+.strip-shell--detail-right .strip-detail-card { right: 54px; }
 .strip-shell--detail-left .strip-detail-card {
-  left: 68px;
+  left: 54px;
   transform-origin: left var(--strip-detail-pointer-y, 50%);
   animation-name: strip-detail-reveal-left;
 }
@@ -1418,58 +1420,58 @@ html:has(.strip-shell) #root {
   content: "";
   position: absolute;
   top: var(--strip-detail-pointer-y, 50%);
-  width: 19px;
-  height: 38px;
+  width: 14px;
+  height: 28px;
   background: var(--strip-detail-surface);
   clip-path: polygon(0 0, 100% 50%, 0 100%, 16% 72%, 22% 50%, 16% 28%);
   transform: translateY(-50%);
 }
 
-.strip-shell--detail-right .strip-detail-card::after { right: -18px; }
+.strip-shell--detail-right .strip-detail-card::after { right: -13px; }
 .strip-shell--detail-left .strip-detail-card::after {
-  left: -18px;
+  left: -13px;
   transform: translateY(-50%) scaleX(-1);
 }
 
 .strip-detail-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   min-width: 0;
 }
 
 .strip-detail-header img {
-  width: 17px;
-  height: 17px;
+  width: 15px;
+  height: 15px;
   border-radius: 4px;
 }
 
 .strip-detail-header strong {
   overflow: hidden;
-  font-size: 14px;
+  font-size: 12.5px;
   font-weight: 650;
-  line-height: 19px;
+  line-height: 17px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .strip-detail-metrics {
   display: grid;
-  gap: 14px;
-  margin-top: 14px;
+  gap: 9px;
+  margin-top: 9px;
 }
 
-.strip-detail-metric { display: grid; gap: 7px; }
+.strip-detail-metric { display: grid; gap: 5px; }
 .strip-detail-metric > span {
   overflow: hidden;
-  font-size: 11.5px;
-  line-height: 14px;
+  font-size: 10.5px;
+  line-height: 13px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .strip-detail-track {
-  height: 6px;
+  height: 5px;
   overflow: hidden;
   background: color-mix(in srgb, var(--strip-detail-ink) 15%, transparent);
   border-radius: 999px;
@@ -1489,10 +1491,10 @@ html:has(.strip-shell) #root {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 10px;
+  gap: 8px;
   margin: 0;
-  font-size: 11.5px;
-  line-height: 14px;
+  font-size: 10.5px;
+  line-height: 13px;
 }
 
 .strip-detail-metric p strong { font-weight: 580; }
@@ -1506,20 +1508,24 @@ html:has(.strip-shell) #root {
 
 .strip-detail-empty,
 .strip-detail-card footer {
-  margin: 14px 0 0;
+  margin: 9px 0 0;
   color: var(--strip-detail-muted);
-  font-size: 11px;
-  line-height: 15px;
+  font-size: 10px;
+  line-height: 13px;
 }
 
 @keyframes strip-detail-reveal-right {
-  from { opacity: 0; transform: translate(8px, -50%) scale(0.97); }
-  to { opacity: 1; transform: translate(0, -50%) scale(1); }
+  from { opacity: 0; transform: translate(4px, -50%); }
+  to { opacity: 1; transform: translate(0, -50%); }
 }
 
 @keyframes strip-detail-reveal-left {
-  from { opacity: 0; transform: translate(-8px, -50%) scale(0.97); }
-  to { opacity: 1; transform: translate(0, -50%) scale(1); }
+  from { opacity: 0; transform: translate(-4px, -50%); }
+  to { opacity: 1; transform: translate(0, -50%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .strip-detail-card { animation: none; }
 }
 
 /* 玻璃模式与小卡片同一条稳定 Alpha 管线；不在条带变形时切换 DWM 材质。 */
@@ -1536,15 +1542,16 @@ html:has(.strip-shell) #root {
 }
 
 .strip-shell--detail-open.strip-shell--transparent {
-  --strip-detail-surface: rgba(9, 10, 12, 0.96);
+  --strip-detail-surface: rgb(21 23 28 / var(--glass-alpha));
+  --strip-detail-background:
+    radial-gradient(120% 160% at 12% 0%, rgba(178, 200, 255, 0.07), transparent 55%),
+    rgb(21 23 28 / var(--glass-alpha));
   --strip-detail-ink: rgba(255, 255, 255, 0.94);
   --strip-detail-muted: rgba(255, 255, 255, 0.46);
 }
 
 .strip-shell--detail-open.strip-shell--transparent .strip-rail {
-  background:
-    radial-gradient(120% 160% at 12% 0%, rgba(178, 200, 255, 0.07), transparent 55%),
-    rgba(21, 23, 28, var(--glass-alpha));
+  background: var(--strip-detail-background);
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.09),
     inset 0 1px rgba(255, 255, 255, 0.12);
@@ -2174,7 +2181,10 @@ html[data-pinned-hover-driver="local"][data-pinned-hover-mode="hide"][data-pinne
 }
 
 .strip-shell--vertical.strip-shell--detail-open.strip-shell--glass-light {
-  --strip-detail-surface: rgba(248, 249, 250, 0.97);
+  --strip-detail-surface: rgb(244 247 251 / var(--glass-alpha));
+  --strip-detail-background:
+    radial-gradient(120% 160% at 12% 0%, rgba(255, 255, 255, 0.42), transparent 55%),
+    linear-gradient(168deg, rgb(252 253 255 / calc(var(--glass-alpha) + 0.06)), rgb(236 240 247 / calc(var(--glass-alpha) - 0.02)));
   --strip-detail-ink: rgba(24, 26, 30, 0.94);
   --strip-detail-muted: rgba(48, 51, 57, 0.5);
   background: transparent;
@@ -2182,9 +2192,7 @@ html[data-pinned-hover-driver="local"][data-pinned-hover-mode="hide"][data-pinne
 }
 
 .strip-shell--detail-open.strip-shell--glass-light .strip-rail {
-  background:
-    radial-gradient(120% 160% at 12% 0%, rgba(255, 255, 255, 0.42), transparent 55%),
-    linear-gradient(168deg, rgb(252 253 255 / calc(var(--glass-alpha) + 0.06)), rgb(236 240 247 / calc(var(--glass-alpha) - 0.02)));
+  background: var(--strip-detail-background);
   box-shadow:
     inset 0 0 0 1px rgba(31, 33, 36, 0.1),
     inset 0 1px rgba(255, 255, 255, 0.68);
@@ -2505,12 +2513,23 @@ html:has(.strip-shell--detail-open.strip-shell--glass-clear) #root {
   box-shadow: none;
 }
 
-.strip-shell--detail-open.strip-shell--glass-clear:not(.strip-shell--glass-ink-light) {
-  --strip-detail-surface: rgba(239, 244, 249, 0.92);
+.strip-shell--detail-open.strip-shell--glass-clear:not(.strip-shell--glass-ink-light):not(.strip-shell--glass-css) {
+  --strip-detail-surface: rgb(
+    229 237 246 /
+      clamp(0.34, calc(0.26 + var(--shell-glass-alpha, 0.82) * 0.32), 0.62)
+  );
+  --strip-detail-background:
+    radial-gradient(120% 160% at 12% 0%, rgba(255, 255, 255, 0.42), transparent 55%),
+    var(--strip-detail-surface);
 }
 
-.strip-shell--detail-open.strip-shell--glass-clear.strip-shell--glass-ink-light {
-  --strip-detail-surface: rgba(16, 20, 27, 0.9);
+.strip-shell--detail-open.strip-shell--glass-clear.strip-shell--glass-ink-light:not(.strip-shell--glass-css) {
+  --strip-detail-surface: rgb(
+    18 24 36 / clamp(0.14, calc(0.1 + var(--shell-glass-alpha, 0.82) * 0.34), 0.44)
+  );
+  --strip-detail-background:
+    radial-gradient(120% 160% at 12% 0%, rgba(178, 200, 255, 0.07), transparent 55%),
+    var(--strip-detail-surface);
 }
 
 .strip-shell--detail-open.strip-shell--glass-clear .strip-detail-card,

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -1084,9 +1084,40 @@ async function expandVerticalStripHover({ width, height, railWidth, railHeight, 
   const base = stripHoverRestore;
   const scale = stripScale * factor;
   let physical = await scaledPhysicalSize(api, appWindow, width, height, stripScale, factor);
-  await appWindow.setSize(physical).catch((error) => {
-    console.warn("Unable to expand the strip hover window.", error);
+  const hoverLayoutFor = (targetSize) => verticalStripHoverLayout({
+    railPosition: base.position,
+    railSize: base.size,
+    workArea: {
+      x: workArea.position.x,
+      y: workArea.position.y,
+      width: workArea.size.width,
+      height: workArea.size.height,
+    },
+    targetSize,
+    anchorY: anchorY * scale,
+    cardHeight: cardHeight * scale,
+    margin: 8 * scale,
   });
+  const predictedLayout = coordinateAware ? hoverLayoutFor(physical) : null;
+  if (coordinateAware && !predictedLayout) return null;
+  const mutations = [
+    appWindow.setSize(physical).catch((error) => {
+      console.warn("Unable to expand the strip hover window.", error);
+    }),
+  ];
+  if (predictedLayout) {
+    mutations.push(
+      appWindow
+        .setPosition(new api.PhysicalPosition(
+          Math.round(predictedLayout.x),
+          Math.round(predictedLayout.y),
+        ))
+        .catch(() => {}),
+    );
+  }
+  // Windows 会在 resize 与随后的 move 之间绘制中间帧；胶囊先跳出鼠标命中区
+  // 就会触发收回。两项原生变更同时下发，随后再按实际视口做一次最终校正。
+  await Promise.all(mutations);
   physical = await reconcileFloatingSizeAfterShow(
     api,
     appWindow,
@@ -1113,20 +1144,7 @@ async function expandVerticalStripHover({ width, height, railWidth, railHeight, 
       railOffsetY: 0,
     };
   }
-  const layout = verticalStripHoverLayout({
-    railPosition: base.position,
-    railSize: base.size,
-    workArea: {
-      x: workArea.position.x,
-      y: workArea.position.y,
-      width: workArea.size.width,
-      height: workArea.size.height,
-    },
-    targetSize: physical,
-    anchorY: anchorY * scale,
-    cardHeight: cardHeight * scale,
-    margin: 8 * scale,
-  });
+  const layout = hoverLayoutFor(physical);
   if (!layout) return null;
   await appWindow
     .setPosition(new api.PhysicalPosition(Math.round(layout.x), Math.round(layout.y)))
@@ -1152,8 +1170,9 @@ async function collapseVerticalStripHover() {
   const api = await windowApi();
   if (!api) return;
   const appWindow = api.getCurrentWindow();
-  await appWindow.setSize(restore.size).catch(() => {});
-  if (restore.position) await appWindow.setPosition(restore.position).catch(() => {});
+  const mutations = [appWindow.setSize(restore.size).catch(() => {})];
+  if (restore.position) mutations.push(appWindow.setPosition(restore.position).catch(() => {}));
+  await Promise.all(mutations);
   rememberStripSize(restore.width, restore.height);
 }
 

--- a/src/windowGeometry.js
+++ b/src/windowGeometry.js
@@ -178,7 +178,12 @@ function verticalStripHoverLayout({ railPosition, railSize, workArea, targetSize
     : railPosition.x + railSize.width - targetSize.width;
   const desiredY = railPosition.y - (cardCenter - anchorY);
   const x = Math.min(Math.max(desiredX, workArea.x), Math.max(workRight - targetSize.width, workArea.x));
-  const y = Math.min(Math.max(desiredY, workArea.y), Math.max(workBottom - targetSize.height, workArea.y));
+  // 窗口不仅要留在工作区，也必须完整包住原胶囊。只按卡片锚点移动时，
+  // 悬停下方条目会让 railOffsetY 变成负数，把胶囊上半段推出透明窗口。
+  const railBottom = railPosition.y + railSize.height;
+  const minY = Math.max(workArea.y, railBottom - targetSize.height);
+  const maxY = Math.min(workBottom - targetSize.height, railPosition.y);
+  const y = Math.min(Math.max(desiredY, minY), Math.max(maxY, minY));
 
   return {
     side,

--- a/src/windowGeometry.test.js
+++ b/src/windowGeometry.test.js
@@ -107,8 +107,48 @@ test("vertical strip hover expands away from the nearest screen edge", () => {
       anchorY: 69,
       cardHeight: 280,
     }),
-    { side: "right", x: 1528, y: 221, cardCenter: 148, railOffsetY: 79 },
+    { side: "right", x: 1528, y: 240, cardCenter: 148, railOffsetY: 60 },
   );
+});
+
+test("vertical strip hover keeps the whole rail visible for a lower cell", () => {
+  const layout = verticalStripHoverLayout({
+    railPosition: { x: 1878, y: 300 },
+    railSize: { width: 42, height: 360 },
+    workArea: { x: 0, y: 0, width: 1920, height: 1040 },
+    targetSize: { width: 312, height: 360 },
+    anchorY: 299,
+    cardHeight: 180,
+  });
+
+  assert.deepEqual(layout, {
+    side: "right",
+    x: 1608,
+    y: 300,
+    cardCenter: 262,
+    railOffsetY: 0,
+  });
+  assert.ok(layout.railOffsetY >= 0);
+  assert.ok(layout.railOffsetY + 360 <= 360);
+});
+
+test("vertical strip hover keeps the rail bottom visible for the first cell", () => {
+  const layout = verticalStripHoverLayout({
+    railPosition: { x: 2464, y: 357 },
+    railSize: { width: 54, height: 314 },
+    workArea: { x: 0, y: 0, width: 2560, height: 1400 },
+    targetSize: { width: 510, height: 314 },
+    anchorY: 23,
+    cardHeight: 270,
+  });
+
+  assert.deepEqual(layout, {
+    side: "right",
+    x: 2008,
+    y: 357,
+    cardCenter: 143,
+    railOffsetY: 0,
+  });
 });
 
 test("vertical strip hover stays inside the work area near the top-left", () => {


### PR DESCRIPTION
## Scope

- shared hover-card rendering and geometry
- Windows shell hover-window transaction and native smoke check
- Linux Wayland-local geometry covered by tests; Ubuntu 24.04 native visual smoke remains unverified

## Changes

- keep the full vertical rail inside the expanded transparent berth
- resize and reposition the native hover window as one transaction to prevent flashing
- cancel stale hover corrections and debounce transient pointer exits
- reduce the detail card to a compact 232px surface using the capsule's active glass material

## Verification

- `npm test` (55 passed)
- `npm run build`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` (237 passed, 6 ignored)
- Windows debug production shell built and rendered the complete vertical strip