### PR TITLE
Fix strip hover and full-view window transitions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1286,26 +1286,32 @@ function StripBar({
   const OrientationIcon = vertical ? ArrowsLeftRight : ArrowsDownUp;
   const detailEnabled = (IS_WINDOWS || IS_LINUX) && vertical && !(pinned && IS_LINUX);
   const [hoveredDetail, setHoveredDetail] = useState(null);
+  // 控制菜单与详情卡不能共用同一次临时扩窗：菜单需要按真实条身高度扩展，
+  // 固定/切形态按钮也必须落在原生窗口的有效命中区内。
+  const [controlsOpen, setControlsOpen] = useState(false);
   const [detailLayout, setDetailLayout] = useState({
     side: IS_LINUX ? "left" : "right",
     railOffsetY: 0,
   });
-  const detailCell = detailEnabled && hoveredDetail
+  const detailCell = detailEnabled && !controlsOpen && hoveredDetail
     ? cells.find(({ agentId }) => agentId === hoveredDetail.agentId) ?? null
     : null;
   const detailOpen = Boolean(detailCell);
   // 控制按钮不再常驻：四个 26px 的槽在竖条上要吃掉 130px，比三个格子还高。
   // 改成按需就地展开——点状态灯位上浮出的 … 把它们放出来，条身随之变长，
   // 指针离开自动收回。窗口尺寸本来就跟着内容测量走，这里不用另外调窗。
-  const [controlsOpen, setControlsOpen] = useState(false);
-  const toggleControls = useCallback(() => setControlsOpen((open) => !open), []);
+  const toggleControls = useCallback(() => {
+    latestWindowCorrection += 1;
+    setHoveredDetail(null);
+    setControlsOpen((open) => !open);
+  }, []);
   // 一旦进入置顶只读态，立即丢弃胶囊的临时操作面板状态，只保留数据展示。
   useEffect(() => {
     if (pinned && IS_LINUX) setControlsOpen(false);
   }, [pinned]);
   useEffect(() => {
-    if (!detailEnabled) setHoveredDetail(null);
-  }, [detailEnabled]);
+    if (!detailEnabled || controlsOpen) setHoveredDetail(null);
+  }, [controlsOpen, detailEnabled]);
   const shellAppearance = glassShellAppearance("strip", {
     transparent,
     glassMode,
@@ -1469,7 +1475,7 @@ function StripBar({
     }, STRIP_DETAIL_LEAVE_DELAY);
   };
   const showDetail = (event, agentId) => {
-    if (!detailEnabled) return;
+    if (!detailEnabled || controlsOpen) return;
     cancelPointerLeave();
     const railBounds = railRef.current?.getBoundingClientRect();
     const cellBounds = event.currentTarget.getBoundingClientRect();
@@ -5366,6 +5372,7 @@ export function App() {
       return;
     }
     const fromMode = viewModeRef.current;
+    latestWindowCorrection += 1;
     previousViewModeRef.current = fromMode;
     const fromPositionMode = fromMode === "strip"
       ? stripPositionMode(stripOrientationRef.current)
@@ -5415,6 +5422,8 @@ export function App() {
     // 完整视图始终是普通窗口；在设置中选择“置顶只读”只为下次回到悬浮形态
     // 预设状态，不能让 1120×760 的设置窗口本身盖住其它应用。
     runWindowAction(async () => {
+      latestWindowCorrection += 1;
+      await collapseVerticalStripHover();
       await setWindowPinned(value && viewModeRef.current !== "expanded");
       await syncLinuxTrayPinned(value);
     });
@@ -5547,7 +5556,7 @@ export function App() {
 
   return (
     <>
-      <div className={`app-shell app-shell--expanded ${appBusy ? "is-loading" : ""}`}>
+      <div className={`app-shell app-shell--expanded ${appBusy ? "is-loading" : ""} ${!IS_MAC ? "app-shell--native-resize" : ""}`}>
         {/* macOS 的完整视图是标准窗口：拖动和窗口按钮都归原生标题栏，不自绘。 */}
         {!IS_MAC && (
           <>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2852,6 +2852,15 @@ html:has(.strip-shell--detail-open.strip-shell--glass-clear) #root {
   overflow: hidden;
 }
 
+/* Windows/Linux 的完整视图由同一个原生窗口从悬浮形态变形而来。窗口已经在
+   hide/resize/center/show，内容再做 640–720ms 位移动画会叠出拖影和卡顿。 */
+.app-shell--native-resize .hero-copy,
+.app-shell--native-resize .chart-section,
+.app-shell--native-resize .breakdown-grid,
+.app-shell--native-resize .inspector-zone {
+  animation: none;
+}
+
 .dashboard {
   min-width: 0;
   height: 100dvh;

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -1516,7 +1516,6 @@ async function startEdgeDock({ getMode, getPinned }) {
 
   const poll = async () => {
     if (disposed || !dock) return;
-    if (stripHoverRestore) return;
     if (getPinned() || !canDock()) {
       await undock();
       return;
@@ -1556,7 +1555,6 @@ async function startEdgeDock({ getMode, getPinned }) {
 
   const check = async () => {
     if (disposed) return;
-    if (stripHoverRestore) return;
     if (!canDock() || getPinned()) {
       if (dock) await undock();
       return;

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -10,6 +10,7 @@ import {
   trayBadgeKey,
 } from "./trayBadge.js";
 import {
+  isStableFloatingMode,
   monitorForWindowPosition,
   physicalWindowSize,
   verticalStripHoverLocalLayout,
@@ -693,9 +694,10 @@ async function startPositionMemory(getMode) {
   let timer = null;
   const unlistenPromise = appWindow.onMoved(() => {
     const mode = getMode();
-    if (!POSITION_KEYS[mode]) return;
+    if (!POSITION_KEYS[mode] || !isStableFloatingMode(mode, Boolean(stripHoverRestore))) return;
     window.clearTimeout(timer);
     timer = window.setTimeout(() => {
+      if (!isStableFloatingMode(getMode(), Boolean(stripHoverRestore))) return;
       rememberWindowPosition(api, appWindow, mode).catch(() => {});
     }, 400);
   });
@@ -823,6 +825,11 @@ async function applyWindowMode(mode, options = {}) {
 
   const appWindow = api.getCurrentWindow();
   const size = WINDOW_SIZES[mode] || WINDOW_SIZES.compact;
+
+  // 详情卡借用同一个 HWND 临时扩窗。任何真正的形态切换都先恢复胶囊基准
+  // 几何；否则下面的记位会保存透明承载区坐标，卸载清理还会在完整视图
+  // 显示后把大窗口重新拖回胶囊位置。
+  await collapseVerticalStripHover();
 
   // 变形前记下离开的悬浮形态的坐标：compact/横条/竖条各记各的，互不污染
   // （以前无条件写 lastPositions.compact，从胶囊条进大视图会把小插件的
@@ -1472,7 +1479,10 @@ async function startEdgeDock({ getMode, getPinned }) {
   let checkTimer;
   let pollTimer;
 
-  const canDock = () => getMode() === "compact" || getMode() === "strip";
+  const canDock = () => isStableFloatingMode(
+    getMode(),
+    Boolean(stripHoverRestore),
+  );
   const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
   const peek = () => Math.round(DOCK_PEEK_PX * dock.scale);
   const exposedPosition = () => ({ x: dock.x, y: dock.y });
@@ -1506,6 +1516,7 @@ async function startEdgeDock({ getMode, getPinned }) {
 
   const poll = async () => {
     if (disposed || !dock) return;
+    if (stripHoverRestore) return;
     if (getPinned() || !canDock()) {
       await undock();
       return;
@@ -1545,6 +1556,7 @@ async function startEdgeDock({ getMode, getPinned }) {
 
   const check = async () => {
     if (disposed) return;
+    if (stripHoverRestore) return;
     if (!canDock() || getPinned()) {
       if (dock) await undock();
       return;

--- a/src/windowGeometry.js
+++ b/src/windowGeometry.js
@@ -2,6 +2,13 @@ function normalizedScale(value) {
   return Number.isFinite(value) && value > 0 ? value : 1;
 }
 
+/// 只有稳定的悬浮形态才能参与位置记忆与边缘挂靠。竖条详情会临时移动、
+/// 放大同一个原生窗口；那段几何不能被当成用户摆放结果。
+function isStableFloatingMode(mode, transient = false) {
+  if (transient) return false;
+  return mode === "compact" || mode === "strip" || mode === "strip-horizontal" || mode === "strip-vertical";
+}
+
 function monitorArea(monitor) {
   if (!monitor?.position || !monitor?.size) return null;
   return {
@@ -238,6 +245,7 @@ function monitorForWindowPosition(
 
 export {
   horizontalStripTargetWidth,
+  isStableFloatingMode,
   monitorForWindowPosition,
   physicalWindowSize,
   verticalStripHoverLocalLayout,

--- a/src/windowGeometry.test.js
+++ b/src/windowGeometry.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   horizontalStripTargetWidth,
+  isStableFloatingMode,
   monitorForWindowPosition,
   physicalWindowSize,
   verticalStripHoverLocalLayout,
@@ -10,6 +11,13 @@ import {
   viewportCorrectedPhysicalSize,
   viewportCorrectedZoom,
 } from "./windowGeometry.js";
+
+test("transient strip geometry never participates in persistent floating state", () => {
+  assert.equal(isStableFloatingMode("compact"), true);
+  assert.equal(isStableFloatingMode("strip-vertical"), true);
+  assert.equal(isStableFloatingMode("strip-vertical", true), false);
+  assert.equal(isStableFloatingMode("expanded"), false);
+});
 
 function monitor(x, width, scaleFactor, workHeight = 1080) {
   return {


### PR DESCRIPTION
## Summary
- keep transient hover geometry out of saved strip positions and edge docking
- collapse hover expansion before pinning or switching window modes
- make strip controls and hover details mutually exclusive so controls remain clickable
- remove duplicate content entrance animation during native Windows/Linux resize

## Scope
- shared window geometry
- Windows shell
- Linux shell

## Verification
- npm test (56/56)
- npm run build
- cargo fmt --check
- Windows native debug startup and edge-position restore
- local interaction check for hover card, pin control, full-view transition, and return to strip

## Native limits
- Linux shell was not smoke-tested on Ubuntu 24.04 Wayland locally; CI is the cross-platform build/test baseline.