### PR TITLE
Fix docked window snapping back while dragging

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,6 +110,7 @@ import {
   setWindowUiScale,
   startEdgeDock,
   startPositionMemory,
+  startWindowDragging,
   syncLinuxTrayPinned,
   stripContentSize,
   toggleMaximizeWindow,
@@ -1275,7 +1276,6 @@ function StripBar({
     agentId,
     cell: stripCellData(agentQuotaFor(snapshot, agentId)),
   }));
-  const dragProps = pinned || IS_MAC ? {} : { "data-tauri-drag-region": true };
   const vertical = orientation === "vertical";
   // 透明档的真实桌面背景变化很大，控制图标加粗以稳定识别。
   const buttonWeight = transparent && glassTint === "clear" ? "bold" : "regular";
@@ -1474,6 +1474,29 @@ function StripBar({
       setControlsOpen(false);
     }, STRIP_DETAIL_LEAVE_DELAY);
   };
+  const handleDragPointerDown = (event) => {
+    if (
+      event.button !== 0
+      || pinned
+      || IS_MAC
+      || !isDesktop()
+      || event.target.closest?.("button, a, input, select, textarea, [role='button']")
+    ) {
+      return;
+    }
+    // 原生拖动必须排在详情扩窗收回之后。直接依赖 data-tauri-drag-region 会让
+    // Windows 先进入系统拖动循环，详情卡随后才收回并用旧坐标覆盖拖动结果。
+    event.preventDefault();
+    event.stopPropagation();
+    cancelPointerLeave();
+    latestWindowCorrection += 1;
+    setHoveredDetail(null);
+    runWindowAction(async () => {
+      await collapseVerticalStripHover();
+      await startWindowDragging();
+    });
+  };
+  const dragProps = pinned || IS_MAC ? {} : { onPointerDown: handleDragPointerDown };
   const showDetail = (event, agentId) => {
     if (!detailEnabled || controlsOpen) return;
     cancelPointerLeave();
@@ -1497,7 +1520,6 @@ function StripBar({
       data-glass-surface={shellAppearance.trueAlpha ? "true-alpha" : undefined}
       data-pinned={pinned && IS_LINUX ? "true" : undefined}
       inert={pinned && IS_LINUX ? true : undefined}
-      {...dragProps}
       {...glassProps}
       onPointerEnter={cancelPointerLeave}
       onPointerLeave={handlePointerLeave}
@@ -1512,7 +1534,7 @@ function StripBar({
       }}
     >
       <h1 className="sr-only">Metrik 官方配额胶囊条</h1>
-      <div ref={railRef} className="strip-rail">
+      <div ref={railRef} className="strip-rail" {...dragProps}>
       {cells.length ? (
         cells.map(({ agentId, cell }) => {
           const meta = AGENT_META[agentId];
@@ -1523,7 +1545,6 @@ function StripBar({
                 className="strip-cell strip-cell--unavailable"
                 title={`${meta.label}：官方配额不可用`}
                 onPointerEnter={(event) => showDetail(event, agentId)}
-                {...dragProps}
               >
                 <img
                   className={`strip-cell-icon ${meta.iconClass || ""}`}
@@ -1545,7 +1566,6 @@ function StripBar({
               className={`strip-cell ${severity ? `strip-cell--${severity}` : ""}`}
               title={detailEnabled ? undefined : stripTooltip(agentId, cell.windows)}
               onPointerEnter={(event) => showDetail(event, agentId)}
-              {...dragProps}
             >
               <img
                 className={`strip-cell-icon ${meta.iconClass || ""}`}
@@ -1560,7 +1580,7 @@ function StripBar({
           );
         })
       ) : (
-        <span className="strip-empty" {...dragProps}>
+        <span className="strip-empty">
           配额不可用
         </span>
       )}

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -1479,6 +1479,7 @@ async function startEdgeDock({ getMode, getPinned }) {
   let outsideSinceMs = null;
   let checkTimer;
   let pollTimer;
+  let alwaysOnTopQueue = Promise.resolve();
 
   const canDock = () => isStableFloatingMode(
     getMode(),
@@ -1500,6 +1501,15 @@ async function startEdgeDock({ getMode, getPinned }) {
     if (!dock) return;
     await win.setPosition(new api.PhysicalPosition(position.x, position.y)).catch(() => {});
   };
+  const setDockAlwaysOnTop = (enabled) => {
+    const requested = Boolean(enabled);
+    // 释放旧挂靠与重新贴边可能前后紧邻；原生调用必须按请求顺序落地，
+    // 否则迟到的 false 会覆盖新挂靠刚写入的 true。
+    alwaysOnTopQueue = alwaysOnTopQueue
+      .catch(() => {})
+      .then(() => win.setAlwaysOnTop(requested).catch(() => {}));
+    return alwaysOnTopQueue;
+  };
 
   const stopPoll = () => {
     window.clearInterval(pollTimer);
@@ -1513,7 +1523,7 @@ async function startEdgeDock({ getMode, getPinned }) {
     hidden = false;
     outsideSinceMs = null;
     stopPoll();
-    win.setAlwaysOnTop(Boolean(getPinned())).catch(() => {});
+    setDockAlwaysOnTop(getPinned());
   };
 
   const undock = async () => {
@@ -1522,7 +1532,7 @@ async function startEdgeDock({ getMode, getPinned }) {
     hidden = false;
     outsideSinceMs = null;
     stopPoll();
-    await win.setAlwaysOnTop(Boolean(getPinned())).catch(() => {});
+    await setDockAlwaysOnTop(getPinned());
   };
 
   const poll = async () => {
@@ -1612,7 +1622,7 @@ async function startEdgeDock({ getMode, getPinned }) {
     hidden = false;
     outsideSinceMs = null;
     await slideTo(exposedPosition());
-    await win.setAlwaysOnTop(true).catch(() => {});
+    await setDockAlwaysOnTop(true);
     if (!pollTimer) pollTimer = window.setInterval(poll, DOCK_POLL_MS);
   };
 
@@ -1634,6 +1644,7 @@ async function startEdgeDock({ getMode, getPinned }) {
     const unlisten = await unlistenPromise.catch(() => null);
     unlisten?.();
     if (dock) await undock();
+    await alwaysOnTopQueue.catch(() => {});
   };
 }
 

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -1653,6 +1653,15 @@ async function setWindowPinned(pinned) {
   if (isLinuxPlatform()) await setPinnedHoverBehavior(pinned);
 }
 
+/// 胶囊条用显式原生拖动代替 data-tauri-drag-region：开始拖动前必须先让详情
+/// 扩窗完整收回，否则它保存的旧坐标会在拖动结束后把窗口搬回原位。
+async function startWindowDragging() {
+  if (isMacPlatform()) return;
+  const api = await windowApi();
+  if (!api) return;
+  await api.getCurrentWindow().startDragging();
+}
+
 /// Linux 托盘菜单的“置顶/取消置顶”请求。其 payload 是后端已经切换过的目标值，
 /// 前端只负责把窗口与持久化状态同步到该值。
 async function onTrayPinnedChange(handler) {
@@ -1777,6 +1786,7 @@ export {
   setWindowUiScale,
   startEdgeDock,
   startPositionMemory,
+  startWindowDragging,
   syncLinuxTrayPinned,
   stripContentSize,
   toggleMaximizeWindow,

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -10,6 +10,7 @@ import {
   trayBadgeKey,
 } from "./trayBadge.js";
 import {
+  isDockAnchorPosition,
   isStableFloatingMode,
   monitorForWindowPosition,
   physicalWindowSize,
@@ -1505,6 +1506,16 @@ async function startEdgeDock({ getMode, getPinned }) {
     pollTimer = undefined;
   };
 
+  // 用户从已挂靠的边缘开始拖动时只清理旧状态，不把窗口“恢复”回旧锚点。
+  // 否则仍在运行的轮询会把拖动中的光标判为离开旧窗口，900ms 后强制拉回。
+  const releaseDockForDrag = () => {
+    dock = null;
+    hidden = false;
+    outsideSinceMs = null;
+    stopPoll();
+    win.setAlwaysOnTop(Boolean(getPinned())).catch(() => {});
+  };
+
   const undock = async () => {
     if (dock && hidden) await slideTo(exposedPosition());
     dock = null;
@@ -1521,7 +1532,7 @@ async function startEdgeDock({ getMode, getPinned }) {
       return;
     }
     const cursor = await api.cursorPosition().catch(() => null);
-    if (!cursor) return;
+    if (!cursor || !dock) return;
     if (hidden) {
       const visible = peek();
       const onStrip = dock.edge === "bottom"
@@ -1605,7 +1616,11 @@ async function startEdgeDock({ getMode, getPinned }) {
     if (!pollTimer) pollTimer = window.setInterval(poll, DOCK_POLL_MS);
   };
 
-  const onMove = () => {
+  const onMove = (event) => {
+    if (dock) {
+      const anchor = hidden ? hiddenPosition() : exposedPosition();
+      if (!isDockAnchorPosition(event?.payload, anchor)) releaseDockForDrag();
+    }
     window.clearTimeout(checkTimer);
     checkTimer = window.setTimeout(check, 220);
   };

--- a/src/windowGeometry.js
+++ b/src/windowGeometry.js
@@ -9,6 +9,25 @@ function isStableFloatingMode(mode, transient = false) {
   return mode === "compact" || mode === "strip" || mode === "strip-horizontal" || mode === "strip-vertical";
 }
 
+/// 原生窗口移动事件是物理坐标。挂靠窗口只要离开当前锚点，就说明用户正在
+/// 把它拖往别处；旧挂靠轮询必须立即失效，不能在拖动途中按旧边缘把窗口拉回。
+function isDockAnchorPosition(position, anchor, tolerance = 2) {
+  if (
+    !position
+    || !anchor
+    || !Number.isFinite(position.x)
+    || !Number.isFinite(position.y)
+    || !Number.isFinite(anchor.x)
+    || !Number.isFinite(anchor.y)
+  ) {
+    return false;
+  }
+  return (
+    Math.abs(position.x - anchor.x) <= tolerance
+    && Math.abs(position.y - anchor.y) <= tolerance
+  );
+}
+
 function monitorArea(monitor) {
   if (!monitor?.position || !monitor?.size) return null;
   return {
@@ -245,6 +264,7 @@ function monitorForWindowPosition(
 
 export {
   horizontalStripTargetWidth,
+  isDockAnchorPosition,
   isStableFloatingMode,
   monitorForWindowPosition,
   physicalWindowSize,

--- a/src/windowGeometry.test.js
+++ b/src/windowGeometry.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   horizontalStripTargetWidth,
+  isDockAnchorPosition,
   isStableFloatingMode,
   monitorForWindowPosition,
   physicalWindowSize,
@@ -11,6 +12,13 @@ import {
   viewportCorrectedPhysicalSize,
   viewportCorrectedZoom,
 } from "./windowGeometry.js";
+
+test("moving a docked window away from its anchor is treated as a user drag", () => {
+  const anchor = { x: 1878, y: 300 };
+  assert.equal(isDockAnchorPosition({ x: 1878, y: 300 }, anchor), true);
+  assert.equal(isDockAnchorPosition({ x: 1880, y: 299 }, anchor), true);
+  assert.equal(isDockAnchorPosition({ x: 1600, y: 300 }, anchor), false);
+});
 
 test("transient strip geometry never participates in persistent floating state", () => {
   assert.equal(isStableFloatingMode("compact"), true);


### PR DESCRIPTION
## Summary
- release stale edge-dock state as soon as a docked window is dragged away from its anchor
- prevent the old polling loop from moving the window back to its previous screen edge
- add a regression test for dock-anchor movement detection

## Scope
Shared edge-dock logic (Windows and coordinate-capable Linux/X11). Ubuntu Wayland continues to skip global edge docking by design.

## Verification
- Windows native smoke: moved an already docked native window continuously to the opposite work-area edge and waited beyond the 900 ms hide threshold; it remained at the new edge
- `npm test`
- `npm run build`
- `git diff --check`