### PR TITLE
Refine strip and hidden window recovery

### DIFF
--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -13,6 +13,11 @@ change.
 - Manual refresh requests `usage_snapshot` with `force: true`, bypassing quota
   TTL caches. A failed refresh retains the last rows and marks them stale; it
   never clears them silently.
+- The data-source drawer is operational UI, not a parser report. It shows a
+  short source status by default. When local data is incomplete it offers a
+  visible rescan that rebuilds only Metrik's derived index and never changes
+  Agent logs; if the same adapter mismatch remains, the UI says that an app
+  update may still be required instead of claiming the rescan repaired it.
 - Metrik is local-first. Optional multi-device sync must not upload prompts,
   conversation text, credentials, or raw tool output.
 - The compact widget prioritizes per-agent official quota windows, including
@@ -106,6 +111,8 @@ change.
 - Compact, strip, and expanded forms are reachable from one another in one
   click. Each form remembers its own position and never overwrites another
   form's position.
+- The tray's "show expanded" action works from a fully hidden main window; it
+  must not require the user to reveal compact or strip first.
 - Pinning and position lock apply only to compact and strip. Entering expanded
   mode always drops always-on-top and provides no pin control.
 - Strip resizing preserves the screen edge it is flush to. Fully off-screen
@@ -125,6 +132,9 @@ change.
   window size and, when the platform exposes it, position. Linux pinned
   read-only hover behavior remains authoritative and never opens the detail
   bubble.
+- The horizontal strip stays glance-only. It shares the vertical strip's glass
+  surface and compact grouping, but does not use a native multiline tooltip or
+  grow into the vertical strip's detail-card berth.
 - Floating-form size uses the destination monitor's DPI. Compact and strip
   reassert size from native DPI-change payloads, and window mutations are
   serialized so stale resizes cannot overwrite corrections.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1391,9 +1391,18 @@ fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
         .on_menu_event(|app, event| match event.id.as_ref() {
             "toggle" => toggle_main_window(app),
             // 胶囊/卡片直达完整视图，省掉"先弹卡片再点展开"这一步。窗口形态归
-            // 前端所有（Windows 是单窗口变形），所以这里只发意图：前端切到
-            // expanded 时自己会 show + focus，托盘再动窗口只会抢出闪帧。
+            // 前端所有（Windows 是单窗口变形）。隐藏的 WebView 在部分 Windows
+            // 机器上不会及时处理事件，因此先只唤醒窗口（不抢焦点），再让前端完成
+            // hide/resize/show 事务；可见窗口不做额外 show，避免重复绘制。
             "expanded" => {
+                if let Some(window) = app.get_webview_window("main") {
+                    let hidden = !window.is_visible().unwrap_or(false);
+                    let minimized = window.is_minimized().unwrap_or(false);
+                    if hidden || minimized {
+                        let _ = window.unminimize();
+                        let _ = window.show();
+                    }
+                }
                 let _ = app.emit(TRAY_SHOW_EXPANDED, ());
             }
             #[cfg(target_os = "linux")]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -516,21 +516,27 @@ function stripCellData(entry) {
   return { tightest: bindingWindow(windows) || windows[0], windows };
 }
 
-// 原生 title tooltip：列出全部窗口的剩余与重置倒计时；快照数据标注更新时间。
-function stripTooltip(agentId, windows) {
-  const lines = windows.map((window) => {
-    const view = window.view;
-    const reset = Number.isFinite(view.resetsInMinutes)
-      ? ` · ${formatReset(view.resetsInMinutes)}后重置`
-      : "";
-    return `${window.label || shortWindowLabel(window.key)}：剩余 ${Math.round(view.remainingPercent)}%${reset}`;
-  });
-  const first = windows[0].view;
-  const head =
-    first.stale || first.quality === "official_snapshot"
-      ? `${AGENT_META[agentId].label}（官方快照 · ${formatQuotaAge(first.ageMinutes)}）`
-      : AGENT_META[agentId].label;
-  return [head, ...lines].join("\n");
+function conciseSourceDetail(source) {
+  if (source.kind === "official") {
+    return "显示官方额度和重置时间。";
+  }
+  if (source.kind === "sync") {
+    return source.quality === "partial"
+      ? "同步未完成，本机统计不受影响。"
+      : "已合并其他设备的统计数据。";
+  }
+
+  const scanSummary = source.detail?.match(/^发现[^。]+。/)?.[0] || "";
+  if (source.quality === "partial") {
+    return `${scanSummary}部分记录未计入。`;
+  }
+  return scanSummary || "本机数据已更新。";
+}
+
+function conciseQualityLabel(source) {
+  if (source.quality === "exact") return "正常";
+  if (source.quality === "partial") return "不完整";
+  return source.qualityLabel;
 }
 
 function quotaUsedPercent(view) {
@@ -1543,7 +1549,7 @@ function StripBar({
               <div
                 key={agentId}
                 className="strip-cell strip-cell--unavailable"
-                title={`${meta.label}：官方配额不可用`}
+                aria-label={`${meta.label}：官方配额不可用`}
                 onPointerEnter={(event) => showDetail(event, agentId)}
               >
                 <img
@@ -1564,7 +1570,7 @@ function StripBar({
             <div
               key={agentId}
               className={`strip-cell ${severity ? `strip-cell--${severity}` : ""}`}
-              title={detailEnabled ? undefined : stripTooltip(agentId, cell.windows)}
+              aria-label={`${meta.label}：剩余 ${Math.round(view.remainingPercent)}%${Number.isFinite(view.resetsInMinutes) ? `，${formatReset(view.resetsInMinutes)}后重置` : ""}`}
               onPointerEnter={(event) => showDetail(event, agentId)}
             >
               <img
@@ -2066,6 +2072,7 @@ function SourceDrawer({ snapshot, onClose, onRebuildLedger, rebuildState }) {
 
   const rebuildBusy = rebuildState.status === "busy";
   const rebuildStatusRole = rebuildState.status === "error" ? "alert" : "status";
+  const partial = snapshotIsPartial(snapshot);
 
   const confirmRebuild = () => {
     setConfirmingRebuild(false);
@@ -2083,20 +2090,96 @@ function SourceDrawer({ snapshot, onClose, onRebuildLedger, rebuildState }) {
         onMouseDown={(event) => event.stopPropagation()}
       >
         <header>
-          <h2 id="source-title">统计说明</h2>
-          <button ref={closeButtonRef} type="button" className="icon-button" onClick={onClose} aria-label="关闭">
-            <X size={21} weight="light" />
-          </button>
+          <h2 id="source-title">数据来源</h2>
+          <div className="source-header-actions">
+            {!partial && !confirmingRebuild && rebuildState.status === "idle" && (
+              <button
+                type="button"
+                className="source-rescan-button"
+                disabled={rebuildBusy}
+                onClick={() => setConfirmingRebuild(true)}
+              >
+                <ClockCounterClockwise size={15} weight="light" aria-hidden="true" />
+                {rebuildBusy ? "扫描中…" : "重新扫描"}
+              </button>
+            )}
+            <button ref={closeButtonRef} type="button" className="icon-button" onClick={onClose} aria-label="关闭">
+              <X size={21} weight="light" />
+            </button>
+          </div>
         </header>
 
         {(snapshot.indexing?.pending || 0) > 0 && (
           <div className="indexing-note" role="status">
             <ClockCounterClockwise size={20} weight="light" aria-hidden="true" />
             <p>
-              正在补齐历史索引，还剩 <strong>{snapshot.indexing.pending}</strong> 个日志文件。
-              历史周期的数字尚不完整，会随补齐自动更新。
+              正在补齐历史，还剩 <strong>{snapshot.indexing.pending}</strong> 个文件。完成后会自动更新。
             </p>
           </div>
+        )}
+
+        {(partial || confirmingRebuild || rebuildState.status !== "idle") && (
+          <section className={`source-repair ${partial ? "source-repair--warning" : ""}`} aria-labelledby="source-repair-title">
+            {confirmingRebuild ? (
+              <div className="source-repair-confirmation" role="group" aria-labelledby="source-repair-title">
+                <div>
+                  <strong id="source-repair-title">重新扫描本机数据？</strong>
+                  <p>只重建 Metrik 的统计索引，不会修改 Agent 日志。</p>
+                </div>
+                <div className="source-repair-actions">
+                  <button
+                    ref={cancelRebuildRef}
+                    type="button"
+                    className="ledger-button ledger-button--secondary"
+                    onClick={() => setConfirmingRebuild(false)}
+                  >
+                    取消
+                  </button>
+                  <button
+                    type="button"
+                    className="ledger-button ledger-button--primary"
+                    onClick={confirmRebuild}
+                  >
+                    重新扫描
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="source-repair-row">
+                <span className="source-repair-icon" aria-hidden="true">
+                  <ClockCounterClockwise size={18} weight="light" />
+                </span>
+                <div>
+                  <strong id="source-repair-title">
+                    {rebuildBusy
+                      ? "正在重新扫描"
+                      : partial && rebuildState.status === "success"
+                        ? "扫描完成，仍不完整"
+                        : partial
+                          ? "部分数据未计入"
+                          : "扫描完成"}
+                  </strong>
+                  <p>
+                    {rebuildBusy
+                      ? "正在重建统计索引，可能需要几分钟。"
+                      : rebuildState.status === "success"
+                        ? rebuildState.message
+                        : partial
+                          ? "可重新扫描本机日志；如果仍不完整，请更新 Metrik 后再试。"
+                          : rebuildState.message}
+                  </p>
+                </div>
+                {partial && !rebuildBusy && (
+                  <button type="button" className="source-rescan-button" onClick={() => setConfirmingRebuild(true)}>
+                    重新扫描
+                  </button>
+                )}
+              </div>
+            )}
+            {!confirmingRebuild && rebuildState.status === "error" && (
+              <p className="source-repair-error" role={rebuildStatusRole}>{rebuildState.message}</p>
+            )}
+          </section>
         )}
 
         <div className="source-list">
@@ -2113,81 +2196,17 @@ function SourceDrawer({ snapshot, onClose, onRebuildLedger, rebuildState }) {
               </span>
               <div>
                 <strong>{source.label}</strong>
-                <p>{source.detail}</p>
+                <p>{conciseSourceDetail(source)}</p>
               </div>
-              <span className={`quality-badge quality-badge--${source.quality}`}>{source.qualityLabel}</span>
+              <span className={`quality-badge quality-badge--${source.quality}`}>{conciseQualityLabel(source)}</span>
             </article>
           ))}
         </div>
 
         <div className="privacy-note">
           <ShieldCheck size={20} weight="light" />
-          <p>本机会顺序扫描日志，但只解析并保存统计字段；不会提取、保存或上传正文、提示词、工具输出或凭据。SQLite 会保留用量时间、Agent、模型、会话标识与本机源路径。</p>
+          <p>只保存用量和来源信息，不读取或上传对话正文与凭据。</p>
         </div>
-
-        <section className="ledger-recovery" aria-labelledby="ledger-recovery-title">
-          <div className="ledger-recovery-heading">
-            <span className="ledger-recovery-icon" aria-hidden="true">
-              <ClockCounterClockwise size={21} weight="light" />
-            </span>
-            <div>
-              <h3 id="ledger-recovery-title">重建本地账本</h3>
-              <p id="ledger-recovery-description">只清理 Metrik 的派生统计索引，再从本机 Agent 日志重建当前周期。</p>
-            </div>
-          </div>
-
-          {snapshot.isDemo && (
-            <p className="ledger-demo-note">
-              浏览器演示：这里仅模拟重建流程，不会访问或删除任何本机文件。
-            </p>
-          )}
-
-          {confirmingRebuild ? (
-            <div className="ledger-confirmation" role="group" aria-labelledby="ledger-confirm-title">
-              <strong id="ledger-confirm-title">确认只重建统计索引？</strong>
-              <p>原始 Agent 日志、提示词、工具输出与登录凭据都不会被删除或改写。重建可能需要几分钟。</p>
-              <div className="ledger-confirm-actions">
-                <button
-                  ref={cancelRebuildRef}
-                  type="button"
-                  className="ledger-button ledger-button--secondary"
-                  onClick={() => setConfirmingRebuild(false)}
-                >
-                  取消
-                </button>
-                <button
-                  type="button"
-                  className="ledger-button ledger-button--primary"
-                  onClick={confirmRebuild}
-                >
-                  确认重建
-                </button>
-              </div>
-            </div>
-          ) : (
-            <button
-              type="button"
-              className={`ledger-button ledger-button--rebuild ${rebuildBusy ? "ledger-button--busy" : ""}`}
-              aria-describedby="ledger-recovery-description"
-              aria-busy={rebuildBusy}
-              disabled={rebuildBusy}
-              onClick={() => setConfirmingRebuild(true)}
-            >
-              <ClockCounterClockwise size={17} weight="light" aria-hidden="true" />
-              {rebuildBusy ? "正在重建…" : "重建本地账本"}
-            </button>
-          )}
-
-          {rebuildState.status !== "idle" && (
-            <p
-              className={`ledger-rebuild-status ledger-rebuild-status--${rebuildState.status}`}
-              role={rebuildStatusRole}
-              aria-live={rebuildState.status === "error" ? "assertive" : "polite"}
-            >
-              {rebuildState.message}
-            </p>
-          )}
-        </section>
       </section>
     </div>
   );
@@ -5489,14 +5508,16 @@ export function App() {
       setRebuildState({
         status: "success",
         message: next.isDemo
-          ? "演示流程已完成；没有访问或删除任何本机文件。"
-          : `重建完成 · 更新于 ${formatClock(next.generatedAt)}`,
+          ? "演示扫描完成。"
+          : snapshotIsPartial(next)
+            ? "扫描完成，仍有记录无法解析。请更新 Metrik 后再试。"
+            : `扫描完成 · ${formatClock(next.generatedAt)}`,
       });
     } catch (error) {
       console.warn("Unable to rebuild the local ledger.", error);
       setRebuildState({
         status: "error",
-        message: "重建未完成。原始 Agent 日志与凭据未受影响，请稍后重试。",
+        message: "扫描失败，请稍后重试。Agent 日志未受影响。",
       });
     } finally {
       rebuildInFlight.current = false;

--- a/src/glassAppearance.js
+++ b/src/glassAppearance.js
@@ -58,7 +58,9 @@ export function glassShellAppearance(
 
   const prefix = kind === "widget" ? "widget-shell" : "strip-shell";
   const classes = [prefix];
-  if (kind === "strip" && vertical) classes.push(`${prefix}--vertical`);
+  if (kind === "strip") {
+    classes.push(`${prefix}--${vertical ? "vertical" : "horizontal"}`);
+  }
   if (transparent) {
     classes.push(`${prefix}--transparent`);
     if (glassMode === GLASS_MODES.css) classes.push(`${prefix}--glass-css`);

--- a/src/glassAppearance.test.js
+++ b/src/glassAppearance.test.js
@@ -89,6 +89,16 @@ test("compact and strip clear glass share one true-alpha appearance", () => {
   }
 });
 
+test("strip orientation is explicit so horizontal and vertical can share material without sharing layout", () => {
+  const horizontal = glassShellAppearance("strip", { transparent: true });
+  const vertical = glassShellAppearance("strip", { transparent: true, vertical: true });
+
+  assert.match(horizontal.className, /strip-shell--horizontal/);
+  assert.doesNotMatch(horizontal.className, /strip-shell--vertical/);
+  assert.match(vertical.className, /strip-shell--vertical/);
+  assert.doesNotMatch(vertical.className, /strip-shell--horizontal/);
+});
+
 test("the clear tint pairs each ink colour with the backdrop that can carry it", () => {
   for (const kind of ["widget", "strip"]) {
     const prefix = kind === "widget" ? "widget-shell" : "strip-shell";

--- a/src/styles.css
+++ b/src/styles.css
@@ -1359,6 +1359,40 @@ html:has(.strip-shell) #root {
   gap: 4px;
 }
 
+/* 横条保留一眼扫完的优势，不复制竖条的扩窗详情。旧版原生 title 已移除，
+   这里只把信息组做成与新版竖条相同的轻量玻璃分组。 */
+.strip-shell--horizontal {
+  padding-inline: 6px 5px;
+  gap: 4px;
+}
+
+.strip-shell--horizontal .strip-rail { gap: 3px; }
+
+.strip-shell--horizontal .strip-cell {
+  position: relative;
+  flex: none;
+  min-height: 24px;
+  padding: 4px 6px 4px 4px;
+}
+
+.strip-shell--horizontal .strip-cell + .strip-cell::before {
+  content: "";
+  position: absolute;
+  top: 6px;
+  bottom: 6px;
+  left: -2px;
+  width: 1px;
+  background: currentColor;
+  opacity: 0.09;
+  pointer-events: none;
+}
+
+.strip-shell--horizontal .strip-controls {
+  margin-left: 1px;
+  padding-left: 3px;
+  box-shadow: -1px 0 color-mix(in srgb, currentColor 9%, transparent);
+}
+
 /* Windows 竖条悬停详情：透明主窗口只提供承载区，原条身和气泡各自画表面。
    条身按原坐标留在屏幕上，详情从指向当前 Agent 的尖角位置展开。 */
 .strip-shell--vertical.strip-shell--detail-open {
@@ -3497,6 +3531,12 @@ html:has(.strip-shell--detail-open.strip-shell--glass-clear) #root {
 
 .source-drawer header { display: flex; align-items: center; justify-content: space-between; }
 
+.source-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .source-drawer h2 {
   margin: 0;
   color: #202124;
@@ -3522,8 +3562,89 @@ html:has(.strip-shell--detail-open.strip-shell--glass-clear) #root {
 
 .icon-button:hover { background: rgba(31, 33, 36, 0.09); }
 
+.source-rescan-button {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 12px;
+  color: #55575b;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 540;
+  background: rgba(31, 33, 36, 0.05);
+  border: 0;
+  border-radius: 11px;
+  cursor: pointer;
+  transition: color 180ms var(--motion), background-color 180ms var(--motion), transform 180ms var(--motion);
+}
+
+.source-rescan-button:hover:not(:disabled) {
+  color: #222428;
+  background: rgba(31, 33, 36, 0.09);
+}
+
+.source-rescan-button:active:not(:disabled) { transform: scale(0.97); }
+.source-rescan-button:disabled { cursor: wait; opacity: 0.6; }
+
+.source-repair {
+  margin-top: 20px;
+  padding: 14px 15px;
+  background: rgba(36, 107, 219, 0.055);
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1px rgba(36, 107, 219, 0.07);
+}
+
+.source-repair--warning {
+  background: rgba(199, 147, 50, 0.09);
+  box-shadow: inset 0 0 0 1px rgba(199, 147, 50, 0.11);
+}
+
+.source-repair-row {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.source-repair-icon {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  color: #8f681f;
+  background: rgba(255, 255, 255, 0.62);
+  border-radius: 10px;
+}
+
+.source-repair strong {
+  display: block;
+  color: #303236;
+  font-size: 12.5px;
+  font-weight: 580;
+}
+
+.source-repair p {
+  margin: 3px 0 0;
+  color: #74767a;
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+
+.source-repair-confirmation {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+}
+
+.source-repair-actions { display: flex; gap: 8px; }
+.source-repair-actions .ledger-button { min-height: 34px; padding: 0 13px; }
+.source-repair-error { color: #a1573d !important; }
+
 .source-list {
-  margin-top: 38px;
+  margin-top: 24px;
   box-shadow: 0 -1px rgba(31, 33, 36, 0.09), 0 1px rgba(31, 33, 36, 0.09);
 }
 
@@ -3579,8 +3700,8 @@ html:has(.strip-shell--detail-open.strip-shell--glass-clear) #root {
 .privacy-note {
   display: flex;
   gap: 13px;
-  margin-top: 28px;
-  padding: 18px;
+  margin-top: 20px;
+  padding: 14px 16px;
   color: #686a6e;
   background: rgba(31, 33, 36, 0.035);
   border-radius: 17px;
@@ -5140,6 +5261,13 @@ html:has(.strip-shell--detail-open.strip-shell--glass-clear) #root {
   .source-drawer h2 { font-size: 23px; }
   .source-list { margin-top: 24px; }
 
+  .source-repair-row,
+  .source-repair-confirmation { grid-template-columns: 1fr; }
+
+  .source-repair-icon { display: none; }
+  .source-repair-row .source-rescan-button { width: 100%; }
+  .source-repair-actions { display: grid; grid-template-columns: 1fr 1fr; }
+
   .source-item {
     grid-template-columns: 42px minmax(0, 1fr);
     gap: 12px;
@@ -5480,6 +5608,28 @@ html:has(.strip-shell--detail-open.strip-shell--glass-clear) #root {
   background: rgba(255, 255, 255, 0.06);
 }
 :root[data-theme="dark"] .icon-button:hover { background: rgba(255, 255, 255, 0.1); }
+:root[data-theme="dark"] .source-rescan-button {
+  color: var(--d-ink-3);
+  background: rgba(255, 255, 255, 0.06);
+}
+:root[data-theme="dark"] .source-rescan-button:hover:not(:disabled) {
+  color: var(--d-strong);
+  background: rgba(255, 255, 255, 0.1);
+}
+:root[data-theme="dark"] .source-repair {
+  background: rgba(111, 155, 240, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(111, 155, 240, 0.1);
+}
+:root[data-theme="dark"] .source-repair--warning {
+  background: rgba(220, 166, 72, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(220, 166, 72, 0.13);
+}
+:root[data-theme="dark"] .source-repair-icon {
+  color: var(--warn);
+  background: rgba(255, 255, 255, 0.06);
+}
+:root[data-theme="dark"] .source-repair strong { color: var(--d-ink-2); }
+:root[data-theme="dark"] .source-repair p { color: var(--d-muted); }
 :root[data-theme="dark"] .source-list {
   box-shadow: 0 -1px rgba(255, 255, 255, 0.08), 0 1px rgba(255, 255, 255, 0.08);
 }


### PR DESCRIPTION
## Scope\n\n- shared UI: simplify the data-source drawer and expose safe local index rescan\n- Windows/Linux shell: wake a fully hidden main window before requesting expanded view\n- Windows strip: align the horizontal strip with the current glass grouping and remove the legacy multiline native tooltip\n\n## Verification\n\n- npm test\n- npm run build\n- cargo fmt --check\n- cargo clippy -- -D warnings\n- cargo test\n- Windows native development build launched; browser preview reviewed for horizontal strip and source drawer\n- Linux packaging and macOS/shared build behavior are covered by CI; no local Ubuntu/macOS native smoke was available\n