### PR TITLE
fix: 胶囊条 zoom 校正出错后可恢复

### DIFF
--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -175,6 +175,10 @@ async function scaledPhysicalSize(
   return new api.PhysicalSize(physical.width, physical.height);
 }
 
+// 最近一次成功下发给 WebView 的 zoom。视口校正（reconcileFloatingSizeAfterShow）
+// 必须以它为基数，而不是本形态的目标系数：两者只在没校正过的时候相等。
+let appliedZoom = null;
+
 /// 内容缩放用 WebView 原生 zoom（等同浏览器 Ctrl+缩放）：视口单位、媒体查询
 /// 全部自洽。CSS zoom 做不到——100vw 元素在 zoom 下会溢出视口（实测）。
 async function applyWebviewZoom(factor) {
@@ -183,6 +187,9 @@ async function applyWebviewZoom(factor) {
   await api
     .getCurrentWebview()
     .setZoom(factor)
+    .then(() => {
+      appliedZoom = factor;
+    })
     .catch((error) => {
       // zoom 失败会让视口与物理尺寸失配（320 内容被裁），不能静默吞掉。
       console.warn("Unable to apply the webview zoom.", error);
@@ -417,36 +424,59 @@ async function reconcileFloatingSizeAfterShow(
     current = await appWindow.innerSize().catch(() => null);
   }
 
-  const initialViewportWidth = window.innerWidth;
-  const initialViewportHeight = window.innerHeight;
-  if (
-    Math.abs(initialViewportWidth - width) <= 1 &&
-    Math.abs(initialViewportHeight - height) <= 1
-  ) {
+  const viewportMatches = () =>
+    Math.abs(window.innerWidth - width) <= 1 &&
+    Math.abs(window.innerHeight - height) <= 1;
+  if (viewportMatches()) {
     await clampIntoWorkArea(api, appWindow, current || appliedPhysical);
     return current || appliedPhysical;
   }
 
   // 外框已经是设计尺寸 × 应用比例 × DPI，但视口仍偏小时，优先抵消 WebView2
   // 额外保留的 zoom。这样不会为了显示完整内容而把整个卡片无端放大。
-  const correctedZoom = viewportCorrectedZoom({
-    contentScale,
-    viewportWidth: initialViewportWidth,
-    viewportHeight: initialViewportHeight,
-    expectedWidth: width,
-    expectedHeight: height,
-  });
-  if (correctedZoom) {
-    await applyWebviewZoom(correctedZoom);
+  //
+  // 基数是上一次真正下发的 zoom，不是本形态的目标系数。一旦某轮校正改过
+  // zoom，再拿目标系数乘比例就是在错的基数上二次修正：上一轮缩到 0.67 倍，
+  // 这一轮量到 1.5 倍的视口，按目标系数算出 1.5 倍，实际该回到 1 倍——两轮
+  // 之间永远差一个因子，卡片在大小之间来回跳。
+  //
+  // 量到的比例出了 0.5–2 或两轴不一致时，不能就此放弃：用户实拍过胶囊条
+  // 内容缩到不足一半、窗口不变、再也不恢复的卡死态——zoom 已经错了，两条
+  // 校正又都因超界拒绝，没有任何路径把它拨回来。先把 zoom 拨回目标系数再量
+  // 一次；若那本来就是目标系数，重设是空操作，不会闪。
+  let zoomBase = appliedZoom ?? contentScale;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const correctedZoom = viewportCorrectedZoom({
+      contentScale: zoomBase,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      expectedWidth: width,
+      expectedHeight: height,
+    });
+    if (correctedZoom) {
+      await applyWebviewZoom(correctedZoom);
+      await settleWebviewLayout();
+      current = await appWindow.innerSize().catch(() => current);
+      if (viewportMatches()) {
+        await clampIntoWorkArea(api, appWindow, current || appliedPhysical);
+        return current || appliedPhysical;
+      }
+      // 没收敛说明量到的是瞬时视口（DPI 切换、resize 未落地），不是真实的
+      // 残留 zoom：撤回，别把一个错的 zoom 留给下面的物理尺寸校正当前提。
+      await applyWebviewZoom(zoomBase);
+      await settleWebviewLayout();
+      current = await appWindow.innerSize().catch(() => current);
+      break;
+    }
+    if (attempt > 0) break;
+    await applyWebviewZoom(contentScale);
     await settleWebviewLayout();
     current = await appWindow.innerSize().catch(() => current);
-    if (
-      Math.abs(window.innerWidth - width) <= 1 &&
-      Math.abs(window.innerHeight - height) <= 1
-    ) {
+    if (viewportMatches()) {
       await clampIntoWorkArea(api, appWindow, current || appliedPhysical);
       return current || appliedPhysical;
     }
+    zoomBase = contentScale;
   }
 
   for (let pass = 0; pass < 2; pass += 1) {


### PR DESCRIPTION
## 现象

用户实拍（Windows 竖胶囊条）：悬停 Kimi 格弹出详情卡、收回后，胶囊条内容缩到约 0.4 倍挤在窗口顶部，窗口外框不变，之后一直卡在这个状态。维护者本机不复现。

## 定位

只有 `reconcileFloatingSizeAfterShow` 里的 `viewportCorrectedZoom` 会把 zoom 设成非配置值。两个缺陷合起来正好是这个表现：

1. 校正基数用的是形态目标系数，默认「当前 zoom 就是目标系数」。校正过一次之后前提不成立，每轮都在错的基数上二次修正。
2. 量到的比例超出 0.5–2 时，zoom 校正与物理尺寸校正都拒绝，函数打 warn 返回，没有任何路径把 zoom 拨回来。`fit()` 检测到失配会一直重走这条路、一直被拒绝。视频里的 0.4 倍正好落在拒绝区。

触发时机是悬停扩窗/收窗期间的 DPI 瞬态（混合 DPI 或 125%/150% 分数缩放），本机显示器配置不同所以不复现。

## 改动

`src/windowClient.js`，只动 reconcile 那一段：

- 记录最近一次真正下发的 `appliedZoom`，校正以它为基数。
- 校正后视口没收敛 → 撤回原 zoom，不把错值留给后面的物理尺寸校正。
- 比例超界或两轴不一致 → 先把 zoom 重设为目标系数再量一次。本来就是目标系数时重设是空操作。

对视频里的卡死态：下一次 `fit()` 触发 reconcile → 比例 >2 被拒 → 重设 zoom → 视口对上 → 一次恢复。

## 验证

`npm test` 63 项、`npm run build` 通过。**未复现、未实机验证**，修的是「校正出错后无法恢复」这一类问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FJwRv2UX33sP6yvnL6znz
