### PR TITLE
chore: release v0.19.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.19.2"
+version = "0.19.3"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
五个版本文件同步到 0.19.3。

本版内容（#171、#173；v0.19.2 只出了 draft 未发布，本版一并带上）：

- 价格表刷新到 2026-09-03，新增 `claude-fable-5-1`（输入 $10 / 缓存命中 $0.25 /
  输出 $50）。同一次刷新里 grok-3/grok-4 全族、`gpt-5.6` 与部分 gemini 条目被
  LiteLLM 改价，历史成本估算会随之变化。
- `MANUAL_PRICING` 删掉 LiteLLM 已收录的五条，手工值不再压过生成值。
- 界面上 Claude 模型名统一点号写法（`claude-fable-5.1`）；原始 ID 仍是计价键、
  筛选值与 CSV 导出值。
- 新增每周自动刷新价格表并开 PR 的工作流。
- 修复胶囊条 zoom 自校正出错后内容缩小、窗口不变且无法恢复的卡死态
  （用户实拍，未复现；修的是校正出错后的恢复路径）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FJwRv2UX33sP6yvnL6znz
