### PR TITLE
chore: .gitattributes 统一 LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# 仓库统一 LF。Windows 开发机曾在 autocrlf=true 下检出，工作树全是 CRLF 而
+# git 存的是 LF，改任何文件都会让整文件变成 diff。显式声明后与本机配置无关。
+* text=auto eol=lf


### PR DESCRIPTION
工作树在 autocrlf=true 下检出、git 存 LF，磁盘全 CRLF，改任何文件都变整文件 diff。显式声明 `eol=lf` 后与本机配置无关。`git add --renormalize .` 对 index 无改动（HEAD 本来就是 LF）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FJwRv2UX33sP6yvnL6znz