### PR TITLE
chore: release v0.19.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrik",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metrik",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrik",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "metrik"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrik"
-version = "0.19.3"
+version = "0.19.4"
 description = "Local-first AI agent usage monitor"
 authors = ["keros68 <keros68@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Metrik",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "identifier": "app.metrik.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
五个版本文件同步到 0.19.4。

本版内容（#175、#176）：

- 修复 Codex 数据来源一直显示「不完整」：`codex exec` 一轮没拿到用量时写的
  「分量全 0、总量等于上下文窗口」占位读数不再当成口径不一致。解析器版本号
  6 → 7，升级后全量重解析一次，旧标记随之清除。
- 仓库加 `.gitattributes` 统一 LF，与本机 git 配置无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FJwRv2UX33sP6yvnL6znz
