### PR TITLE
Fix floating geometry, request pricing, and account quota refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,10 @@ jobs:
 
       # 读取本机真实 Agent 日志的烟测标记为 ignored，CI 里跑不了也不该跑。
       - name: Test
+        # Windows process-tree fixtures start PowerShell under a real deadline.
+        # Serialize them so runner contention does not consume that startup budget.
+        env:
+          RUST_TEST_THREADS: ${{ runner.os == 'Windows' && '1' || '4' }}
         run: cargo test
         working-directory: src-tauri
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,7 +124,7 @@ responses stay out of presentation and storage.
 - `event_observation`: relation between logical facts and local files
 - `quota_snapshot`: latest official quota per rolling window
 
-SQLite runs in WAL mode under the operating system's local application-data directory. Source replacement and observation updates are transactional. `PARSER_VERSION` is currently 5; version changes force retained-history reconciliation.
+SQLite runs in WAL mode under the operating system's local application-data directory. Source replacement and observation updates are transactional. The shared `PARSER_VERSION` is currently 7, with Codex using parser version 8 while request-level pricing metadata is enriched. Version changes force retained-history reconciliation.
 
 `usage_event.project_path` records the working directory an event happened in, so usage can be grouped by project as well as by session. Optional columns like it are added with `ALTER TABLE` and stay out of the required-column check: listing one there would classify every existing ledger as incompatible and rebuild it, when the column simply reads NULL until the next scan. The path is deliberately **not** part of `payload_hash` — it is attribution, not a measured quantity, and hashing it would make the same event hash differently after a parser upgrade, which non-mergeable adapters reject as an identity collision. Backfill is therefore its own write: a rescan fills the column when it is NULL and never overwrites a value already there, because where usage happened is settled fact.
 
@@ -170,7 +170,7 @@ Where a source reports its own total, `TokenVector::disagrees_with_reported_tota
 - Compact mode refreshes every five minutes while visible; expanded mode refreshes every minute. While `indexing.pending > 0` the UI polls every 400 ms instead, so each snapshot spends another `PARSE_BUDGET` on the backlog until it is drained. Returning to the window triggers a refresh. A hidden window also keeps the five-minute cadence while the Windows tray quota badge is enabled, because the taskbar number must not freeze.
 - One in-flight request is allowed from the UI; duplicate period requests are coalesced. The Rust scan remains serialized by one lock.
 - A desktop single-instance guard focuses the existing window instead of starting a second scanner.
-- Unchanged files are cheap metadata checks. A changed file is still reparsed from the beginning, so very large active logs remain the main CPU and disk bottleneck until an append cursor with durable parser state is implemented. The budget bounds a snapshot between files, not within one, so a single very large file can still overrun it.
+- Unchanged files are cheap metadata checks. Codex JSONL files can now pause between records and resume the same file on the next snapshot, using a bounded reader so append-only growth is ingested after the captured prefix completes. Truncation or same-size rewrite restarts parsing. Other adapters still budget between files, so a single very large non-Codex source can overrun one snapshot.
 - Tauri does not remove the platform webview cost: WebView2/WebKit/WebKitGTK dominates resident memory relative to the Rust process.
 
 ## Planned device sync

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,6 +102,21 @@ Quota rows are replaced wholesale, never merged, so a window a plan no longer ha
   cleaned up by the unmanaged-row prune.
 - A window whose reset time has passed without fresh data renders as `--`, not as its last known percentage.
 
+Claude OAuth usage parsing accepts both flat windows and `limits[]`. Explicit
+session/weekly classifications supply total windows; model scopes supply model
+windows. An inactive array entry removes its matching flat window. Percentages
+retain their reported 0–100 unit, including fractional values below 1; invalid
+or missing values never become zero usage. Unknown surface scopes are skipped.
+
+Low-quota notifications run after `usage_snapshot` produces its official window
+views, under the shared scan lock. A local `app_setting` switch defaults to off;
+per-agent and account notification state persists in the same local settings table. Stale,
+expired, unavailable, and estimated windows cannot trigger notifications. The
+native notification plugin delivers messages without adding another polling loop.
+Codex reset-credit queries reuse `account/rateLimits/read` and expose only the
+reported count and earliest known available-credit expiry; credit IDs and raw
+responses stay out of presentation and storage.
+
 ## Storage
 
 - `scan_source`: local locator, file state, parser version, and covered time horizon
@@ -168,3 +183,24 @@ Sync is deliberately outside the first release. The planned boundary is:
 - deterministic strong event IDs for cross-device deduplication;
 - paths, prompts, output, and credentials excluded;
 - local application remains fully useful while offline.
+
+## Request pricing and bounded Codex scans
+
+Codex stores nullable request input counts only when `last_token_usage` agrees
+with the cumulative delta. This metadata does not change event identity or token
+totals. Astra requests above 272,000 input tokens use the published long-context
+multipliers; absent request evidence retains the base estimate. Fast pricing is
+not inferred from model names or arbitrary log text. Synced events currently
+lack request-size metadata and retain base pricing.
+
+Codex parsing checks the refresh deadline between JSONL records and retains one
+in-memory checkpoint, including the cumulative baseline and fork state. A pending
+source is prioritized on the next refresh. Only a complete captured file prefix
+is committed; append-only growth is handled on a later refresh. Truncation or a
+same-size rewrite restarts parsing. Other adapters retain per-file budgeting.
+Codex parser version 8 enriches existing events once; other adapters stay at 7.
+
+Codex and Claude quota caches and notification episodes include the local account
+identity digest. Results arriving after an observed account or settings change
+are discarded. An account change clears prior account quota rows; older local
+fallback samples cannot restore them. Quota replacement is transactional.

--- a/docs/PRODUCT-CONSTRAINTS.md
+++ b/docs/PRODUCT-CONSTRAINTS.md
@@ -12,7 +12,19 @@ change.
   numbers. Missing and stale data must be labeled explicitly.
 - Manual refresh requests `usage_snapshot` with `force: true`, bypassing quota
   TTL caches. A failed refresh retains the last rows and marks them stale; it
-  never clears them silently.
+  never clears them silently within the same account. An observed account
+  change clears the previous account’s quota until current data is available.
+- Low-quota system notifications are opt-in and use the existing 15% remaining
+  threshold. Only fresh, available official windows are eligible. Each agent and account's
+  continuous low-quota episode produces one notification; after recovery,
+  notifications remain at least six hours apart. Notification state is local
+  and persists across windows and restarts. Checks follow existing snapshot
+  refreshes, including existing tray-badge refreshes when enabled; notifications
+  introduce no additional background quota polling.
+- Codex reset credits are queried manually through the local app-server's
+  read-only rate-limit method. Missing counts remain unavailable, and an
+  incomplete detail list never replaces the official available count. Displayed
+  expiry is the earliest known expiry, not a guarantee of complete coverage.
 - The data-source drawer is operational UI, not a parser report. It shows a
   short source status by default. When local data is incomplete it offers a
   visible rescan that rebuilds only Metrik's derived index and never changes
@@ -139,8 +151,11 @@ change.
   reassert size from native DPI-change payloads, and window mutations are
   serialized so stale resizes cannot overwrite corrections.
 - The rendered CSS viewport is the final sizing authority for Windows floating
-  forms. After native resize, compact and strip must compensate WebView zoom
-  drift and verify the full design viewport rather than trusting HWND size alone.
+  forms. After native resize, compact and strip restore their configured zoom
+  and verify the viewport. Transient resize measurements must never redefine
+  that zoom, and hover expansion only changes native size and position.
+  Floating dimensions are bounded by the monitor work area; overflowing strip
+  content remains scrollable at the selected scale.
 - Strip window size is measured from rendered content. Constants may seed the
   first frame but are not the source of truth.
 - The notification-area icon can become a quota badge: while the setting is on,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "node --test src/platformDetection.test.js src/windowGeometry.test.js src/glassAppearance.test.js src/quotaWindows.test.js src/macosWidgetBundle.test.js src/trayBadge.test.js src/modelNames.test.js",
+    "test": "node --test src/platformDetection.test.js src/windowGeometry.test.js src/windowClient.test.js src/glassAppearance.test.js src/quotaWindows.test.js src/macosWidgetBundle.test.js src/trayBadge.test.js src/modelNames.test.js",
     "preview": "vite preview",
     "pricing:update": "node --use-env-proxy scripts/update-pricing.mjs",
     "tauri": "tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1018,7 +1018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2303,7 +2303,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2350,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.18.0"
+version = "4.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
 dependencies = [
  "futures-lite",
  "log",
@@ -2393,7 +2393,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3240,7 +3240,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3297,7 +3297,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3682,7 +3682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4324,10 +4324,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4686,7 +4686,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4715,7 +4715,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5127,7 +5127,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2158,6 +2158,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2231,7 @@ dependencies = [
  "tauri-build",
  "tauri-nspanel",
  "tauri-plugin-autostart",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",
@@ -2331,6 +2346,20 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -2881,6 +2910,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,6 +3021,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -4023,6 +4090,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2fd40946aef810c4be9fd33a2d1b9b397cb79042b2d21c81a0a8f204354fd1"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4218,6 +4304,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]
@@ -5654,6 +5751,26 @@ dependencies = [
  "serde",
  "winnow 1.0.3",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1"
 sha2 = "0.10"
 tauri = { version = "2", features = ["tray-icon", "image-png", "macos-private-api"] }
 tauri-plugin-autostart = "2.5.1"
+tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-os = "2.3.2"
 tauri-plugin-process = "2.3.1"

--- a/src-tauri/migrations/001_init.sql
+++ b/src-tauri/migrations/001_init.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS usage_event (
     quality                  TEXT NOT NULL,
     payload_hash             TEXT NOT NULL,
     project_path             TEXT,
+    request_input_tokens     INTEGER,
     UNIQUE(adapter_id, event_key)
 );
 

--- a/src-tauri/src/adapters/codex.rs
+++ b/src-tauri/src/adapters/codex.rs
@@ -490,6 +490,58 @@ mod tests {
             assert_eq!(a.tokens, b.tokens);
         }
         assert!(!adapter.has_pending(&candidate));
+        // An active rollout can grow between slices. Complete the captured
+        // prefix, then let the next source revision ingest the append.
+        assert!(adapter
+            .parse_until(&candidate, 0, Instant::now())
+            .unwrap()
+            .is_none());
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(file, r#"{{"timestamp":"2026-09-05T00:00:00Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":300030,"total_tokens":300030}}}}}}}}"#).unwrap();
+        drop(file);
+        let grown = SourceCandidate {
+            size: path.metadata().unwrap().len(),
+            mtime_ns: 2,
+            ..candidate.clone()
+        };
+        let prefix = adapter
+            .parse_until(
+                &grown,
+                1,
+                Instant::now() + std::time::Duration::from_secs(10),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(prefix.source.events.len(), 10_000);
+        assert_eq!(prefix.source.size, candidate.size);
+        let appended = adapter.parse(&grown, 1).unwrap();
+        assert_eq!(appended.source.events.len(), 10_001);
+        assert_eq!(
+            appended.source.events.last().unwrap().tokens.processed(),
+            30
+        );
+        assert!(adapter
+            .parse_until(&grown, 1, Instant::now())
+            .unwrap()
+            .is_none());
+        std::fs::write(&path, "\n").unwrap();
+        let truncated = SourceCandidate {
+            size: 1,
+            mtime_ns: 3,
+            ..grown
+        };
+        let scan = adapter
+            .parse_until(
+                &truncated,
+                1,
+                Instant::now() + std::time::Duration::from_secs(10),
+            )
+            .unwrap()
+            .unwrap();
+        assert!(scan.source.events.is_empty());
         std::fs::remove_file(path).unwrap();
     }
 

--- a/src-tauri/src/adapters/codex.rs
+++ b/src-tauri/src/adapters/codex.rs
@@ -5,11 +5,29 @@ use crate::domain::{ParsedSource, QuotaSample, TokenVector, UsageEvent};
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read, Take};
 use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Instant;
 
 pub struct CodexAdapter {
     roots: Vec<PathBuf>,
+}
+
+static CHECKPOINT: Mutex<Option<Checkpoint>> = Mutex::new(None);
+
+struct Checkpoint {
+    candidate: SourceCandidate,
+    cutoff_ms: i64,
+    reader: BufReader<Take<File>>,
+    session_id: String,
+    current_model: Option<String>,
+    current_cwd: Option<String>,
+    previous: Option<TokenVector>,
+    in_fork_replay: bool,
+    pending_events: Vec<PendingEvent>,
+    quotas: Vec<QuotaSample>,
+    diagnostics: ScanDiagnostics,
 }
 
 #[derive(Deserialize, Default)]
@@ -39,11 +57,13 @@ struct PendingEvent {
     model: Option<String>,
     tokens: TokenVector,
     cwd: Option<String>,
+    request_input_tokens: Option<i64>,
 }
 
 #[derive(Deserialize, Default)]
 struct TokenInfo {
     total_token_usage: Option<RawTokenUsage>,
+    last_token_usage: Option<RawTokenUsage>,
     #[serde(default)]
     model_context_window: Option<i64>,
 }
@@ -124,34 +144,111 @@ impl AgentAdapter for CodexAdapter {
     }
 
     fn parse(&self, candidate: &SourceCandidate, cutoff_ms: i64) -> Result<ParsedScan> {
-        let file = File::open(&candidate.path)
-            .with_context(|| format!("failed to open {}", candidate.path.display()))?;
-        let reader = BufReader::with_capacity(256 * 1024, file);
+        self.parse_slice(candidate, cutoff_ms, None)
+            .map(|scan| scan.expect("unbounded scan completes"))
+    }
 
-        let fallback_session = candidate
-            .path
-            .file_stem()
-            .and_then(|value| value.to_str())
-            .unwrap_or("unknown-session")
-            .to_owned();
-        let mut session_id = fallback_session;
-        let mut current_model: Option<String> = None;
-        // `session_meta.cwd` 是会话起始目录，`turn_context.cwd` 是当轮实际目录
-        // （用户中途换目录时只有后者会变）。按事件发生时的值记录。
-        let mut current_cwd: Option<String> = None;
-        let mut previous: Option<TokenVector> = None;
-        // Codex Desktop fork/subagent files replay the parent thread's history
-        // (including its cumulative token_count events) before the first live
-        // turn. Those replayed counters are already ledgered under the parent
-        // session, so counting them again would double-count. The replay never
-        // contains turn_context lines, so the first turn_context marks live data.
-        let mut in_fork_replay = false;
-        let mut pending_events: Vec<PendingEvent> = Vec::new();
-        let mut quotas = Vec::new();
-        let mut diagnostics = ScanDiagnostics::default();
+    fn has_pending(&self, candidate: &SourceCandidate) -> bool {
+        CHECKPOINT.lock().ok().is_some_and(|state| {
+            state
+                .as_ref()
+                .is_some_and(|state| state.candidate.source_id == candidate.source_id)
+        })
+    }
+
+    fn parse_until(
+        &self,
+        candidate: &SourceCandidate,
+        cutoff_ms: i64,
+        deadline: Instant,
+    ) -> Result<Option<ParsedScan>> {
+        self.parse_slice(candidate, cutoff_ms, Some(deadline))
+    }
+}
+
+impl CodexAdapter {
+    fn parse_slice(
+        &self,
+        candidate: &SourceCandidate,
+        cutoff_ms: i64,
+        deadline: Option<Instant>,
+    ) -> Result<Option<ParsedScan>> {
+        let local = Mutex::new(None);
+        let checkpoint_store = if deadline.is_some() {
+            &CHECKPOINT
+        } else {
+            &local
+        };
+        let mut checkpoint = checkpoint_store
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Codex scan lock poisoned"))?;
+        // Keep one interrupted source in memory. Growing append-only rollouts
+        // finish their captured prefix before a later refresh reads new bytes.
+        let resumed = checkpoint.take().filter(|state| {
+            state.candidate.source_id == candidate.source_id
+                && state.cutoff_ms <= cutoff_ms
+                && (candidate.size > state.candidate.size
+                    || (candidate.size == state.candidate.size
+                        && candidate.mtime_ns == state.candidate.mtime_ns))
+        });
+        let Checkpoint {
+            candidate,
+            cutoff_ms,
+            mut reader,
+            mut session_id,
+            mut current_model,
+            mut current_cwd,
+            mut previous,
+            mut in_fork_replay,
+            mut pending_events,
+            mut quotas,
+            mut diagnostics,
+        } = match resumed {
+            Some(state) => state,
+            None => {
+                let file = File::open(&candidate.path)
+                    .with_context(|| format!("failed to open {}", candidate.path.display()))?;
+                Checkpoint {
+                    candidate: candidate.clone(),
+                    cutoff_ms,
+                    reader: BufReader::with_capacity(256 * 1024, file.take(candidate.size)),
+                    session_id: candidate
+                        .path
+                        .file_stem()
+                        .and_then(|v| v.to_str())
+                        .unwrap_or("unknown-session")
+                        .to_owned(),
+                    current_model: None,
+                    current_cwd: None,
+                    previous: None,
+                    in_fork_replay: false,
+                    pending_events: Vec::new(),
+                    quotas: Vec::new(),
+                    diagnostics: ScanDiagnostics::default(),
+                }
+            }
+        };
         let track_skipped_lines = candidate.mtime_ns / 1_000_000 >= cutoff_ms;
-
-        for line in reader.lines() {
+        loop {
+            if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+                *checkpoint = Some(Checkpoint {
+                    candidate,
+                    cutoff_ms,
+                    reader,
+                    session_id,
+                    current_model,
+                    current_cwd,
+                    previous,
+                    in_fork_replay,
+                    pending_events,
+                    quotas,
+                    diagnostics,
+                });
+                return Ok(None);
+            }
+            let Some(line) = reader.by_ref().lines().next() else {
+                break;
+            };
             let line = match line {
                 Ok(line) => line,
                 Err(_) => {
@@ -224,6 +321,15 @@ impl AgentAdapter for CodexAdapter {
                             diagnostics.total_mismatches += 1;
                         }
                         let delta = current.positive_delta(previous.as_ref());
+                        // A missed group of requests cannot select one pricing tier.
+                        let request_input_tokens =
+                            info.last_token_usage.as_ref().and_then(|last| {
+                                (last.input_tokens == delta.input_uncached + delta.cache_read
+                                    && last.cached_input_tokens == delta.cache_read
+                                    && last.output_tokens == delta.output
+                                    && last.input_tokens >= 0)
+                                    .then_some(last.input_tokens)
+                            });
                         // Replayed counters still advance the baseline so the first
                         // live delta only counts the fork's own increment.
                         previous = Some(current.clone());
@@ -243,6 +349,7 @@ impl AgentAdapter for CodexAdapter {
                                 model,
                                 tokens: delta,
                                 cwd: current_cwd.clone(),
+                                request_input_tokens,
                             });
                         }
                     }
@@ -268,7 +375,7 @@ impl AgentAdapter for CodexAdapter {
             .into_iter()
             .map(|pending| {
                 let event_key = format!("{session_id}:{}", pending.fingerprint);
-                UsageEvent::new(
+                let mut event = UsageEvent::new(
                     self.id(),
                     event_key,
                     pending.timestamp,
@@ -277,11 +384,13 @@ impl AgentAdapter for CodexAdapter {
                     pending.tokens,
                     "cumulative_delta",
                 )
-                .with_project(pending.cwd)
+                .with_project(pending.cwd);
+                event.request_input_tokens = pending.request_input_tokens;
+                event
             })
             .collect();
 
-        Ok(ParsedScan {
+        Ok(Some(ParsedScan {
             source: ParsedSource {
                 source_id: candidate.source_id.clone(),
                 adapter_id: self.id(),
@@ -293,7 +402,7 @@ impl AgentAdapter for CodexAdapter {
                 quotas,
             },
             diagnostics,
-        })
+        }))
     }
 }
 
@@ -328,6 +437,61 @@ fn parse_quota_windows(rate_limits: RateLimits, timestamp: i64, source: &str) ->
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn bounded_scan_resumes_and_pricing_requires_matching_request_evidence() {
+        let path = std::env::temp_dir().join(format!("metrik-resume-{}.jsonl", std::process::id()));
+        let mut file = File::create(&path).unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"session_meta","payload":{{"id":"resume"}}}}"#
+        )
+        .unwrap();
+        for index in 1..=10_000 {
+            writeln!(file, "").unwrap();
+            let last = if index == 2 { 1 } else { 30 };
+            writeln!(file, r#"{{"timestamp":"2026-09-05T00:00:00Z","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":{},"total_tokens":{}}},"last_token_usage":{{"input_tokens":{last}}}}}}}}}"#, index * 30, index * 30).unwrap();
+        }
+        drop(file);
+        let candidate = SourceCandidate {
+            source_id: path.display().to_string(),
+            path: path.clone(),
+            size: path.metadata().unwrap().len(),
+            mtime_ns: 1,
+        };
+        let adapter = CodexAdapter::with_roots(vec![]);
+        let full = adapter.parse(&candidate, 0).unwrap();
+        assert_eq!(full.source.events[0].request_input_tokens, Some(30));
+        assert_eq!(full.source.events[1].request_input_tokens, None);
+        assert!(adapter
+            .parse_until(&candidate, 0, Instant::now())
+            .unwrap()
+            .is_none());
+        assert!(adapter.has_pending(&candidate));
+        let mut slices = 0;
+        let resumed = loop {
+            slices += 1;
+            assert!(slices < 2000, "scan must make progress");
+            if let Some(scan) = adapter
+                .parse_until(
+                    &candidate,
+                    1,
+                    Instant::now() + std::time::Duration::from_millis(1),
+                )
+                .unwrap()
+            {
+                break scan;
+            }
+        };
+        assert!(slices > 1);
+        assert_eq!(resumed.source.events.len(), full.source.events.len());
+        for (a, b) in resumed.source.events.iter().zip(&full.source.events) {
+            assert_eq!(a.event_id, b.event_id);
+            assert_eq!(a.tokens, b.tokens);
+        }
+        assert!(!adapter.has_pending(&candidate));
+        std::fs::remove_file(path).unwrap();
+    }
 
     #[test]
     fn cumulative_snapshots_become_positive_deltas_without_double_counting() {

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -107,6 +107,18 @@ pub trait AgentAdapter: Send + Sync {
     fn id(&self) -> &'static str;
     fn discover(&self, cutoff_ms: i64) -> Vec<SourceCandidate>;
     fn parse(&self, candidate: &SourceCandidate, cutoff_ms: i64) -> Result<ParsedScan>;
+    fn has_pending(&self, _candidate: &SourceCandidate) -> bool {
+        false
+    }
+    /// Return None when the parsing budget expires; the adapter retains progress.
+    fn parse_until(
+        &self,
+        candidate: &SourceCandidate,
+        cutoff_ms: i64,
+        _deadline: std::time::Instant,
+    ) -> Result<Option<ParsedScan>> {
+        self.parse(candidate, cutoff_ms).map(Some)
+    }
     /// 已知存在、但当前版本读不了的存储形态（例：OpenCode 1.2+ 改用 SQLite）。
     /// 非空时该 Agent 的覆盖必须标为"部分"并把原因展示给用户——此时显示的 0
     /// 是"读不到"，不是"没用过"，静默显示 0 违反诚实约束。默认没有。

--- a/src-tauri/src/app_server.rs
+++ b/src-tauri/src/app_server.rs
@@ -11,10 +11,48 @@ pub fn read_codex_quota(timeout: Duration) -> Result<Vec<QuotaSample>> {
     read_codex_quota_with_command(codex_app_server_command(), timeout)
 }
 
-fn read_codex_quota_with_command(
-    mut command: Command,
-    timeout: Duration,
-) -> Result<Vec<QuotaSample>> {
+fn read_codex_quota_with_command(command: Command, timeout: Duration) -> Result<Vec<QuotaSample>> {
+    Ok(parse_rate_limits(&read_usage_with_command(
+        command, timeout,
+    )?))
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResetCreditsView {
+    pub available_count: Option<i64>,
+    pub next_known_expiry_ms: Option<i64>,
+}
+
+pub fn read_reset_credits(timeout: Duration) -> Result<ResetCreditsView> {
+    let result = read_usage_with_command(codex_app_server_command(), timeout)?;
+    Ok(parse_reset_credits(&result, chrono::Utc::now().timestamp()))
+}
+
+fn parse_reset_credits(result: &Value, now_secs: i64) -> ResetCreditsView {
+    let summary = result.get("rateLimitResetCredits");
+    let available_count = summary
+        .and_then(|value| value.get("availableCount"))
+        .and_then(Value::as_i64)
+        .filter(|count| *count >= 0);
+    let next_known_expiry_ms = summary
+        .and_then(|value| value.get("credits"))
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|credit| credit.get("status").and_then(Value::as_str) == Some("available"))
+        .filter_map(|credit| credit.get("expiresAt").and_then(Value::as_i64))
+        .filter(|expiry| *expiry > now_secs)
+        .min()
+        .and_then(|expiry| expiry.checked_mul(1000))
+        .filter(|_| available_count.is_some_and(|count| count > 0));
+    ResetCreditsView {
+        available_count,
+        next_known_expiry_ms,
+    }
+}
+
+fn read_usage_with_command(mut command: Command, timeout: Duration) -> Result<Value> {
     if std::env::var_os("METRIK_DEBUG").is_some() {
         eprintln!("app-server command: {command:?}");
     }
@@ -99,7 +137,7 @@ fn read_codex_quota_with_command(
     child.terminate();
 
     let result = result.context("codex app-server quota request timed out")?;
-    Ok(parse_rate_limits(&result))
+    Ok(result)
 }
 
 struct ManagedChild {
@@ -304,6 +342,29 @@ fn integer(value: &Value) -> Option<i64> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn reset_credits_preserve_missing_count_and_ignore_unavailable_expiries() {
+        use serde_json::json;
+        assert_eq!(
+            super::parse_reset_credits(&json!({}), 100).available_count,
+            None
+        );
+        assert_eq!(
+            super::parse_reset_credits(&json!({"rateLimitResetCredits":{"availableCount":0}}), 100)
+                .available_count,
+            Some(0)
+        );
+        let value = json!({"rateLimitResetCredits":{"availableCount":5,"credits":[
+            {"status":"redeemed","expiresAt":150},
+            {"status":"available","expiresAt":90},
+            {"status":"available","expiresAt":300},
+            {"status":"available","expiresAt":200}
+        ]}});
+        let parsed = super::parse_reset_credits(&value, 100);
+        assert_eq!(parsed.available_count, Some(5));
+        assert_eq!(parsed.next_known_expiry_ms, Some(200_000));
+    }
+
     use super::*;
 
     #[test]

--- a/src-tauri/src/claude_oauth.rs
+++ b/src-tauri/src/claude_oauth.rs
@@ -163,16 +163,18 @@ struct UsageResponse {
 #[derive(Deserialize)]
 struct UsageWindow {
     /// 已用百分比（0–100）。
-    utilization: Option<f64>,
-    /// ISO-8601 重置时刻。
-    resets_at: Option<String>,
+    utilization: Option<serde_json::Value>,
+    /// ISO-8601 或 Unix 秒/毫秒重置时刻。
+    resets_at: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
 struct LimitEntry {
+    kind: Option<String>,
+    group: Option<String>,
     /// 已用百分比（0–100），与 UsageWindow.utilization 同义。
-    percent: Option<f64>,
-    resets_at: Option<String>,
+    percent: Option<serde_json::Value>,
+    resets_at: Option<serde_json::Value>,
     scope: Option<LimitScope>,
     is_active: Option<bool>,
 }
@@ -180,6 +182,7 @@ struct LimitEntry {
 #[derive(Deserialize)]
 struct LimitScope {
     model: Option<LimitScopeModel>,
+    surface: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -191,24 +194,33 @@ struct LimitScopeModel {
 struct ExtraUsage {
     is_enabled: Option<bool>,
     /// 已用超额预算的百分比（0–100）。
-    utilization: Option<f64>,
+    utilization: Option<serde_json::Value>,
 }
 
 impl LimitEntry {
-    /// 归一成与平铺字段一致的窗口键：`seven_day_<模型名小写>`。
-    /// 只认带模型 scope 的条目——不带 scope 的总量窗口平铺字段已经覆盖，
-    /// 而 limits[] 里的分类键（kind/group）尚不稳定，不猜。
+    /// 按明确的周期和模型分类；未知或限定使用入口的窗口不能当作账户总量。
     fn window_key(&self) -> Option<String> {
-        if self.is_active == Some(false) {
+        let kind = self.kind.as_deref().unwrap_or_default();
+        let group = self.group.as_deref().unwrap_or_default();
+        let scope = self.scope.as_ref();
+        if scope.is_some_and(|scope| scope.surface.is_some()) {
             return None;
         }
-        let name = self
-            .scope
-            .as_ref()?
-            .model
-            .as_ref()?
-            .display_name
-            .as_deref()?;
+        let model = scope.and_then(|scope| scope.model.as_ref());
+        if kind == "session" && (group.is_empty() || group == "session") && model.is_none() {
+            return Some("five_hour".into());
+        }
+        let legacy_model_scope = kind.is_empty() && group.is_empty() && model.is_some();
+        if !legacy_model_scope
+            && (group != "weekly" || !matches!(kind, "weekly" | "weekly_all" | "weekly_scoped"))
+        {
+            return None;
+        }
+        let Some(model) = model else {
+            return matches!(kind, "weekly" | "weekly_all").then(|| "seven_day".into());
+        };
+        let name = model.display_name.as_deref()?.trim();
+        let name = name.strip_prefix("Claude ").unwrap_or(name);
         let slug = name
             .trim()
             .to_lowercase()
@@ -485,6 +497,10 @@ fn samples_from_usage(usage: UsageResponse, now: i64) -> Vec<QuotaSample> {
         let Some(key) = entry.window_key() else {
             continue;
         };
+        if entry.is_active == Some(false) {
+            windows.retain(|(existing_key, _)| *existing_key != key);
+            continue;
+        }
         let window = UsageWindow {
             utilization: entry.percent,
             resets_at: entry.resets_at,
@@ -515,15 +531,18 @@ fn samples_from_usage(usage: UsageResponse, now: i64) -> Vec<QuotaSample> {
     windows
         .into_iter()
         .filter_map(|(key, window)| {
-            let used = window.utilization?;
+            let used = quota_number(window.utilization.as_ref()?)?;
+            if !(0.0..=100.0).contains(&used) {
+                return None;
+            }
             Some(QuotaSample {
                 adapter_id: "claude",
                 window_key: key.clone(),
                 remaining_percent: (100.0 - used).clamp(0.0, 100.0),
                 resets_at_ms: window
                     .resets_at
-                    .as_deref()
-                    .and_then(parse_iso8601_ms)
+                    .as_ref()
+                    .and_then(parse_reset_ms)
                     .and_then(|value| sane_resets_at_ms(&key, value, now)),
                 collected_at_ms: now,
                 source_label: SOURCE_LABEL.to_owned(),
@@ -531,6 +550,26 @@ fn samples_from_usage(usage: UsageResponse, now: i64) -> Vec<QuotaSample> {
             })
         })
         .collect()
+}
+
+fn quota_number(value: &serde_json::Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_str()?.parse().ok())
+        .filter(|value| value.is_finite())
+}
+
+fn parse_reset_ms(value: &serde_json::Value) -> Option<i64> {
+    if let Some(parsed) = value.as_str().and_then(parse_iso8601_ms) {
+        return Some(parsed);
+    }
+    let timestamp = quota_number(value)?;
+    let millis = if timestamp.abs() < 100_000_000_000.0 {
+        timestamp * 1000.0
+    } else {
+        timestamp
+    };
+    (millis > 0.0 && millis < i64::MAX as f64).then_some(millis as i64)
 }
 
 fn parse_iso8601_ms(value: &str) -> Option<i64> {
@@ -815,20 +854,88 @@ attributes:
             .map(|sample| sample.window_key.as_str())
             .collect::<Vec<_>>();
         // 同键覆盖（opus 用 limits 值）、新增 scoped 模型（fable）、
-        // 跳过 is_active=false（haiku）与不带模型 scope 的条目、追加超额付费。
+        // 跳过 is_active=false（haiku）、识别总周限、追加超额付费。
         assert_eq!(
             keys,
             vec![
                 "five_hour",
                 "seven_day_opus",
                 "seven_day_fable",
+                "seven_day",
                 "extra_usage"
             ],
         );
         let opus = &samples[1];
         assert_eq!(opus.remaining_percent, 70.0);
         assert_eq!(opus.resets_at_ms, parse_iso8601_ms("2026-07-18T21:00:00Z"));
-        assert_eq!(samples[3].remaining_percent, 92.5);
+        assert_eq!(samples[4].remaining_percent, 92.5);
+    }
+
+    #[test]
+    fn array_only_windows_keep_percentage_units_and_parse_reset_formats() {
+        let usage = serde_json::from_value(serde_json::json!({"limits": [
+            {"kind":"session", "group":"session", "percent":0.5, "resets_at":1784007000},
+            {"kind":"weekly_all", "group":"weekly", "percent":"18", "resets_at":"1784322000000"},
+            {"kind":"weekly_scoped", "group":"weekly", "percent":9,
+             "scope":{"model":{"display_name":"Claude Sonnet"},"surface":null}}
+        ]}))
+        .unwrap();
+        let samples = samples_from_usage(usage, 1_783_987_200_000);
+        assert_eq!(samples.len(), 3);
+        assert_eq!(samples[0].remaining_percent, 99.5);
+        assert_eq!(samples[0].resets_at_ms, Some(1_784_007_000_000));
+        assert_eq!(samples[1].window_key, "seven_day");
+        assert_eq!(samples[1].remaining_percent, 82.0);
+        assert_eq!(samples[1].resets_at_ms, Some(1_784_322_000_000));
+        assert_eq!(samples[2].window_key, "seven_day_sonnet");
+    }
+
+    #[test]
+    fn inactive_windows_remove_flat_fallback_and_unknown_scopes_do_not_become_totals() {
+        let usage = serde_json::from_value(serde_json::json!({
+            "five_hour":{"utilization":10}, "seven_day":{"utilization":20},
+            "seven_day_sonnet":{"utilization":30},
+            "limits":[
+                {"kind":"weekly_all","group":"weekly","percent":0,"is_active":false},
+                {"kind":"weekly_scoped","group":"weekly","is_active":false,
+                 "scope":{"model":{"display_name":"Sonnet"}}},
+                {"kind":"weekly_scoped","group":"weekly","percent":90},
+                {"kind":"weekly_all","group":"weekly","percent":90,
+                 "scope":{"surface":{"display_name":"Cowork"}}},
+                {"kind":"future_kind","group":"weekly","percent":90}
+            ]
+        }))
+        .unwrap();
+        let samples = samples_from_usage(usage, 1_783_987_200_000);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].window_key, "five_hour");
+    }
+
+    #[test]
+    fn invalid_or_missing_percentages_do_not_become_zero_usage() {
+        for percent in [
+            serde_json::Value::Null,
+            serde_json::json!("bad"),
+            serde_json::json!(-1),
+            serde_json::json!(101),
+        ] {
+            let usage = serde_json::from_value(serde_json::json!({"limits":[
+                {"kind":"session","group":"session","percent":percent}
+            ]}))
+            .unwrap();
+            assert!(samples_from_usage(usage, 1_783_987_200_000).is_empty());
+        }
+    }
+
+    #[test]
+    fn model_only_legacy_entry_remains_supported() {
+        let usage = serde_json::from_value(serde_json::json!({"limits":[
+            {"percent":25,"scope":{"model":{"display_name":"Fable"}}}
+        ]}))
+        .unwrap();
+        let samples = samples_from_usage(usage, 1_783_987_200_000);
+        assert_eq!(samples[0].window_key, "seven_day_fable");
+        assert_eq!(samples[0].remaining_percent, 75.0);
     }
 
     #[test]

--- a/src-tauri/src/domain.rs
+++ b/src-tauri/src/domain.rs
@@ -104,6 +104,8 @@ pub struct UsageEvent {
     /// 现有账本在解析器升级后重扫时会对同一 event_id 算出不同的 hash，而
     /// 非合并型 adapter（Codex/Kimi 等）遇到 hash 不一致就报身份冲突。
     pub project_path: Option<String>,
+    /// Validated single-request input size; never a session or period total.
+    pub request_input_tokens: Option<i64>,
 }
 
 impl UsageEvent {
@@ -138,6 +140,7 @@ impl UsageEvent {
             quality,
             payload_hash,
             project_path: None,
+            request_input_tokens: None,
         }
     }
 

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -71,6 +71,7 @@ struct StoredEvent {
     cache_read: i64,
     cache_write: i64,
     output: i64,
+    request_input_tokens: Option<i64>,
 }
 
 /// 一个 Agent 在周期内的 processed token 分量拆解。远端同步事件不带分量，
@@ -106,6 +107,7 @@ struct StoredSessionEvent {
     cache_write: i64,
     output: i64,
     project: Option<String>,
+    request_input_tokens: Option<i64>,
 }
 
 #[derive(Default)]
@@ -156,8 +158,16 @@ struct CostAccrual {
 }
 
 impl CostAccrual {
-    fn add(&mut self, model: Option<&str>, occurred_at_ms: i64, comps: &TokenComponents) {
-        match model.and_then(|model| pricing::price_for(model, occurred_at_ms)) {
+    fn add(
+        &mut self,
+        model: Option<&str>,
+        occurred_at_ms: i64,
+        comps: &TokenComponents,
+        request_input_tokens: Option<i64>,
+    ) {
+        match model.and_then(|model| {
+            pricing::price_for_request(model, occurred_at_ms, request_input_tokens)
+        }) {
             Some(price) => {
                 self.priced_any = true;
                 self.usd += comps.input_uncached as f64 * price.input / 1_000_000.0
@@ -475,7 +485,8 @@ fn sessions_at(
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty());
-        agg.cost.add(model, event.timestamp, &comps);
+        agg.cost
+            .add(model, event.timestamp, &comps, event.request_input_tokens);
         if let Some(model) = model {
             agg.model_components
                 .entry(model.to_owned())
@@ -552,7 +563,7 @@ fn load_session_events(
     let mut statement = connection.prepare(
         "SELECT adapter_id, session_id, occurred_at_ms, model,
                 input_uncached_tokens, cache_read_tokens, cache_write_tokens, output_tokens,
-                project_path
+                project_path, request_input_tokens
          FROM usage_event
          WHERE occurred_at_ms >= ?1 AND occurred_at_ms < ?2
          ORDER BY occurred_at_ms",
@@ -568,6 +579,7 @@ fn load_session_events(
             cache_write: row.get(6)?,
             output: row.get(7)?,
             project: row.get(8)?,
+            request_input_tokens: row.get(9)?,
         })
     })?;
     Ok(rows.filter_map(Result::ok).collect())
@@ -649,7 +661,8 @@ fn projects_at(
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty());
-        agg.cost.add(model, event.timestamp, &comps);
+        agg.cost
+            .add(model, event.timestamp, &comps, event.request_input_tokens);
         if let Some(model) = model {
             agg.model_components
                 .entry(model.to_owned())
@@ -785,7 +798,12 @@ fn ingest_sources(connection: &mut Connection, horizon_ms: i64) -> Result<ScanRe
     }
 
     // 最近改动的先解析：当前周期的数字最先变准，历史从近端往回填。
-    queue.sort_by_key(|(_, candidate)| Reverse(candidate.mtime_ns));
+    queue.sort_by_key(|(index, candidate)| {
+        (
+            !adapters[*index].has_pending(candidate),
+            Reverse(candidate.mtime_ns),
+        )
+    });
     let deadline = Instant::now() + PARSE_BUDGET;
     for (index, candidate) in &queue {
         if Instant::now() >= deadline {
@@ -798,6 +816,7 @@ fn ingest_sources(connection: &mut Connection, horizon_ms: i64) -> Result<ScanRe
             candidate,
             horizon_ms,
             &mut report,
+            deadline,
         )?;
     }
 
@@ -810,9 +829,11 @@ fn ingest_candidate(
     candidate: &SourceCandidate,
     horizon_ms: i64,
     report: &mut ScanReport,
+    deadline: Instant,
 ) -> Result<()> {
-    match adapter.parse(candidate, horizon_ms) {
-        Ok(scan) => {
+    match adapter.parse_until(candidate, horizon_ms, deadline) {
+        Ok(None) => report.backfill_pending += 1,
+        Ok(Some(scan)) => {
             let mut diagnostics = scan.diagnostics;
             if let Ok(outcome) = storage::replace_source(connection, &scan.source, horizon_ms) {
                 diagnostics.rejected_events += outcome.rejected_events;
@@ -958,6 +979,7 @@ fn query_snapshot_at(
             model,
             event.timestamp,
             &event_comps,
+            event.request_input_tokens,
         );
     }
 
@@ -1140,12 +1162,12 @@ fn load_events(connection: &Connection, start_ms: i64, end_ms: i64) -> Result<Ve
     // 的 "unknown" 区分开，而不是混在一起被误读成一个叫"未标注"的模型。
     let mut statement = connection.prepare(
         "SELECT adapter_id, occurred_at_ms, processed_tokens, model,
-                input_uncached_tokens, cache_read_tokens, cache_write_tokens, output_tokens
+                input_uncached_tokens, cache_read_tokens, cache_write_tokens, output_tokens, request_input_tokens
          FROM usage_event
          WHERE occurred_at_ms >= ?1 AND occurred_at_ms < ?2
          UNION ALL
          SELECT adapter_id, occurred_at_ms, processed_tokens, 'synced-remote' AS model,
-                0, 0, 0, 0
+                0, 0, 0, 0, NULL
          FROM remote_usage_event
          WHERE occurred_at_ms >= ?1 AND occurred_at_ms < ?2
          ORDER BY occurred_at_ms",
@@ -1160,6 +1182,7 @@ fn load_events(connection: &Connection, start_ms: i64, end_ms: i64) -> Result<Ve
             cache_read: row.get(5)?,
             cache_write: row.get(6)?,
             output: row.get(7)?,
+            request_input_tokens: row.get(8)?,
         })
     })?;
     Ok(rows.filter_map(Result::ok).collect())
@@ -2555,7 +2578,11 @@ mod tests {
                      source_id, adapter_id, logical_key, locator, observed_size,
                      mtime_ns, coverage_start_ms, parser_version, last_success_ms, last_error
                  ) VALUES ('source', 'codex', 'source', 'rollout.jsonl', 10, 1, ?1, ?2, ?3, NULL)",
-                params![horizon_at_parse, storage::PARSER_VERSION, parsed_at],
+                params![
+                    horizon_at_parse,
+                    storage::parser_version_for("codex"),
+                    parsed_at
+                ],
             )
             .unwrap();
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod pinned_hover;
 mod pricing;
 mod projects;
 mod quota;
+mod quota_alerts;
 mod schema;
 mod storage;
 mod sync;
@@ -405,6 +406,7 @@ async fn usage_snapshot(
     period: String,
     force: Option<bool>,
     widget_agents: Option<Vec<String>>,
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
 ) -> Result<UsageSnapshot, String> {
     let database_path = state.database_path.clone();
@@ -422,6 +424,25 @@ async fn usage_snapshot(
             force.unwrap_or(false),
         )
         .map_err(|error| error.to_string())?;
+
+        if let Err(error) = storage::open_database(&database_path).and_then(|connection| {
+            quota_alerts::check(
+                &connection,
+                &snapshot.agent_quotas,
+                chrono::Utc::now().timestamp_millis(),
+                |body| {
+                    use tauri_plugin_notification::NotificationExt;
+                    app.notification()
+                        .builder()
+                        .title("Metrik · 额度提醒")
+                        .body(body)
+                        .show()?;
+                    Ok(())
+                },
+            )
+        }) {
+            eprintln!("Metrik quota notification failed: {error}");
+        }
 
         // WidgetKit 只存在于 macOS；其它平台上这个参数没有消费者，
         // 显式标记已读，避免 clippy 的 unused-variables 报警。
@@ -475,6 +496,55 @@ async fn usage_snapshot(
     })
     .await
     .map_err(|error| format!("usage scan task failed: {error}"))?
+}
+
+#[tauri::command]
+async fn quota_alert_settings(state: State<'_, AppState>) -> Result<bool, String> {
+    let path = state.database_path.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        storage::open_database(&path)
+            .and_then(|db| quota_alerts::enabled(&db))
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+async fn codex_reset_credits(
+    state: State<'_, AppState>,
+) -> Result<app_server::ResetCreditsView, String> {
+    let gate = Arc::clone(&state.scan_gate);
+    tauri::async_runtime::spawn_blocking(move || {
+        let _guard = gate
+            .lock()
+            .map_err(|_| "usage scan lock poisoned".to_owned())?;
+        app_server::read_reset_credits(std::time::Duration::from_secs(15))
+            .map_err(|_| "Codex 重置券查询失败，请确认 Codex 已登录后重试。".to_owned())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+async fn set_quota_alerts(enabled: bool, state: State<'_, AppState>) -> Result<bool, String> {
+    let path = state.database_path.clone();
+    let gate = Arc::clone(&state.scan_gate);
+    tauri::async_runtime::spawn_blocking(move || {
+        let _guard = gate
+            .lock()
+            .map_err(|_| "usage scan lock poisoned".to_owned())?;
+        let db = storage::open_database(&path).map_err(|error| error.to_string())?;
+        storage::set_app_setting(
+            &db,
+            quota_alerts::ENABLED_KEY,
+            if enabled { "1" } else { "0" },
+        )
+        .map_err(|error| error.to_string())?;
+        Ok(enabled)
+    })
+    .await
+    .map_err(|error| error.to_string())?
 }
 
 /// 设置窗口显式提交 macOS Agent 选择。它是唯一允许覆盖已保存选择的通道；
@@ -1439,7 +1509,9 @@ fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // 前端窗口形态必须使用编译期真实平台，不能依赖 WebView user-agent。
-    let builder = tauri::Builder::default().plugin(tauri_plugin_os::init());
+    let builder = tauri::Builder::default()
+        .plugin(tauri_plugin_os::init())
+        .plugin(tauri_plugin_notification::init());
 
     #[cfg(target_os = "macos")]
     let builder = builder.plugin(tauri_nspanel::init());
@@ -1590,6 +1662,9 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             usage_snapshot,
+            quota_alert_settings,
+            set_quota_alerts,
+            codex_reset_credits,
             usage_report,
             usage_sessions,
             usage_projects,

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -199,6 +199,26 @@ pub fn price_for(model: &str, occurred_at_ms: i64) -> Option<Pricing> {
     })
 }
 
+/// https://developers.openai.com/api/docs/models/gpt-6-astra (2026-09-05).
+/// Only validated request sizes select the long-context tier; missing evidence
+/// retains the base estimate rather than using cumulative session counters.
+pub fn price_for_request(
+    model: &str,
+    occurred_at_ms: i64,
+    request_input_tokens: Option<i64>,
+) -> Option<Pricing> {
+    let mut price = price_for(model, occurred_at_ms)?;
+    if resolve(model)?.0 == "gpt-6-astra"
+        && request_input_tokens.is_some_and(|input| input > 272_000)
+    {
+        price.input *= 2.0;
+        price.cache_read *= 2.0;
+        price.cache_write *= 2.0;
+        price.output *= 1.5;
+    }
+    Some(price)
+}
+
 /// 归一到表里的规范名，连同标准价一起返回。规范名（而不是调用方传进来的
 /// 别名）才是查分时定价的依据。
 fn resolve(model: &str) -> Option<(&str, Pricing)> {
@@ -274,6 +294,37 @@ fn strip_date_suffix(model: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn astra_request_boundary_and_missing_evidence() {
+        for input in [None, Some(272_000), Some(-1)] {
+            let price = price_for_request("gpt-6-astra", 0, input).unwrap();
+            assert_eq!(
+                (
+                    price.input,
+                    price.cache_read,
+                    price.cache_write,
+                    price.output
+                ),
+                (10.0, 1.0, 12.5, 50.0)
+            );
+        }
+        let price = price_for_request("gpt-6-astra", 0, Some(272_001)).unwrap();
+        assert_eq!(
+            (
+                price.input,
+                price.cache_read,
+                price.cache_write,
+                price.output
+            ),
+            (20.0, 2.0, 25.0, 75.0)
+        );
+        assert!(price_for_request("other/gpt-6-astra", 0, Some(300_000)).is_none());
+        assert_eq!(
+            price_for_request("gpt-5", 0, Some(300_000)).unwrap().input,
+            price_for("gpt-5", 0).unwrap().input
+        );
+    }
 
     /// 峰谷之外的模型全天一价，用哪个时刻都一样；固定一个（2026-08-20 12:30
     /// UTC）省得每条断言各写各的。

--- a/src-tauri/src/quota.rs
+++ b/src-tauri/src/quota.rs
@@ -115,7 +115,77 @@ pub trait QuotaProvider: Send + Sync {
 }
 
 /// adapter 每次快照都重建，故缓存不能放 provider 里，必须由调用方跨快照持有。
-pub type QuotaCache = Mutex<HashMap<&'static str, (Instant, Vec<QuotaSample>)>>;
+pub type QuotaCache = Mutex<HashMap<&'static str, (Instant, String, Vec<QuotaSample>)>>;
+
+// Only a digest is stored locally; raw account identifiers stay in their source.
+fn account_scope(adapter: &str) -> String {
+    let home = dirs::home_dir().unwrap_or_default();
+    let (path, pointers) = match adapter {
+        "codex" => (
+            std::env::var_os("CODEX_HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| home.join(".codex"))
+                .join("auth.json"),
+            vec!["/tokens/account_id", "/OPENAI_API_KEY"],
+        ),
+        "claude" => {
+            if let Ok(token) = std::env::var("CLAUDE_CODE_OAUTH_TOKEN") {
+                if !token.trim().is_empty() {
+                    return crate::domain::stable_hash(&token);
+                }
+            }
+            let path = std::env::var_os("CLAUDE_CONFIG_DIR")
+                .map(|dir| std::path::PathBuf::from(dir).join(".claude.json"))
+                .unwrap_or_else(|| home.join(".claude.json"));
+            (
+                path,
+                vec![
+                    "/oauthAccount/accountUuid",
+                    "/oauthAccount/organizationUuid",
+                ],
+            )
+        }
+        _ => return "default".into(),
+    };
+    let value = std::fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok());
+    let identity: Vec<_> = pointers
+        .iter()
+        .filter_map(|pointer| {
+            value
+                .as_ref()?
+                .pointer(pointer)?
+                .as_str()
+                .filter(|s| !s.is_empty())
+        })
+        .collect();
+    crate::domain::stable_hash(&serde_json::to_string(&identity).unwrap_or_default())
+}
+
+fn accept_scope(connection: &Connection, adapter: &str, scope: &str) -> Result<i64> {
+    let key = format!("quota_scope_{adapter}");
+    let since_key = format!("quota_scope_since_{adapter}");
+    let previous = storage::get_app_setting(connection, &key)?;
+    if previous.as_deref() != Some(scope) {
+        let tx = connection.unchecked_transaction()?;
+        tx.execute(
+            "DELETE FROM quota_snapshot WHERE adapter_id = ?1",
+            [adapter],
+        )?;
+        storage::set_app_setting(&tx, &key, scope)?;
+        let since = if previous.is_some() {
+            chrono::Utc::now().timestamp_millis()
+        } else {
+            0
+        };
+        storage::set_app_setting(&tx, &since_key, &since.to_string())?;
+        tx.commit()?;
+    }
+    Ok(storage::get_app_setting(connection, &since_key)?
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0))
+}
 
 pub fn registry() -> Vec<Box<dyn QuotaProvider>> {
     let mut providers: Vec<Box<dyn QuotaProvider>> = vec![
@@ -164,36 +234,61 @@ impl QuotaProvider for GrokQuota {
 
 /// 取数并落库。engine 只调这一个。
 pub fn refresh_all(connection: &Connection, cache: &QuotaCache, force: bool) -> Result<()> {
-    let env = ProviderEnv::load(connection)?;
     for provider in registry() {
         let provider = provider.as_ref();
-        let mut samples = Vec::new();
-        if provider.is_available(&env) {
-            let outcome = cached_fetch(cache, provider, force);
-            match &outcome.failure {
-                Some(message) => provider.record_failure(connection, message)?,
-                // 缓存命中失败时返回的是"空且无错误"：既不留档也不清除，
-                // 上一条记录继续有效。
-                None if !outcome.samples.is_empty() => provider.clear_failure(connection)?,
-                None => {}
+        let scope = account_scope(provider.adapter_id());
+        let since = if matches!(provider.adapter_id(), "codex" | "claude") {
+            accept_scope(connection, provider.adapter_id(), &scope)?
+        } else {
+            0
+        };
+        let env = ProviderEnv::load(connection)?;
+        connection.execute(
+            "DELETE FROM quota_snapshot WHERE adapter_id = ?1 AND collected_at_ms < ?2",
+            rusqlite::params![provider.adapter_id(), since],
+        )?;
+        let cache_scope = format!("{scope}:{}", provider.is_available(&env));
+        let outcome = if provider.is_available(&env) {
+            cached_fetch(cache, provider, force, &cache_scope)
+        } else {
+            QuotaOutcome {
+                samples: Vec::new(),
+                failure: None,
             }
-            samples = outcome.samples;
-        }
+        };
+        let mut samples = outcome.samples;
         if samples.is_empty() {
             samples = provider.fallback();
+        }
+        samples.retain(|sample| sample.collected_at_ms >= since);
+        // Reject a request that outlived an account switch or settings edit.
+        let current_scope = account_scope(provider.adapter_id());
+        if current_scope != scope || ProviderEnv::load(connection)?.settings != env.settings {
+            if current_scope != scope {
+                accept_scope(connection, provider.adapter_id(), &current_scope)?;
+            }
+            if let Ok(mut guard) = cache.lock() {
+                guard.remove(provider.adapter_id());
+            }
+            continue;
+        }
+        match &outcome.failure {
+            Some(message) => provider.record_failure(connection, message)?,
+            None if !samples.is_empty() => provider.clear_failure(connection)?,
+            None => {}
         }
         if samples.is_empty() {
             continue;
         }
-        connection
-            .execute(
-                "DELETE FROM quota_snapshot WHERE adapter_id = ?1",
-                [provider.adapter_id()],
-            )
-            .with_context(|| format!("failed to clear {} quota rows", provider.adapter_id()))?;
+        let tx = connection.unchecked_transaction()?;
+        tx.execute(
+            "DELETE FROM quota_snapshot WHERE adapter_id = ?1",
+            [provider.adapter_id()],
+        )?;
         for sample in &samples {
-            storage::upsert_quota(connection, sample)?;
+            storage::upsert_quota(&tx, sample)?;
         }
+        tx.commit()?;
     }
     prune_unmanaged_quota_rows(connection)?;
     Ok(())
@@ -214,7 +309,12 @@ pub fn prune_unmanaged_quota_rows(connection: &Connection) -> Result<()> {
 
 /// 按 provider 的节奏取数并跨快照缓存。`force`（手动刷新）跳过新鲜缓存立即
 /// 重拉；失败路径与常规一致——写入空哨兵、保留库中旧行，绝不因强制刷新而删数据。
-fn cached_fetch(cache: &QuotaCache, provider: &dyn QuotaProvider, force: bool) -> QuotaOutcome {
+fn cached_fetch(
+    cache: &QuotaCache,
+    provider: &dyn QuotaProvider,
+    force: bool,
+    scope: &str,
+) -> QuotaOutcome {
     let policy = provider.policy();
     let Ok(mut guard) = cache.lock() else {
         // 锁中毒只可能来自别处的 panic，此时当作"这次没数据"：保留库中旧行，
@@ -225,13 +325,13 @@ fn cached_fetch(cache: &QuotaCache, provider: &dyn QuotaProvider, force: bool) -
         };
     };
     if !force {
-        if let Some((captured, cached)) = guard.get(provider.adapter_id()) {
+        if let Some((captured, cached_scope, cached)) = guard.get(provider.adapter_id()) {
             let ttl = if cached.is_empty() {
                 policy.empty_ttl
             } else {
                 policy.fresh_ttl
             };
-            if captured.elapsed() < ttl {
+            if cached_scope == scope && captured.elapsed() < ttl {
                 return QuotaOutcome {
                     samples: cached.clone(),
                     failure: None,
@@ -241,7 +341,10 @@ fn cached_fetch(cache: &QuotaCache, provider: &dyn QuotaProvider, force: bool) -
     }
     match provider.fetch(policy.timeout) {
         Ok(samples) => {
-            guard.insert(provider.adapter_id(), (Instant::now(), samples.clone()));
+            guard.insert(
+                provider.adapter_id(),
+                (Instant::now(), scope.to_owned(), samples.clone()),
+            );
             QuotaOutcome {
                 samples,
                 failure: None,
@@ -249,7 +352,10 @@ fn cached_fetch(cache: &QuotaCache, provider: &dyn QuotaProvider, force: bool) -
         }
         Err(error) => {
             // 来源不可用时不该让每次周期性刷新都付一次完整超时，空哨兵用更长的 TTL。
-            guard.insert(provider.adapter_id(), (Instant::now(), Vec::new()));
+            guard.insert(
+                provider.adapter_id(),
+                (Instant::now(), scope.to_owned(), Vec::new()),
+            );
             QuotaOutcome {
                 samples: Vec::new(),
                 failure: Some(error.to_string()),
@@ -341,6 +447,32 @@ mod tests {
             .execute_batch(include_str!("../migrations/001_init.sql"))
             .unwrap();
         connection
+    }
+
+    #[test]
+    fn account_switch_removes_only_that_accounts_quota_rows() {
+        let db = memory_ledger();
+        accept_scope(&db, "codex", "a").unwrap();
+        db.execute(
+            "INSERT INTO quota_snapshot VALUES ('codex','primary',5,NULL,1,'official_live','test')",
+            [],
+        )
+        .unwrap();
+        db.execute("INSERT INTO quota_snapshot VALUES ('claude','primary',50,NULL,1,'official_live','test')", []).unwrap();
+        accept_scope(&db, "codex", "a").unwrap();
+        assert_eq!(
+            db.query_row("SELECT COUNT(*) FROM quota_snapshot", [], |r| r
+                .get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
+        assert!(accept_scope(&db, "codex", "b").unwrap() > 0);
+        assert_eq!(
+            db.query_row("SELECT adapter_id FROM quota_snapshot", [], |r| r
+                .get::<_, String>(0))
+                .unwrap(),
+            "claude"
+        );
     }
 
     #[test]
@@ -464,18 +596,20 @@ mod tests {
         let cache: QuotaCache = Mutex::new(HashMap::new());
 
         // 第一次真的去拉，失败原因如实带回。
-        let first = cached_fetch(&cache, &provider, false);
+        let first = cached_fetch(&cache, &provider, false, "account-a");
         assert!(first.samples.is_empty());
         assert_eq!(first.failure.as_deref(), Some("来源不可用"));
 
         // 空哨兵在 TTL 内挡住重拉，且不再报错——上一条记录继续有效。
-        let second = cached_fetch(&cache, &provider, false);
+        let second = cached_fetch(&cache, &provider, false, "account-a");
         assert!(second.failure.is_none());
         assert_eq!(provider.calls.load(std::sync::atomic::Ordering::SeqCst), 1);
 
         // force 跳过缓存，立即重试。
-        let third = cached_fetch(&cache, &provider, true);
+        let third = cached_fetch(&cache, &provider, true, "account-a");
         assert_eq!(third.failure.as_deref(), Some("来源不可用"));
         assert_eq!(provider.calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+        cached_fetch(&cache, &provider, false, "account-b");
+        assert_eq!(provider.calls.load(std::sync::atomic::Ordering::SeqCst), 3);
     }
 }

--- a/src-tauri/src/quota_alerts.rs
+++ b/src-tauri/src/quota_alerts.rs
@@ -1,0 +1,205 @@
+//! Optional notifications from fresh quota snapshots. State is local and shared by all windows.
+use crate::{domain::AgentQuotaView, storage};
+use anyhow::Result;
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const ENABLED_KEY: &str = "quota_alerts_enabled";
+const STATE_KEY: &str = "quota_alerts_state";
+const LOW_REMAINING: f64 = 15.0;
+const COOLDOWN_MS: i64 = 6 * 60 * 60 * 1000;
+
+#[derive(Default, Deserialize, Serialize)]
+struct AlertState {
+    notified_low: bool,
+    last_sent_ms: Option<i64>,
+}
+
+pub fn enabled(connection: &Connection) -> Result<bool> {
+    Ok(storage::get_app_setting(connection, ENABLED_KEY)?.as_deref() == Some("1"))
+}
+
+pub fn check(
+    connection: &Connection,
+    quotas: &[AgentQuotaView],
+    now: i64,
+    mut send: impl FnMut(&str) -> Result<()>,
+) -> Result<()> {
+    if !enabled(connection)? {
+        return Ok(());
+    }
+    let raw = storage::get_app_setting(connection, STATE_KEY)?.unwrap_or_default();
+    let mut states: BTreeMap<String, AlertState> = serde_json::from_str(&raw).unwrap_or_default();
+    for quota in quotas {
+        let current: Vec<_> = quota
+            .windows
+            .iter()
+            .filter(|window| {
+                let view = &window.view;
+                view.available
+                    && !view.stale
+                    && !view.reset_expired
+                    && view.remaining_percent.is_finite()
+                    && matches!(view.quality.as_str(), "official_live" | "official_snapshot")
+            })
+            .collect();
+        if current.is_empty() {
+            continue;
+        }
+        let scope = storage::get_app_setting(connection, &format!("quota_scope_{}", quota.agent))?
+            .unwrap_or_else(|| "legacy".into());
+        let state = states
+            .entry(format!("{}:{scope}", quota.agent))
+            .or_default();
+        let low = current
+            .iter()
+            .filter(|window| window.view.remaining_percent <= LOW_REMAINING)
+            .min_by(|a, b| {
+                a.view
+                    .remaining_percent
+                    .total_cmp(&b.view.remaining_percent)
+            });
+        let Some(window) = low else {
+            // A partial/stale set cannot prove that all constraints recovered.
+            if current.len() == quota.windows.len() {
+                state.notified_low = false;
+            }
+            continue;
+        };
+        if state.notified_low
+            || state
+                .last_sent_ms
+                .is_some_and(|last| now.saturating_sub(last) < COOLDOWN_MS)
+        {
+            continue;
+        }
+        let name = match quota.agent.as_str() {
+            "codex" => "Codex",
+            "claude" => "Claude",
+            "zcode" => "GLM",
+            "kimi" => "Kimi",
+            "qoder" => "Qoder",
+            "workbuddy" => "WorkBuddy",
+            "grok" => "Grok",
+            "antigravity" => "Antigravity",
+            other => other,
+        };
+        send(&format!(
+            "{name} · {}：剩余 {:.1}%",
+            window.label, window.view.remaining_percent
+        ))?;
+        state.notified_low = true;
+        state.last_sent_ms = Some(now);
+        storage::set_app_setting(connection, STATE_KEY, &serde_json::to_string(&states)?)?;
+    }
+    let encoded = serde_json::to_string(&states)?;
+    if encoded != raw {
+        storage::set_app_setting(connection, STATE_KEY, &encoded)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{AgentQuotaWindow, QuotaView};
+
+    fn database() -> Connection {
+        let db = Connection::open_in_memory().unwrap();
+        db.execute_batch("CREATE TABLE app_setting (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            .unwrap();
+        db
+    }
+
+    fn quota(remaining: f64) -> AgentQuotaView {
+        AgentQuotaView {
+            agent: "codex".into(),
+            note: None,
+            windows: vec![AgentQuotaWindow {
+                key: "primary".into(),
+                label: "Session".into(),
+                view: QuotaView {
+                    available: true,
+                    remaining_percent: remaining,
+                    resets_in_minutes: Some(60.0),
+                    age_minutes: Some(0.0),
+                    stale: false,
+                    reset_expired: false,
+                    source_label: "Codex app-server".into(),
+                    quality: "official_live".into(),
+                },
+            }],
+        }
+    }
+
+    #[test]
+    fn switching_account_has_an_independent_notification_episode() {
+        let db = database();
+        storage::set_app_setting(&db, ENABLED_KEY, "1").unwrap();
+        let mut sent = 0;
+        for account in ["a", "a", "b", "b", "a"] {
+            storage::set_app_setting(&db, "quota_scope_codex", account).unwrap();
+            check(&db, &[quota(10.0)], 0, |_| {
+                sent += 1;
+                Ok(())
+            })
+            .unwrap();
+        }
+        assert_eq!(sent, 2);
+    }
+
+    #[test]
+    fn disabled_stale_expired_and_missing_windows_do_not_notify() {
+        let db = database();
+        check(&db, &[quota(0.0)], 0, |_| panic!("disabled")).unwrap();
+        storage::set_app_setting(&db, ENABLED_KEY, "1").unwrap();
+        for mode in 0..4 {
+            let mut q = quota(0.0);
+            match mode {
+                0 => q.windows[0].view.stale = true,
+                1 => q.windows[0].view.reset_expired = true,
+                2 => q.windows[0].view.available = false,
+                _ => q.windows[0].view.quality = "estimated".into(),
+            }
+            check(&db, &[q], 0, |_| panic!("unreliable quota")).unwrap();
+        }
+    }
+
+    #[test]
+    fn persisted_episode_and_cooldown_prevent_repeated_notifications() {
+        let db = database();
+        storage::set_app_setting(&db, ENABLED_KEY, "1").unwrap();
+        let mut messages = Vec::new();
+        for (time, remaining) in [
+            (0, 15.0),
+            (1, 0.0),
+            (COOLDOWN_MS, 0.0),
+            (COOLDOWN_MS + 1, 80.0),
+            (COOLDOWN_MS + 2, 10.0),
+            (COOLDOWN_MS + 3, 80.0),
+            (COOLDOWN_MS + 4, 10.0),
+        ] {
+            check(&db, &[quota(remaining)], time, |body| {
+                messages.push(body.to_owned());
+                Ok(())
+            })
+            .unwrap();
+        }
+        assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn failed_delivery_does_not_consume_notification() {
+        let db = database();
+        storage::set_app_setting(&db, ENABLED_KEY, "1").unwrap();
+        assert!(check(&db, &[quota(5.0)], 0, |_| anyhow::bail!("delivery failed")).is_err());
+        let mut count = 0;
+        check(&db, &[quota(5.0)], 1, |_| {
+            count += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -97,7 +97,10 @@ pub fn ensure_schema(connection: &Connection) -> Result<()> {
 /// 进了兼容性判定就会把所有老账本判为不兼容而整库重建；这些列缺失时旧数据
 /// 依然可用（该列读出 NULL），随下一次重扫补齐即可。
 fn ensure_optional_columns(connection: &Connection) -> Result<()> {
-    for (table, column, definition) in [("usage_event", "project_path", "TEXT")] {
+    for (table, column, definition) in [
+        ("usage_event", "project_path", "TEXT"),
+        ("usage_event", "request_input_tokens", "INTEGER"),
+    ] {
         if !table_has_column(connection, table, column)? {
             connection
                 .execute_batch(&format!(
@@ -221,6 +224,7 @@ mod tests {
         connection
             .execute_batch(
                 "ALTER TABLE usage_event DROP COLUMN project_path;
+                 ALTER TABLE usage_event DROP COLUMN request_input_tokens;
                  INSERT INTO usage_event VALUES (
                      'keep', 'codex', 'key', 1, 'session', 'gpt-5.2',
                      1, 0, 0, 1, 0, 2, 'exact', 'hash'

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -19,6 +19,14 @@ use std::path::{Path, PathBuf};
 // so without the bump the stale "incomplete" marker would survive the upgrade.
 pub const PARSER_VERSION: i64 = 7;
 
+pub fn parser_version_for(adapter: &str) -> i64 {
+    if adapter == "codex" {
+        8
+    } else {
+        PARSER_VERSION
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ReplaceSourceOutcome {
     pub rejected_events: usize,
@@ -129,7 +137,7 @@ pub fn source_is_current(
 ) -> Result<bool> {
     let state = connection
         .query_row(
-            "SELECT observed_size, mtime_ns, parser_version, coverage_start_ms
+            "SELECT observed_size, mtime_ns, parser_version, coverage_start_ms, adapter_id
              FROM scan_source WHERE source_id = ?1",
             [source_id],
             |row| {
@@ -138,16 +146,17 @@ pub fn source_is_current(
                     row.get::<_, i64>(1)?,
                     row.get::<_, i64>(2)?,
                     row.get::<_, i64>(3)?,
+                    row.get::<_, String>(4)?,
                 ))
             },
         )
         .optional()?;
     Ok(matches!(
         state,
-        Some((stored_size, stored_mtime, parser_version, coverage_start_ms))
+        Some((stored_size, stored_mtime, parser_version, coverage_start_ms, adapter))
             if stored_size == size as i64
                 && stored_mtime == mtime_ns
-                && parser_version == PARSER_VERSION
+                && parser_version == parser_version_for(&adapter)
                 && coverage_start_ms <= requested_coverage_start_ms
     ))
 }
@@ -184,7 +193,7 @@ pub fn replace_source(
             source.size as i64,
             source.mtime_ns,
             coverage_start_ms,
-            PARSER_VERSION,
+            parser_version_for(source.adapter_id),
             now,
         ],
     )?;
@@ -273,8 +282,8 @@ fn insert_or_merge_usage_event(
                 event_id, adapter_id, event_key, occurred_at_ms, session_id, model,
                 input_uncached_tokens, cache_read_tokens, cache_write_tokens,
                 output_tokens, reasoning_tokens, processed_tokens, quality, payload_hash,
-                project_path
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                project_path, request_input_tokens
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
             params![
                 event.event_id,
                 event.adapter_id,
@@ -291,6 +300,7 @@ fn insert_or_merge_usage_event(
                 event.quality,
                 event.payload_hash,
                 event.project_path,
+                event.request_input_tokens,
             ],
         )?;
         return Ok(EventWriteOutcome::Accepted);
@@ -355,6 +365,10 @@ fn insert_or_merge_usage_event(
         )?;
     }
     if stored.payload_hash == event.payload_hash && !fills_missing_model {
+        transaction.execute(
+            "UPDATE usage_event SET request_input_tokens = COALESCE(?2, request_input_tokens) WHERE event_id = ?1",
+            params![event.event_id, event.request_input_tokens],
+        )?;
         return Ok(EventWriteOutcome::Accepted);
     }
     if !mergeable {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,6 +48,7 @@ import zcodeAppIcon from "./assets/zcode-app-icon.png";
 import { glassShellAppearance, nextGlassTint, resolveGlassMode } from "./glassAppearance.js";
 import { modelDisplayName } from "./modelNames.js";
 import { QUOTA_LOW_REMAINING, bindingWindow } from "./quotaWindows.js";
+import { CodexCreditsCard, QuotaAlertsCard } from "./QuotaSettings.jsx";
 import { horizontalStripTargetWidth } from "./windowGeometry";
 import {
   configureQoderCookie,
@@ -1281,6 +1282,7 @@ function StripBar({
   const railRef = useRef(null);
   const detailCardRef = useRef(null);
   const pointerLeaveTimerRef = useRef(null);
+  const hoverTransitionRef = useRef(false);
   const OrientationIcon = vertical ? ArrowsLeftRight : ArrowsDownUp;
   const detailEnabled = (IS_WINDOWS || IS_LINUX) && vertical && !(pinned && IS_LINUX);
   const [hoveredDetail, setHoveredDetail] = useState(null);
@@ -1310,6 +1312,11 @@ function StripBar({
   useEffect(() => {
     if (!detailEnabled || controlsOpen) setHoveredDetail(null);
   }, [controlsOpen, detailEnabled]);
+  useEffect(() => {
+    if (!isDesktop()) return undefined;
+    const stop = onScaleFactorChanged(() => setHoveredDetail(null));
+    return () => { stop.then((unlisten) => unlisten?.()); };
+  }, []);
   const shellAppearance = glassShellAppearance("strip", {
     transparent,
     glassMode,
@@ -1357,14 +1364,20 @@ function StripBar({
       return;
     }
     runLatestWindowCorrection(async (isLatest) => {
-      const layout = await expandVerticalStripHover({
-        width: STRIP_DETAIL_WINDOW_WIDTH,
-        height: targetHeight,
-        railWidth: STRIP_VERTICAL_WIDTH,
-        railHeight,
-        anchorY: hoveredDetail.anchorY,
-        cardHeight: Math.ceil(cardRect.height),
-      });
+      hoverTransitionRef.current = true;
+      let layout;
+      try {
+        layout = await expandVerticalStripHover({
+          width: STRIP_DETAIL_WINDOW_WIDTH,
+          height: targetHeight,
+          railWidth: STRIP_VERTICAL_WIDTH,
+          railHeight,
+          anchorY: hoveredDetail.anchorY,
+          cardHeight: Math.ceil(cardRect.height),
+        });
+      } finally {
+        hoverTransitionRef.current = false;
+      }
       if (!isLatest()) return;
       if (layout) {
         setDetailLayout(layout);
@@ -1397,7 +1410,7 @@ function StripBar({
         if (!targetHeight) return;
         // 交叉轴是设计常量：竖条恒为 52 宽（方向切换后窗口可能还停在横条宽度）。
         if (
-          Math.abs(targetHeight - shell.clientHeight) < 1
+          Math.abs(targetHeight - shell.clientHeight) <= 1
           && Math.abs(shell.clientWidth - STRIP_VERTICAL_WIDTH) <= 1
         ) {
           return;
@@ -1417,7 +1430,7 @@ function StripBar({
       if (
         widthDelta < 1
         && widthDelta > -STRIP_WIDTH_SHRINK_SLACK
-        && shell.clientHeight === STRIP_BAR_HEIGHT
+        && Math.abs(shell.clientHeight - STRIP_BAR_HEIGHT) <= 1
       ) {
         return;
       }
@@ -1466,11 +1479,17 @@ function StripBar({
   const handlePointerLeave = (event) => {
     glassProps.onPointerLeave?.(event);
     cancelPointerLeave();
-    pointerLeaveTimerRef.current = window.setTimeout(() => {
+    const closeAfterTransition = () => {
+      if (hoverTransitionRef.current) {
+        pointerLeaveTimerRef.current = window.setTimeout(closeAfterTransition, STRIP_DETAIL_LEAVE_DELAY);
+        return;
+      }
       pointerLeaveTimerRef.current = null;
+      if (shellRef.current?.matches(":hover")) return;
       setHoveredDetail(null);
       setControlsOpen(false);
-    }, STRIP_DETAIL_LEAVE_DELAY);
+    };
+    pointerLeaveTimerRef.current = window.setTimeout(closeAfterTransition, STRIP_DETAIL_LEAVE_DELAY);
   };
   const handleDragPointerDown = (event) => {
     if (
@@ -3081,9 +3100,9 @@ const SETTINGS_TABS = [
   },
   {
     id: "display",
-    label: "Agent 选择",
-    title: "小组件展示的 Agent",
-    blurb: "选择小组件与胶囊条展示的 Agent 及其顺序。",
+    label: "Agent 与提醒",
+    title: "Agent 展示与额度提醒",
+    blurb: "选择展示的 Agent、调整顺序及配置低额度提醒。",
   },
   {
     id: "sources",
@@ -3214,22 +3233,26 @@ function SettingsSection({ onSnapshotRefresh, widgetAgents, onToggleWidgetAgent,
         )}
 
         {activeTab.id === "display" && (
-          <AgentsDisplayCard
-            widgetAgents={widgetAgents}
-            onToggleWidgetAgent={onToggleWidgetAgent}
-            onMoveWidgetAgent={onMoveWidgetAgent}
-            stripAgents={stripAgents}
-            onToggleStripAgent={onToggleStripAgent}
-            onMoveStripAgent={onMoveStripAgent}
-            detectedAgents={detectedAgents}
-            trayBadgeEnabled={trayBadgeEnabled}
-            onToggleTrayBadge={onToggleTrayBadge}
-          />
+          <>
+            <AgentsDisplayCard
+              widgetAgents={widgetAgents}
+              onToggleWidgetAgent={onToggleWidgetAgent}
+              onMoveWidgetAgent={onMoveWidgetAgent}
+              stripAgents={stripAgents}
+              onToggleStripAgent={onToggleStripAgent}
+              onMoveStripAgent={onMoveStripAgent}
+              detectedAgents={detectedAgents}
+              trayBadgeEnabled={trayBadgeEnabled}
+              onToggleTrayBadge={onToggleTrayBadge}
+            />
+            <QuotaAlertsCard onSnapshotRefresh={onSnapshotRefresh} />
+          </>
         )}
         {activeTab.id === "sources" && (
           <>
             <ClaudeHookCard onSnapshotRefresh={onSnapshotRefresh} />
             <QoderQuotaCard onSnapshotRefresh={onSnapshotRefresh} />
+            <CodexCreditsCard />
           </>
         )}
 

--- a/src/QuotaSettings.jsx
+++ b/src/QuotaSettings.jsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+const desktop = () => Boolean(window.__TAURI_INTERNALS__);
+
+export function QuotaAlertsCard({ onSnapshotRefresh }) {
+  const [enabled, setEnabled] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  useEffect(() => {
+    if (!desktop()) return;
+    let cancelled = false;
+    invoke("quota_alert_settings").then((value) => {
+      if (!cancelled) setEnabled(value);
+    }).catch(() => {
+      if (!cancelled) setError("提醒设置读取失败，请重新打开设置页。");
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const toggle = async () => {
+    setBusy(true);
+    setError("");
+    try {
+      setEnabled(await invoke("set_quota_alerts", { enabled: !enabled }));
+      onSnapshotRefresh();
+    } catch {
+      setError("提醒设置保存失败，请重试。");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="settings-card">
+      <h2>额度提醒</h2>
+      <p className="settings-muted">额度刷新后，任一有效窗口剩余不超过 15% 时发送系统通知。持续低额度只提醒一次；恢复后再次降低，两次提醒至少间隔 6 小时。</p>
+      <label className="settings-check">
+        <input type="checkbox" checked={enabled === true} disabled={!desktop() || enabled === null || busy} onChange={toggle} />
+        开启低额度提醒
+      </label>
+      <p className="settings-muted">随现有额度刷新检查。通知显示受系统通知设置影响。</p>
+      {!desktop() && <p className="settings-muted">浏览器演示模式：仅桌面应用可配置。</p>}
+      {error && <p className="settings-feedback settings-feedback--error" role="alert">{error}</p>}
+    </div>
+  );
+}
+
+export function CodexCreditsCard() {
+  const [credits, setCredits] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const query = async () => {
+    setBusy(true);
+    setError("");
+    setCredits(null);
+    try {
+      setCredits(await invoke("codex_reset_credits"));
+    } catch {
+      setError("查询失败，请确认 Codex 已登录后重试。");
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <div className="settings-card">
+      <h2>Codex 重置券</h2>
+      <p className="settings-muted">查询当前 Codex 账号的可用重置券及已知到期时间。</p>
+      <button type="button" className="ledger-button ledger-button--secondary" disabled={!desktop() || busy} onClick={query}>
+        {busy ? "查询中…" : "查询重置券"}
+      </button>
+      {credits && <dl className="settings-status" aria-live="polite">
+        <div><dt>可用数量</dt><dd>{credits.availableCount == null ? "未提供" : `${credits.availableCount} 张`}</dd></div>
+        {credits.availableCount > 0 && <div><dt>已知最早到期</dt><dd>{credits.nextKnownExpiryMs == null ? "未提供" : new Date(credits.nextKnownExpiryMs).toLocaleString("zh-CN", { hour12: false })}</dd></div>}
+      </dl>}
+      {!desktop() && <p className="settings-muted">浏览器演示模式：仅桌面应用可查询。</p>}
+      {error && <p className="settings-feedback settings-feedback--error" role="alert">{error}</p>}
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -200,6 +200,21 @@ button:focus-visible {
   transition-timing-function: var(--motion);
 }
 
+/* 极小工作区保留卡片的最低可读尺寸，整卡滚动以便仍可触达底栏。 */
+@media (max-width: 319px), (max-height: 259px) {
+  html:has(.widget-shell),
+  html:has(.widget-shell) body {
+    min-width: 0;
+  }
+  html:has(.widget-shell) #root {
+    min-width: 0;
+    min-height: 0;
+    height: 100dvh;
+    place-items: start;
+    overflow: auto !important;
+  }
+}
+
 /* ============ 玻璃材质：默认深色 HUD，可选透亮白 ============
    浅色玻璃曾在浅壁纸上"透了等于没透"且洗平层次（多轮迭代验证失败），
    故默认不跟随系统主题：深色半透在任何壁纸上对比度都成立。
@@ -1343,7 +1358,12 @@ html:has(.strip-shell) #root {
   min-width: 0;
   align-items: center;
   gap: 2px;
+  min-height: 0;
+  overflow: auto;
+  scrollbar-width: none;
 }
+
+.strip-rail::-webkit-scrollbar { display: none; }
 
 .strip-shell--vertical {
   flex-direction: column;
@@ -1412,6 +1432,7 @@ html:has(.strip-shell) #root {
   flex: none;
   width: 42px;
   height: max-content;
+  max-height: calc(100dvh - var(--strip-rail-offset-y, 0px));
   padding: 6px 3px 4px;
   gap: 4px;
   border-radius: 8px;
@@ -1427,6 +1448,7 @@ html:has(.strip-shell) #root {
   z-index: 4;
   top: var(--strip-detail-card-center-y, 50%);
   width: 232px;
+  max-width: calc(100vw - 70px);
   padding: 12px;
   color: var(--strip-detail-ink);
   background: var(--strip-detail-background);

--- a/src/windowClient.js
+++ b/src/windowClient.js
@@ -10,6 +10,7 @@ import {
   trayBadgeKey,
 } from "./trayBadge.js";
 import {
+  floatingViewportSize,
   isDockAnchorPosition,
   isStableFloatingMode,
   monitorForWindowPosition,
@@ -17,7 +18,6 @@ import {
   verticalStripHoverLocalLayout,
   verticalStripHoverLayout,
   viewportCorrectedPhysicalSize,
-  viewportCorrectedZoom,
 } from "./windowGeometry";
 
 const WINDOW_SIZES = {
@@ -127,12 +127,12 @@ function saneSize(value, minW, minH, maxW, maxH) {
 let stripSizeCache = readJson(STRIP_SIZE_CACHE_KEY) || {};
 let compactHeightCache = saneSize(
   { width: 320, height: Number(readJson(COMPACT_HEIGHT_CACHE_KEY)?.height) },
-  320, 320, 320, 2000,
+  320, WINDOW_SIZES.compact.minHeight, 320, 2000,
 )?.height || null;
 
 /// 胶囊条变形时的首帧尺寸：优先上次测量缓存，没有就用常量估计。
 function stripContentSize(orientation, fallback) {
-  const cached = saneSize(stripSizeCache[orientation], 40, 40, 2000, 2000);
+  const cached = saneSize(stripSizeCache[orientation], 28, 28, 2000, 2000);
   return cached || fallback;
 }
 
@@ -175,10 +175,6 @@ async function scaledPhysicalSize(
   return new api.PhysicalSize(physical.width, physical.height);
 }
 
-// 最近一次成功下发给 WebView 的 zoom。视口校正（reconcileFloatingSizeAfterShow）
-// 必须以它为基数，而不是本形态的目标系数：两者只在没校正过的时候相等。
-let appliedZoom = null;
-
 /// 内容缩放用 WebView 原生 zoom（等同浏览器 Ctrl+缩放）：视口单位、媒体查询
 /// 全部自洽。CSS zoom 做不到——100vw 元素在 zoom 下会溢出视口（实测）。
 async function applyWebviewZoom(factor) {
@@ -187,9 +183,6 @@ async function applyWebviewZoom(factor) {
   await api
     .getCurrentWebview()
     .setZoom(factor)
-    .then(() => {
-      appliedZoom = factor;
-    })
     .catch((error) => {
       // zoom 失败会让视口与物理尺寸失配（320 内容被裁），不能静默吞掉。
       console.warn("Unable to apply the webview zoom.", error);
@@ -199,11 +192,10 @@ async function applyWebviewZoom(factor) {
 /// 启动时就地应用缩放系数（不走 applyWindowMode 的 hide/show，避免闪烁）。
 /// strip 的启动尺寸由 strip 专属 effect 走 applyWindowMode，这里只管 compact。
 async function applyStartupUiScale(mode) {
-  if (isMacPlatform()) return;
+  if (isMacPlatform() || mode !== "compact") return;
   const api = await windowApi();
   if (!api) return;
   await applyWebviewZoom(uiScale);
-  if (mode !== "compact") return;
   const appWindow = api.getCurrentWindow();
   const size = WINDOW_SIZES.compact;
   const height = compactContentHeight(size.height);
@@ -285,8 +277,8 @@ async function clampIntoWorkArea(api, appWindow, knownOuter = null) {
     }
   });
   if (!best) return false;
-  const x = Math.min(Math.max(pos.x, best.x), best.x + best.width - outer.width);
-  const y = Math.min(Math.max(pos.y, best.y), best.y + best.height - outer.height);
+  const x = Math.min(Math.max(pos.x, best.x), Math.max(best.x, best.x + best.width - outer.width));
+  const y = Math.min(Math.max(pos.y, best.y), Math.max(best.y, best.y + best.height - outer.height));
   if (x !== pos.x || y !== pos.y) {
     await appWindow.setPosition(new api.PhysicalPosition(Math.round(x), Math.round(y))).catch(() => {});
   }
@@ -400,6 +392,10 @@ async function reconcileFloatingSizeAfterShow(
   await settleWebviewLayout();
   const factor = await appWindow.scaleFactor().catch(() => null);
   if (!Number.isFinite(factor) || factor <= 0) return previousPhysical;
+  const monitor = await api.currentMonitor().catch(() => null);
+  ({ width, height } = floatingViewportSize(
+    width, height, contentScale, factor, monitor?.workArea?.size,
+  ));
   const formulaPhysical = await scaledPhysicalSize(
     api,
     appWindow,
@@ -432,52 +428,11 @@ async function reconcileFloatingSizeAfterShow(
     return current || appliedPhysical;
   }
 
-  // 外框已经是设计尺寸 × 应用比例 × DPI，但视口仍偏小时，优先抵消 WebView2
-  // 额外保留的 zoom。这样不会为了显示完整内容而把整个卡片无端放大。
-  //
-  // 基数是上一次真正下发的 zoom，不是本形态的目标系数。一旦某轮校正改过
-  // zoom，再拿目标系数乘比例就是在错的基数上二次修正：上一轮缩到 0.67 倍，
-  // 这一轮量到 1.5 倍的视口，按目标系数算出 1.5 倍，实际该回到 1 倍——两轮
-  // 之间永远差一个因子，卡片在大小之间来回跳。
-  //
-  // 量到的比例出了 0.5–2 或两轴不一致时，不能就此放弃：用户实拍过胶囊条
-  // 内容缩到不足一半、窗口不变、再也不恢复的卡死态——zoom 已经错了，两条
-  // 校正又都因超界拒绝，没有任何路径把它拨回来。先把 zoom 拨回目标系数再量
-  // 一次；若那本来就是目标系数，重设是空操作，不会闪。
-  let zoomBase = appliedZoom ?? contentScale;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    const correctedZoom = viewportCorrectedZoom({
-      contentScale: zoomBase,
-      viewportWidth: window.innerWidth,
-      viewportHeight: window.innerHeight,
-      expectedWidth: width,
-      expectedHeight: height,
-    });
-    if (correctedZoom) {
-      await applyWebviewZoom(correctedZoom);
-      await settleWebviewLayout();
-      current = await appWindow.innerSize().catch(() => current);
-      if (viewportMatches()) {
-        await clampIntoWorkArea(api, appWindow, current || appliedPhysical);
-        return current || appliedPhysical;
-      }
-      // 没收敛说明量到的是瞬时视口（DPI 切换、resize 未落地），不是真实的
-      // 残留 zoom：撤回，别把一个错的 zoom 留给下面的物理尺寸校正当前提。
-      await applyWebviewZoom(zoomBase);
-      await settleWebviewLayout();
-      current = await appWindow.innerSize().catch(() => current);
-      break;
-    }
-    if (attempt > 0) break;
-    await applyWebviewZoom(contentScale);
-    await settleWebviewLayout();
-    current = await appWindow.innerSize().catch(() => current);
-    if (viewportMatches()) {
-      await clampIntoWorkArea(api, appWindow, current || appliedPhysical);
-      return current || appliedPhysical;
-    }
-    zoomBase = contentScale;
-  }
+  // resize/show 的旧视口不能作为缩放依据。只恢复用户选择的比例，
+  // 剩余误差交给物理尺寸校正，避免一次临时尺寸被永久写成 WebView zoom。
+  await applyWebviewZoom(contentScale);
+  await settleWebviewLayout();
+  current = await appWindow.innerSize().catch(() => current);
 
   for (let pass = 0; pass < 2; pass += 1) {
     const viewportWidth = window.innerWidth;
@@ -501,7 +456,10 @@ async function reconcileFloatingSizeAfterShow(
         })
       : null;
     appliedPhysical = corrected
-      ? new api.PhysicalSize(corrected.width, corrected.height)
+      ? new api.PhysicalSize(
+          Math.min(corrected.width, monitor?.workArea?.size.width ?? corrected.width),
+          Math.min(corrected.height, monitor?.workArea?.size.height ?? corrected.height),
+        )
       : formulaPhysical;
     await appWindow.setSize(appliedPhysical).catch((error) => {
       console.warn("Unable to reconcile the floating window size.", error);
@@ -1121,6 +1079,7 @@ async function expandVerticalStripHover({ width, height, railWidth, railHeight, 
   }
   const base = stripHoverRestore;
   const scale = stripScale * factor;
+  ({ width, height } = floatingViewportSize(width, height, stripScale, factor, workArea?.size));
   let physical = await scaledPhysicalSize(api, appWindow, width, height, stripScale, factor);
   const hoverLayoutFor = (targetSize) => verticalStripHoverLayout({
     railPosition: base.position,
@@ -1154,16 +1113,11 @@ async function expandVerticalStripHover({ width, height, railWidth, railHeight, 
     );
   }
   // Windows 会在 resize 与随后的 move 之间绘制中间帧；胶囊先跳出鼠标命中区
-  // 就会触发收回。两项原生变更同时下发，随后再按实际视口做一次最终校正。
+  // 就会触发收回。两项原生变更同时下发，随后只核对原生尺寸和位置。
   await Promise.all(mutations);
-  physical = await reconcileFloatingSizeAfterShow(
-    api,
-    appWindow,
-    width,
-    height,
-    stripScale,
-    physical,
-  );
+  // 悬停画布是临时几何，不能反算 zoom，也不能经过通用钳位再次移动条身。
+  await settleWebviewLayout();
+  physical = await appWindow.innerSize().catch(() => physical);
   if (!coordinateAware) {
     const local = verticalStripHoverLocalLayout({
       targetHeight: physical.height / scale,
@@ -1208,6 +1162,7 @@ async function collapseVerticalStripHover() {
   const api = await windowApi();
   if (!api) return;
   const appWindow = api.getCurrentWindow();
+  await applyWebviewZoom(stripScale);
   const mutations = [appWindow.setSize(restore.size).catch(() => {})];
   if (restore.position) mutations.push(appWindow.setPosition(restore.position).catch(() => {}));
   await Promise.all(mutations);
@@ -1294,6 +1249,7 @@ async function reassertCompactSize(scaleFactor = null) {
 /// 完整，真正被裁的是外层 HWND。DPI 事件必须像 compact 一样直接重断言。
 async function reassertStripSize({ width, height, scaleFactor = null }) {
   if (isMacPlatform()) return;
+  await collapseVerticalStripHover();
   const api = await windowApi();
   if (!api) return;
   const appWindow = api.getCurrentWindow();

--- a/src/windowClient.test.js
+++ b/src/windowClient.test.js
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import test from "node:test";
+import * as geometry from "./windowGeometry.js";
+
+// Execute the window controller against a simulated native boundary. No real
+// desktop window, persisted settings, or WebView zoom is changed by these tests.
+const source = readFileSync(new URL("./windowClient.js", import.meta.url), "utf8")
+  .replace(/^import[\s\S]*?;\r?\n/gm, "")
+  .replace(/export \{[\s\S]*?\};\s*$/, "");
+
+function controller(stored = {}) {
+  const context = vm.createContext({
+    ...geometry,
+    console: { warn() {} },
+    window: { innerWidth: 320, innerHeight: 320 },
+    localStorage: { getItem: (key) => stored[key] ?? null, setItem() {} },
+  });
+  vm.runInContext(source, context);
+  return context;
+}
+
+test("startup does not apply compact zoom to a strip or expanded window", async () => {
+  const context = controller();
+  let zoomCalls = 0;
+  Object.assign(context, {
+    isMacPlatform: () => false,
+    windowApi: async () => ({}),
+    applyWebviewZoom: async () => { zoomCalls += 1; },
+  });
+  await context.applyStartupUiScale("strip");
+  await context.applyStartupUiScale("expanded");
+  assert.equal(zoomCalls, 0);
+});
+
+test("cached 28px horizontal strip and short compact heights survive startup", () => {
+  const context = controller({
+    "metrik:stripContentSize": JSON.stringify({ horizontal: { width: 366, height: 28 } }),
+    "metrik:compactContentHeight": JSON.stringify({ height: 280 }),
+  });
+  assert.equal(context.stripContentSize("horizontal", {}).height, 28);
+  assert.equal(context.compactContentHeight(320), 280);
+});
+
+test("an oversized window cannot be clamped above the work-area origin", async () => {
+  const context = controller();
+  let position = { x: 0, y: 0 };
+  context.isLinuxPlatform = () => false;
+  await context.clampIntoWorkArea({
+    availableMonitors: async () => [{
+      position: { x: 0, y: 0 }, size: { width: 1280, height: 720 },
+    }],
+    PhysicalPosition: class { constructor(x, y) { this.x = x; this.y = y; } },
+  }, {
+    outerPosition: async () => position,
+    setPosition: async (value) => { position = value; },
+  }, { width: 1600, height: 1000 });
+  assert.equal(position.x, 0);
+  assert.equal(position.y, 0);
+});
+
+test("a stale resize viewport cannot change the user's chosen zoom", async () => {
+  const context = controller();
+  let physical = { width: 320, height: 320 };
+  const zooms = [];
+  Object.assign(context, {
+    window: { innerWidth: 640, innerHeight: 640 },
+    settleWebviewLayout: async () => {},
+    scaledPhysicalSize: async () => ({ width: 320, height: 320 }),
+    clampIntoWorkArea: async () => {},
+    applyWebviewZoom: async (zoom) => {
+      zooms.push(zoom);
+      context.window.innerWidth = 320;
+      context.window.innerHeight = 320;
+    },
+  });
+  const appWindow = {
+    scaleFactor: async () => 1,
+    innerSize: async () => physical,
+    setSize: async (size) => { physical = size; },
+  };
+  await context.reconcileFloatingSizeAfterShow({ currentMonitor: async () => null }, appWindow, 320, 320, 1, physical);
+  assert.deepEqual(zooms, [1]);
+});
+
+test("hover expansion preserves zoom and collapse restores the chosen strip scale", async () => {
+  const context = controller();
+  let physical = { width: 42, height: 300 };
+  let position = { x: 1878, y: 500 };
+  let reconciliations = 0;
+  const zooms = [];
+  const appWindow = {
+    outerPosition: async () => position,
+    outerSize: async () => physical,
+    innerSize: async () => physical,
+    scaleFactor: async () => 1,
+    setSize: async (size) => { physical = size; },
+    setPosition: async (value) => { position = value; },
+  };
+  const api = {
+    getCurrentWindow: () => appWindow,
+    currentMonitor: async () => ({ workArea: {
+      position: { x: 0, y: 0 }, size: { width: 1920, height: 1040 },
+    } }),
+    PhysicalPosition: class { constructor(x, y) { this.x = x; this.y = y; } },
+  };
+  Object.assign(context, {
+    isWindowsPlatform: () => true,
+    isLinuxPlatform: () => false,
+    windowApi: async () => api,
+    scaledPhysicalSize: async (_api, _win, width, height) => ({ width, height }),
+    settleWebviewLayout: async () => {},
+    reconcileFloatingSizeAfterShow: async () => { reconciliations += 1; return physical; },
+    applyWebviewZoom: async (zoom) => { zooms.push(zoom); },
+  });
+  await context.expandVerticalStripHover({
+    width: 312, height: 300, railWidth: 42, railHeight: 300,
+    anchorY: 260, cardHeight: 180,
+  });
+  assert.equal(reconciliations, 0);
+  assert.deepEqual(zooms, []);
+  await context.collapseVerticalStripHover();
+  assert.equal(physical.width, 42);
+  assert.equal(physical.height, 300);
+  assert.equal(position.x, 1878);
+  assert.equal(position.y, 500);
+  assert.deepEqual(zooms, [1]);
+});

--- a/src/windowGeometry.js
+++ b/src/windowGeometry.js
@@ -55,6 +55,14 @@ function physicalWindowSize(width, height, contentScale = 1, monitorScale = 1) {
   };
 }
 
+function floatingViewportSize(width, height, contentScale, monitorScale, workArea) {
+  const scale = normalizedScale(contentScale) * normalizedScale(monitorScale);
+  return {
+    width: workArea?.width > 0 ? Math.min(width, Math.floor(workArea.width / scale)) : width,
+    height: workArea?.height > 0 ? Math.min(height, Math.floor(workArea.height / scale)) : height,
+  };
+}
+
 /// WebView2 偶尔在混合 DPI 环境保留一层额外 zoom，导致原生窗口物理尺寸正确，
 /// 但 CSS 视口仍偏小。以当前“物理像素 / CSS 视口”的实测比例反算目标尺寸，
 /// 不再假设系统 DPI 与 setZoom 就是完整缩放链。
@@ -92,44 +100,6 @@ function viewportCorrectedPhysicalSize({
     width: Math.max(1, Math.round(currentPhysicalWidth * widthRatio)),
     height: Math.max(1, Math.round(currentPhysicalHeight * heightRatio)),
   };
-}
-
-function viewportCorrectedZoom({
-  contentScale,
-  viewportWidth,
-  viewportHeight,
-  expectedWidth,
-  expectedHeight,
-}) {
-  const values = [
-    contentScale,
-    viewportWidth,
-    viewportHeight,
-    expectedWidth,
-    expectedHeight,
-  ];
-  if (values.some((value) => !Number.isFinite(value) || value <= 0)) return null;
-
-  const widthRatio = viewportWidth / expectedWidth;
-  const heightRatio = viewportHeight / expectedHeight;
-  // 真实 zoom 应在两条轴上给出近似相同的比例；差异过大说明布局/尺寸仍在变化，
-  // 此时交给物理窗口兜底，不贸然改变内容缩放。
-  if (
-    widthRatio < 0.5 ||
-    widthRatio > 2 ||
-    heightRatio < 0.5 ||
-    heightRatio > 2 ||
-    Math.abs(widthRatio - heightRatio) > 0.08
-  ) {
-    return null;
-  }
-  // 只取长轴的比例，短轴仅用于上面的一致性校验。取平均会把短轴的取整残差
-  // 放大成很大的 zoom 变更：横向胶囊条高 40px，视口差 1 物理像素就是 2.5%，
-  // 平均之后 zoom 被改 1.25%；zoom 一变布局重排，测出来的目标宽度跟着变，
-  // 于是「调窗 → 重排 → 再调窗」闭环，表现为胶囊条持续闪烁。长轴上同样的
-  // 1px 只有 0.25%，落在噪声里。竖条不闪是因为它的宽度是常量，环路断开。
-  const ratio = expectedWidth >= expectedHeight ? widthRatio : heightRatio;
-  return contentScale * ratio;
 }
 
 function horizontalStripTargetWidth({
@@ -263,6 +233,7 @@ function monitorForWindowPosition(
 }
 
 export {
+  floatingViewportSize,
   horizontalStripTargetWidth,
   isDockAnchorPosition,
   isStableFloatingMode,
@@ -271,5 +242,4 @@ export {
   verticalStripHoverLocalLayout,
   verticalStripHoverLayout,
   viewportCorrectedPhysicalSize,
-  viewportCorrectedZoom,
 };

--- a/src/windowGeometry.test.js
+++ b/src/windowGeometry.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  floatingViewportSize,
   horizontalStripTargetWidth,
   isDockAnchorPosition,
   isStableFloatingMode,
@@ -10,8 +11,17 @@ import {
   verticalStripHoverLocalLayout,
   verticalStripHoverLayout,
   viewportCorrectedPhysicalSize,
-  viewportCorrectedZoom,
 } from "./windowGeometry.js";
+
+test("floating content fits the physical work area at combined app and monitor scale", () => {
+  assert.deepEqual(floatingViewportSize(42, 900, 2, 1.5, { width: 1920, height: 1040 }), {
+    width: 42, height: 346,
+  });
+  assert.deepEqual(floatingViewportSize(1200, 28, 1.25, 1.5, { width: 1366, height: 728 }), {
+    width: 728, height: 28,
+  });
+  assert.deepEqual(floatingViewportSize(320, 900, 1, 1, null), { width: 320, height: 900 });
+});
 
 test("moving a docked window away from its anchor is treated as a user drag", () => {
   const anchor = { x: 1878, y: 300 };
@@ -223,73 +233,6 @@ test("runtime viewport correction rejects transient invalid measurements", () =>
       viewportHeight: 0,
       expectedWidth: 320,
       expectedHeight: 320,
-    }),
-    null,
-  );
-});
-
-test("runtime viewport can cancel a hidden WebView zoom layer", () => {
-  assert.equal(
-    viewportCorrectedZoom({
-      contentScale: 1,
-      viewportWidth: 256,
-      viewportHeight: 256,
-      expectedWidth: 320,
-      expectedHeight: 320,
-    }),
-    0.8,
-  );
-});
-
-test("短轴上的 1px 取整残差不该改变 zoom 修正", () => {
-  // 横条 400x40：视口高多出 1 物理像素。取两轴平均会得到 1.0125，
-  // 也就是凭空把内容放大 1.25%；放大后布局重排、测出的目标宽度变化，
-  // 就与调窗形成震荡（双屏用户实拍到持续闪烁）。只取长轴则不受影响。
-  assert.equal(
-    viewportCorrectedZoom({
-      contentScale: 1,
-      viewportWidth: 400,
-      viewportHeight: 41,
-      expectedWidth: 400,
-      expectedHeight: 40,
-    }),
-    1,
-  );
-});
-
-test("竖条取高度轴，横条取宽度轴", () => {
-  // 竖条 42x211：长轴是高度，视口高少 10% 时 zoom 应跟着降 10%。
-  assert.equal(
-    viewportCorrectedZoom({
-      contentScale: 1,
-      viewportWidth: 42,
-      viewportHeight: 190,
-      expectedWidth: 42,
-      expectedHeight: 200,
-    }),
-    0.95,
-  );
-  // 横条 400x40：长轴是宽度。
-  assert.equal(
-    viewportCorrectedZoom({
-      contentScale: 1,
-      viewportWidth: 380,
-      viewportHeight: 40,
-      expectedWidth: 400,
-      expectedHeight: 40,
-    }),
-    0.95,
-  );
-});
-
-test("两轴分歧过大时仍然拒绝修正，交给物理尺寸兜底", () => {
-  assert.equal(
-    viewportCorrectedZoom({
-      contentScale: 1,
-      viewportWidth: 400,
-      viewportHeight: 48,
-      expectedWidth: 400,
-      expectedHeight: 40,
     }),
     null,
   );


### PR DESCRIPTION
Floating windows could retain a wrong WebView zoom after a resize or hover transition, clipping capsule content. Restore the configured scale, separate transient hover geometry, and bound floating dimensions to the monitor work area with scrolling for overflow.

Shared changes add Claude array quota parsing, opt-in quota notifications, a manual read-only Codex reset-credit query, validated Astra request-size pricing, bounded resumable Codex parsing, and account-scoped Codex/Claude quota caches and alert episodes. Missing Fast evidence retains base estimates. Nullable pricing metadata preserves event identity and existing ledgers.

Scope: shared data/UI, Windows and Linux floating shells. No version bump.

Validation: frontend tests and production build passed; Rust library tests passed (251 passed, 6 ignored), rustfmt and clippy passed on Windows. The native Windows compact card was visible and complete. Capsule switching, hover, multi-scale checks and Linux native smoke remain incomplete; keep this PR in draft and do not release until those checks finish. CI supplies the three-platform build/test baseline.
